### PR TITLE
Tweak the skill creator

### DIFF
--- a/.github/agents/SkillCreator.agent.md
+++ b/.github/agents/SkillCreator.agent.md
@@ -42,4 +42,6 @@ Once the research is complete, compile all the gathered requirements in a new fi
 
 REQUIREMENTS.md should _always_ include the following:
 - Relevant links to the [Agent Skills](https://agentskills.io/) documentation.
-- An instruction that any shell scripts should include bash and PowerShell versions for compatibility with Linux, Mac, and Windows environments.
+- An instruction that any non-trivial scripts should include bash and PowerShell versions for compatibility with Linux, Mac, and Windows environments. It is OK if trivial scripts only include a bash version.
+- A requirement that Azure MCP tools and `azd` should be preferred where possible over direct Azure CLI commands. Azure CLI commands should only be used when absolutely necessary.
+- A requirement that any relevant Azure MCP tools be utilized and listed (with a short description) in a "Relevant MCP Tools" section.


### PR DESCRIPTION
Update the skill creator with some small changes:
- Only require bash and PowerShell versions of scripts when they are non-trivial. Including two versions when the LM can easily figure out the PowerShell version from the bash just makes the skills harder for a human to review and uses more tokens.
- Add a requirement that Azure MCP and `azd` should be preferred over `az`. We want to lean into these as the default approach _where it is possible and reasonable to do so_; the important point is to have a golden path in the skill, and after that to have consistency across skills.
- Make it explicit that relevant Azure MCP tools should be highlighted in the skill.