### PR TITLE
Update VALIDATION-COMMANDS.md with PowerShell equivalents for Windows support

### DIFF
--- a/claude/skills/azure-deployment-preflight/references/VALIDATION-COMMANDS.md
+++ b/claude/skills/azure-deployment-preflight/references/VALIDATION-COMMANDS.md
@@ -241,6 +241,7 @@ bicep build <bicep-file> [options]
 
 **Examples:**
 
+**Bash:**
 ```bash
 # Validate syntax (output to stdout, no file created)
 bicep build main.bicep --stdout > /dev/null
@@ -250,6 +251,18 @@ bicep build main.bicep --outdir ./build
 
 # Validate multiple files
 for f in *.bicep; do bicep build "$f" --stdout; done
+```
+
+**PowerShell:**
+```powershell
+# Validate syntax (output to stdout, no file created)
+bicep build main.bicep --stdout | Out-Null
+
+# Build to specific directory
+bicep build main.bicep --outdir ./build
+
+# Validate multiple files
+Get-ChildItem -Filter *.bicep | ForEach-Object { bicep build $_.FullName --stdout }
 ```
 
 **Error Output Format:**
@@ -372,7 +385,16 @@ targetScope = 'tenant'
 | Bicep CLI | 0.4.0 | Latest | Best error messages |
 
 **Check versions:**
+
+**Bash:**
 ```bash
+az --version
+azd version
+bicep --version
+```
+
+**PowerShell:**
+```powershell
 az --version
 azd version
 bicep --version


### PR DESCRIPTION
## Summary

This PR updates `VALIDATION-COMMANDS.md` to include PowerShell equivalents for bash scripts that perform complex operations beyond simple `az` or `azd` CLI calls.

## Changes

- Added PowerShell equivalents for Bicep build examples:
  - `> /dev/null` → `| Out-Null` for suppressing output
  - `for f in *.bicep; do ... done` → `Get-ChildItem -Filter *.bicep | ForEach-Object { ... }` for iterating over files
- Added PowerShell version check commands alongside bash versions

## Motivation

Windows users often use PowerShell rather than bash, and these complex shell operations require different syntax. This update ensures Windows users have clear guidance for running validation commands in their native shell environment.