### PR TITLE
Update the azure-cli skill

### DIFF
--- a/plugin/skills/azure-cli-reference/SKILL.md
+++ b/plugin/skills/azure-cli-reference/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: azure-cli
+name: azure-cli-reference
 description: Provides guidance on the Azure CLI tools (az, azd, func) with command reference and advanced patterns. Use this when asked about installing, configuring, or using az, azd, or func.
 ---
 


### PR DESCRIPTION
Update the azure-cli skill to clarify that it is meant as reference material for the user, not Copilot. Also shorten the installation instructions by directing Copilot to the appropriate Azure MCP tool.