### PR TITLE
feat: Add integration test support with Copilot SDK

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -185,11 +185,82 @@ const prompts = loadFixture('azure-validation', 'prompts');
 
 ---
 
+## Writing Integration Tests
+
+Integration tests run a real Copilot agent session to verify skill behavior.
+
+### Prerequisites
+
+1. Install Copilot CLI: `npm install -g @github/copilot-cli`
+2. Authenticate: Run `copilot` and follow prompts
+
+### Basic Integration Test
+
+```javascript
+const { 
+  run, 
+  isSkillInvoked, 
+  doesAssistantMessageIncludeKeyword,
+  shouldSkipIntegrationTests 
+} = require('../utils/agent-runner');
+
+const SKILL_NAME = 'azure-role-selector';
+
+// Skip in CI or when SKIP_INTEGRATION_TESTS is set
+const describeIntegration = shouldSkipIntegrationTests() ? describe.skip : describe;
+
+describeIntegration(`${SKILL_NAME} - Integration Tests`, () => {
+  test('invokes skill for relevant prompt', async () => {
+    const agentMetadata = await run({
+      prompt: 'What role should I assign for blob storage access?'
+    });
+
+    expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
+    expect(doesAssistantMessageIncludeKeyword(agentMetadata, 'Storage Blob')).toBe(true);
+  });
+});
+```
+
+### Agent Runner Helpers
+
+| Helper | Purpose |
+|--------|---------|
+| `run(config)` | Execute agent session with prompt |
+| `isSkillInvoked(metadata, skillName)` | Check if skill was invoked |
+| `areToolCallsSuccess(metadata, toolName)` | Check if tool calls succeeded |
+| `doesAssistantMessageIncludeKeyword(metadata, keyword)` | Search response for keyword |
+| `shouldSkipIntegrationTests()` | Check if tests should be skipped |
+
+### Test with Workspace Setup
+
+```javascript
+test('works with project files', async () => {
+  const agentMetadata = await run({
+    setup: async (workspace) => {
+      const fs = require('fs');
+      const path = require('path');
+      fs.writeFileSync(path.join(workspace, 'main.bicep'), 'resource ...');
+    },
+    prompt: 'Validate my Bicep file'
+  });
+
+  expect(isSkillInvoked(agentMetadata, 'azure-validation')).toBe(true);
+});
+```
+
+---
+
 ## Running Tests
 
 ### Local Development
 
 ```bash
+# Unit and trigger tests (fast, no auth)
+npm run test:unit
+
+# Integration tests (requires Copilot CLI auth)
+npm run test:integration
+
 # All tests
 npm test
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -129,6 +129,35 @@ test.each(shouldTriggerPrompts)('triggers on: "%s"', (prompt) => {
 npm run update:snapshots -- --testPathPattern={skill-name}
 ```
 
+### 3. Integration Tests (`integration.test.js`)
+
+**Purpose:** Test skill behavior with a real Copilot agent session.
+
+**What it checks:**
+- ✅ Skill is invoked by the agent for relevant prompts
+- ✅ Agent response contains expected content
+- ✅ Azure MCP tool calls succeed
+
+**Prerequisites:**
+1. Install Copilot CLI: `npm install -g @github/copilot-cli`
+2. Authenticate: Run `copilot` and follow prompts
+
+**Example:**
+```javascript
+const { run, isSkillInvoked, doesAssistantMessageIncludeKeyword } = require('../utils/agent-runner');
+
+test('invokes skill for relevant prompt', async () => {
+  const agentMetadata = await run({
+    prompt: 'What role should I assign for Azure Container Registry access?'
+  });
+
+  expect(isSkillInvoked(agentMetadata, 'azure-role-selector')).toBe(true);
+  expect(doesAssistantMessageIncludeKeyword(agentMetadata, 'AcrPull')).toBe(true);
+});
+```
+
+**Note:** Integration tests are skipped in CI (no auth) and when `SKIP_INTEGRATION_TESTS=true`.
+
 ---
 
 ## Running Tests Locally
@@ -144,7 +173,9 @@ npm install
 
 | Command | Use Case |
 |---------|----------|
-| `npm test` | Run all tests |
+| `npm test` | Run all tests (unit + trigger) |
+| `npm run test:unit` | Run unit and trigger tests only (fast, no auth) |
+| `npm run test:integration` | Run integration tests (requires Copilot CLI auth) |
 | `npm test -- --testPathPattern=azure-validation` | Run tests for one skill |
 | `npm run test:watch` | Re-run tests on file changes |
 | `npm run test:coverage` | Generate coverage report |
@@ -279,20 +310,22 @@ This updates the Skills Coverage Grid in this README.
 tests/
 ├── README.md                 # This file - developer guide
 ├── AGENTS.md                 # AI agent testing patterns
-├── package.json              # Dependencies (jest, jest-junit)
+├── package.json              # Dependencies (jest, jest-junit, @github/copilot-sdk)
 ├── jest.config.js            # Jest configuration
 ├── jest.setup.js             # Global setup, custom matchers
 │
 ├── _template/                # 📋 Copy this for new skills
 │   ├── unit.test.js          #    Metadata & logic tests
 │   ├── triggers.test.js      #    Prompt activation tests
+│   ├── integration.test.js   #    Real agent tests (optional)
 │   ├── fixtures/             #    Test data
 │   └── README.md             #    Template usage guide
 │
 ├── utils/                    # 🔧 Shared test utilities
 │   ├── skill-loader.js       #    Load & parse SKILL.md
 │   ├── trigger-matcher.js    #    Test prompt → skill matching
-│   └── fixtures.js           #    Load test fixtures
+│   ├── fixtures.js           #    Load test fixtures
+│   └── agent-runner.js       #    Copilot SDK agent runner
 │
 ├── scripts/                  # 📜 Helper scripts
 │   └── generate-coverage-grid.js    # Update README coverage table

--- a/tests/_template/integration.test.js
+++ b/tests/_template/integration.test.js
@@ -1,0 +1,82 @@
+/**
+ * Integration Tests for {SKILL_NAME}
+ * 
+ * Tests skill behavior with a real Copilot agent session.
+ * These tests require Copilot CLI to be installed and authenticated.
+ * 
+ * Prerequisites:
+ * 1. npm install -g @github/copilot-cli
+ * 2. Run `copilot` and authenticate
+ * 
+ * Run with: npm run test:integration -- --testPathPattern={skill-name}
+ */
+
+const { 
+  run, 
+  isSkillInvoked, 
+  areToolCallsSuccess, 
+  doesAssistantMessageIncludeKeyword,
+  shouldSkipIntegrationTests 
+} = require('../utils/agent-runner');
+
+// Replace with your skill name
+const SKILL_NAME = 'your-skill-name';
+
+// Skip integration tests in CI or when SKIP_INTEGRATION_TESTS is set
+const describeIntegration = shouldSkipIntegrationTests() ? describe.skip : describe;
+
+describeIntegration(`${SKILL_NAME} - Integration Tests`, () => {
+  
+  // Example test: Verify the skill is invoked for a relevant prompt
+  test('invokes skill for relevant prompt', async () => {
+    const agentMetadata = await run({
+      prompt: 'Your test prompt that should trigger this skill'
+    });
+
+    const isSkillUsed = isSkillInvoked(agentMetadata, SKILL_NAME);
+    expect(isSkillUsed).toBe(true);
+  });
+
+  // Example test: Verify expected content in response
+  test('response contains expected keywords', async () => {
+    const agentMetadata = await run({
+      prompt: 'Your test prompt here'
+    });
+
+    const hasExpectedContent = doesAssistantMessageIncludeKeyword(
+      agentMetadata, 
+      'expected keyword'
+    );
+    expect(hasExpectedContent).toBe(true);
+  });
+
+  // Example test: Verify MCP tool calls succeed
+  test('MCP tool calls are successful', async () => {
+    const agentMetadata = await run({
+      prompt: 'Your test prompt that uses Azure tools'
+    });
+
+    // Check that azure-documentation (or other relevant tool) calls succeeded
+    const toolsSucceeded = areToolCallsSuccess(agentMetadata, 'azure-documentation');
+    expect(toolsSucceeded).toBe(true);
+  });
+
+  // Example test with workspace setup
+  test('works with project files', async () => {
+    const agentMetadata = await run({
+      setup: async (workspace) => {
+        // Create any files needed in the workspace
+        const fs = require('fs');
+        const path = require('path');
+        
+        fs.writeFileSync(
+          path.join(workspace, 'example.json'),
+          JSON.stringify({ key: 'value' })
+        );
+      },
+      prompt: 'Your test prompt that needs workspace files'
+    });
+
+    expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
+  });
+});

--- a/tests/azure-role-selector/integration.test.js
+++ b/tests/azure-role-selector/integration.test.js
@@ -1,0 +1,64 @@
+/**
+ * Integration Tests for azure-role-selector
+ * 
+ * Tests skill behavior with a real Copilot agent session.
+ * Adapted from PR #617's azureRoleSelectorTests.ts
+ * 
+ * Prerequisites:
+ * 1. npm install -g @github/copilot-cli
+ * 2. Run `copilot` and authenticate
+ */
+
+const { 
+  run, 
+  isSkillInvoked, 
+  areToolCallsSuccess, 
+  doesAssistantMessageIncludeKeyword,
+  shouldSkipIntegrationTests 
+} = require('../utils/agent-runner');
+
+const SKILL_NAME = 'azure-role-selector';
+
+// Skip integration tests in CI or when SKIP_INTEGRATION_TESTS is set
+const describeIntegration = shouldSkipIntegrationTests() ? describe.skip : describe;
+
+describeIntegration(`${SKILL_NAME} - Integration Tests`, () => {
+  
+  test('invokes azure-role-selector skill for AcrPull prompt', async () => {
+    const agentMetadata = await run({
+      prompt: 'What role should I assign to my managed identity to read images in an Azure Container Registry?'
+    });
+
+    const isAzureRoleSelectorSkillUsed = isSkillInvoked(agentMetadata, 'azure-role-selector');
+    const isAcrPullRoleMentioned = doesAssistantMessageIncludeKeyword(agentMetadata, 'AcrPull');
+    const areDocumentationToolCallsSuccess = areToolCallsSuccess(agentMetadata, 'azure-documentation');
+
+    expect(isAzureRoleSelectorSkillUsed).toBe(true);
+    expect(isAcrPullRoleMentioned).toBe(true);
+    expect(areDocumentationToolCallsSuccess).toBe(true);
+  });
+
+  test('recommends Storage Blob Data Reader for blob read access', async () => {
+    const agentMetadata = await run({
+      prompt: 'What Azure role should I use to give my app read-only access to blob storage?'
+    });
+
+    const isSkillUsed = isSkillInvoked(agentMetadata, 'azure-role-selector');
+    const mentionsStorageRole = doesAssistantMessageIncludeKeyword(agentMetadata, 'Storage Blob Data Reader');
+
+    expect(isSkillUsed).toBe(true);
+    expect(mentionsStorageRole).toBe(true);
+  });
+
+  test('recommends Key Vault Secrets User for secret access', async () => {
+    const agentMetadata = await run({
+      prompt: 'What role do I need to read secrets from Azure Key Vault?'
+    });
+
+    const isSkillUsed = isSkillInvoked(agentMetadata, 'azure-role-selector');
+    const mentionsKeyVaultRole = doesAssistantMessageIncludeKeyword(agentMetadata, 'Key Vault');
+
+    expect(isSkillUsed).toBe(true);
+    expect(mentionsKeyVaultRole).toBe(true);
+  });
+});

--- a/tests/azure-validation/integration.test.js
+++ b/tests/azure-validation/integration.test.js
@@ -1,0 +1,68 @@
+/**
+ * Integration Tests for azure-validation
+ * 
+ * Tests skill behavior with a real Copilot agent session.
+ * 
+ * Prerequisites:
+ * 1. npm install -g @github/copilot-cli
+ * 2. Run `copilot` and authenticate
+ */
+
+const { 
+  run, 
+  isSkillInvoked, 
+  areToolCallsSuccess, 
+  doesAssistantMessageIncludeKeyword,
+  shouldSkipIntegrationTests 
+} = require('../utils/agent-runner');
+
+const SKILL_NAME = 'azure-validation';
+
+// Skip integration tests in CI or when SKIP_INTEGRATION_TESTS is set
+const describeIntegration = shouldSkipIntegrationTests() ? describe.skip : describe;
+
+describeIntegration(`${SKILL_NAME} - Integration Tests`, () => {
+  
+  test('invokes azure-validation skill for storage naming question', async () => {
+    const agentMetadata = await run({
+      prompt: 'What are the naming rules for Azure storage accounts?'
+    });
+
+    const isSkillUsed = isSkillInvoked(agentMetadata, 'azure-validation');
+    
+    // Should mention key constraints
+    const mentions24Chars = doesAssistantMessageIncludeKeyword(agentMetadata, '24');
+    const mentionsLowercase = doesAssistantMessageIncludeKeyword(agentMetadata, 'lowercase');
+
+    expect(isSkillUsed).toBe(true);
+    expect(mentions24Chars).toBe(true);
+    expect(mentionsLowercase).toBe(true);
+  });
+
+  test('provides Key Vault naming constraints', async () => {
+    const agentMetadata = await run({
+      prompt: 'What are the naming constraints for Azure Key Vault?'
+    });
+
+    const isSkillUsed = isSkillInvoked(agentMetadata, 'azure-validation');
+    const mentionsKeyVault = doesAssistantMessageIncludeKeyword(agentMetadata, 'Key Vault');
+
+    expect(isSkillUsed).toBe(true);
+    expect(mentionsKeyVault).toBe(true);
+  });
+
+  test('validates a specific storage account name', async () => {
+    const agentMetadata = await run({
+      prompt: 'Is "MyStorageAccount123" a valid Azure storage account name?'
+    });
+
+    const isSkillUsed = isSkillInvoked(agentMetadata, 'azure-validation');
+    // Should mention it's invalid due to uppercase
+    const mentionsInvalid = doesAssistantMessageIncludeKeyword(agentMetadata, 'invalid') ||
+                           doesAssistantMessageIncludeKeyword(agentMetadata, 'lowercase') ||
+                           doesAssistantMessageIncludeKeyword(agentMetadata, 'not valid');
+
+    expect(isSkillUsed).toBe(true);
+    expect(mentionsInvalid).toBe(true);
+  });
+});

--- a/tests/jest.config.js
+++ b/tests/jest.config.js
@@ -46,8 +46,8 @@ const config = {
   // Fail fast in CI
   bail: process.env.CI ? 1 : 0,
   
-  // Test timeout (skills may have async operations)
-  testTimeout: 10000,
+  // Test timeout - longer for integration tests (agent sessions can take 60s+)
+  testTimeout: 120000,
   
   // Clear mocks between tests
   clearMocks: true,

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -8,6 +8,7 @@
       "name": "azure-copilot-skills-tests",
       "version": "1.0.0",
       "devDependencies": {
+        "@github/copilot-sdk": "^0.1.19",
         "gray-matter": "^4.0.3",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0"
@@ -508,6 +509,141 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@github/copilot": {
+      "version": "0.0.394",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-0.0.394.tgz",
+      "integrity": "sha512-koSiaHvVwjgppgh+puxf6dgsR8ql/WST1scS5bjzMsJFfWk7f4xtEXla7TCQfSGoZkCmCsr2Tis27v5TpssiCg==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "0.0.394",
+        "@github/copilot-darwin-x64": "0.0.394",
+        "@github/copilot-linux-arm64": "0.0.394",
+        "@github/copilot-linux-x64": "0.0.394",
+        "@github/copilot-win32-arm64": "0.0.394",
+        "@github/copilot-win32-x64": "0.0.394"
+      }
+    },
+    "node_modules/@github/copilot-darwin-arm64": {
+      "version": "0.0.394",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.394.tgz",
+      "integrity": "sha512-qDmDFiFaYFW45UhxylN2JyQRLVGLCpkr5UmgbfH5e0aksf+69qytK/MwpD2Cq12KdTjyGMEorlADkSu5eftELA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-darwin-x64": {
+      "version": "0.0.394",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.394.tgz",
+      "integrity": "sha512-iN4YwSVFxhASiBjLk46f+AzRTNHCvYcmyTKBASxieMIhnDxznYmpo+haFKPCv2lCsEWU8s5LARCnXxxx8J1wKA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-arm64": {
+      "version": "0.0.394",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.394.tgz",
+      "integrity": "sha512-9NeGvmO2tGztuneXZfYAyW3fDk6Pdl6Ffg8MAUaevA/p0awvA+ti/Vh0ZSTcI81nDTjkzONvrcIcjYAN7x0oSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-linux-x64": {
+      "version": "0.0.394",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.394.tgz",
+      "integrity": "sha512-toahsYQORrP/TPSBQ7sxj4/fJg3YUrD0ksCj/Z4y2vT6EwrE9iC2BspKgQRa4CBoCqxYDNB2blc+mQ1UuzPOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
+    "node_modules/@github/copilot-sdk": {
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.1.19.tgz",
+      "integrity": "sha512-h/KvYb6g99v9SurNJGxeXUatmP7GO8KHTAb68GYfmgUqH1EUeN5g0xMUc5lvKxAi7hwj2OxRR73dd37zMMiiiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@github/copilot": "^0.0.394",
+        "vscode-jsonrpc": "^8.2.1",
+        "zod": "^4.3.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@github/copilot-win32-arm64": {
+      "version": "0.0.394",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.394.tgz",
+      "integrity": "sha512-R7XBP3l+oeDuBrP0KD80ZBEMsZoxAW8QO2MNsDUV8eVrNJnp6KtGHoA+iCsKYKNOD6wHA/q5qm/jR+gpsz46Aw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@github/copilot-win32-x64": {
+      "version": "0.0.394",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.394.tgz",
+      "integrity": "sha512-/XYV8srP+pMXbf9Gc3wr58zCzBZvsdA3X4poSvr2uU8yCZ6E4pD0agFaZ1c/CikANJi8nb0Id3kulhEhePz/3A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
+      }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -3634,6 +3770,16 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
+      "integrity": "sha512-kdjOSJ2lLIn7r1rtrMbbNCHjyMPfRnowdKjBQ+mGq6NAW5QY2bEZC/khaC5OR8svbbjvLEaIXkOq45e2X9BIbQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -3763,6 +3909,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/tests/package.json
+++ b/tests/package.json
@@ -5,18 +5,21 @@
   "private": true,
   "scripts": {
     "test": "jest",
+    "test:unit": "jest --testPathIgnorePatterns=\"node_modules|_template|integration\"",
+    "test:integration": "jest --testPathPattern=integration --testPathIgnorePatterns=\"node_modules|_template\"",
     "test:verbose": "jest --verbose",
-    "test:coverage": "jest --coverage",
-    "test:ci": "jest --ci --reporters=default --reporters=jest-junit",
+    "test:coverage": "jest --coverage --testPathIgnorePatterns=\"node_modules|_template|integration\"",
+    "test:ci": "jest --ci --reporters=default --reporters=jest-junit --testPathIgnorePatterns=\"node_modules|_template|integration\"",
     "test:watch": "jest --watch",
     "test:skill": "jest --testPathPattern",
     "coverage:grid": "node scripts/generate-coverage-grid.js",
     "update:snapshots": "jest --updateSnapshot"
   },
   "devDependencies": {
+    "@github/copilot-sdk": "^0.1.19",
+    "gray-matter": "^4.0.3",
     "jest": "^29.7.0",
-    "jest-junit": "^16.0.0",
-    "gray-matter": "^4.0.3"
+    "jest-junit": "^16.0.0"
   },
   "jest-junit": {
     "outputDirectory": "./reports",

--- a/tests/reports/junit.xml
+++ b/tests/reports/junit.xml
@@ -1,6 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<testsuites name="jest tests" tests="33" failures="0" errors="0" time="0.143">
-  <testsuite name="azure-validation/triggers.test.js" errors="0" failures="0" skipped="0" timestamp="2026-01-29T19:50:04" time="0.098" tests="22">
+<testsuites name="jest tests" tests="33" failures="0" errors="0" time="0.207">
+  <testsuite name="azure-validation/unit.test.js" errors="0" failures="0" skipped="0" timestamp="2026-01-29T20:21:36" time="0.154" tests="11">
+    <testcase classname="azure-validation - Unit Tests › Skill Metadata" name="has valid SKILL.md with required fields" time="0.001">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Skill Metadata" name="description mentions validation or pre-deployment" time="0">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Skill Content" name="has substantive content" time="0.001">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Skill Content" name="contains naming constraints section" time="0">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Skill Content" name="documents storage account limits" time="0">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Skill Content" name="documents key vault limits" time="0">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Skill Content" name="includes validation checklist" time="0">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Skill Content" name="references MCP tools" time="0">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Naming Rules Validation" name="storage account: valid names" time="0">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Naming Rules Validation" name="storage account: invalid names" time="0">
+    </testcase>
+    <testcase classname="azure-validation - Unit Tests › Naming Rules Validation" name="key vault: valid names" time="0">
+    </testcase>
+  </testsuite>
+  <testsuite name="azure-validation/triggers.test.js" errors="0" failures="0" skipped="0" timestamp="2026-01-29T20:21:36" time="0.027" tests="22">
     <testcase classname="azure-validation - Trigger Tests › Should Trigger" name="triggers on: &quot;Validate my Azure storage account name&quot;" time="0">
     </testcase>
     <testcase classname="azure-validation - Trigger Tests › Should Trigger" name="triggers on: &quot;What are the naming constraints for Azure Key Vault?&quot;" time="0">
@@ -35,39 +59,15 @@
     </testcase>
     <testcase classname="azure-validation - Trigger Tests › Should NOT Trigger" name="does not trigger on: &quot;How do I use Docker?&quot;" time="0">
     </testcase>
-    <testcase classname="azure-validation - Trigger Tests › Trigger Keywords Snapshot" name="skill keywords match snapshot" time="0">
+    <testcase classname="azure-validation - Trigger Tests › Trigger Keywords Snapshot" name="skill keywords match snapshot" time="0.001">
     </testcase>
-    <testcase classname="azure-validation - Trigger Tests › Trigger Keywords Snapshot" name="skill description triggers match snapshot" time="0.001">
+    <testcase classname="azure-validation - Trigger Tests › Trigger Keywords Snapshot" name="skill description triggers match snapshot" time="0">
     </testcase>
     <testcase classname="azure-validation - Trigger Tests › Edge Cases" name="handles empty prompt" time="0">
     </testcase>
     <testcase classname="azure-validation - Trigger Tests › Edge Cases" name="handles very long prompt" time="0">
     </testcase>
     <testcase classname="azure-validation - Trigger Tests › Edge Cases" name="is case insensitive for Azure terms" time="0">
-    </testcase>
-  </testsuite>
-  <testsuite name="azure-validation/unit.test.js" errors="0" failures="0" skipped="0" timestamp="2026-01-29T19:50:04" time="0.016" tests="11">
-    <testcase classname="azure-validation - Unit Tests › Skill Metadata" name="has valid SKILL.md with required fields" time="0.001">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Skill Metadata" name="description mentions validation or pre-deployment" time="0">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Skill Content" name="has substantive content" time="0">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Skill Content" name="contains naming constraints section" time="0">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Skill Content" name="documents storage account limits" time="0">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Skill Content" name="documents key vault limits" time="0">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Skill Content" name="includes validation checklist" time="0">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Skill Content" name="references MCP tools" time="0">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Naming Rules Validation" name="storage account: valid names" time="0">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Naming Rules Validation" name="storage account: invalid names" time="0">
-    </testcase>
-    <testcase classname="azure-validation - Unit Tests › Naming Rules Validation" name="key vault: valid names" time="0">
     </testcase>
   </testsuite>
 </testsuites>

--- a/tests/utils/agent-runner.js
+++ b/tests/utils/agent-runner.js
@@ -1,0 +1,223 @@
+/**
+ * Agent Runner Utility
+ * 
+ * Executes real Copilot agent sessions for integration testing.
+ * Adapted from PR #617's runner.ts pattern.
+ * 
+ * Prerequisites:
+ * - Install Copilot CLI: npm install -g @github/copilot-cli
+ * - Login: Run `copilot` and follow prompts to authenticate
+ */
+
+const { CopilotClient } = require('@github/copilot-sdk');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+/**
+ * @typedef {Object} AgentMetadata
+ * @property {Array} events - All session events captured during execution
+ */
+
+/**
+ * @typedef {Object} TestConfig
+ * @property {Function} [setup] - Optional setup function (workspace) => Promise<void>
+ * @property {string} prompt - The prompt to send to the agent
+ * @property {Function} [shouldEarlyTerminate] - Optional early termination check
+ */
+
+/**
+ * Run an agent session with the given configuration
+ * @param {TestConfig} config - Test configuration
+ * @returns {Promise<AgentMetadata>} - Captured agent metadata
+ */
+async function run(config) {
+  const testWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), 'skill-test-'));
+
+  try {
+    // Run optional setup
+    if (config.setup) {
+      await config.setup(testWorkspace);
+    }
+
+    const client = new CopilotClient({
+      logLevel: process.env.DEBUG ? 'all' : 'error',
+      cwd: testWorkspace
+    });
+
+    const skillDirectory = path.resolve(__dirname, '../../plugin/skills');
+
+    const session = await client.createSession({
+      model: 'claude-sonnet-4',
+      skillDirectories: [skillDirectory],
+      mcpServers: {
+        azure: {
+          type: 'stdio',
+          command: 'npx',
+          args: ['-y', '@azure/mcp', 'server', 'start'],
+          tools: ['*']
+        }
+      }
+    });
+
+    const agentMetadata = { events: [] };
+
+    const done = new Promise((resolve) => {
+      session.on(async (event) => {
+        if (process.env.DEBUG) {
+          console.log(`=== session event ${event.type}`);
+        }
+
+        if (event.type === 'session.idle') {
+          resolve();
+          return;
+        }
+
+        // Capture all events
+        agentMetadata.events.push(event);
+
+        // Check for early termination
+        if (config.shouldEarlyTerminate) {
+          if (config.shouldEarlyTerminate(agentMetadata)) {
+            resolve();
+            session.abort();
+            return;
+          }
+        }
+
+        // Debug logging for selected events
+        if (process.env.DEBUG) {
+          if (event.type === 'assistant.message') {
+            console.log('Assistant.message:', event.data.content);
+          } else if (event.type === 'tool.execution_start') {
+            console.log('tool.execution_start:', event.data.toolName);
+          } else if (event.type === 'session.error') {
+            console.error('Session error:', event.data.message);
+          }
+        }
+      });
+    });
+
+    await session.send({ prompt: config.prompt });
+    await done;
+
+    await session.destroy();
+    await client.stop();
+
+    return agentMetadata;
+  } catch (error) {
+    console.error('Agent runner error:', error);
+    throw error;
+  } finally {
+    // Cleanup workspace
+    try {
+      fs.rmSync(testWorkspace, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  }
+}
+
+/**
+ * Check if a skill was invoked during the session
+ * @param {AgentMetadata} agentMetadata - Captured metadata
+ * @param {string} skillName - Name of the skill to check
+ * @returns {boolean}
+ */
+function isSkillInvoked(agentMetadata, skillName) {
+  return agentMetadata.events
+    .filter(event => event.type === 'tool.execution_start')
+    .filter(event => event.data.toolName === 'skill')
+    .some(event => {
+      const args = event.data.arguments;
+      return JSON.stringify(args).includes(skillName);
+    });
+}
+
+/**
+ * Check if all tool calls for a given tool were successful
+ * @param {AgentMetadata} agentMetadata - Captured metadata
+ * @param {string} toolName - Name of the tool to check
+ * @returns {boolean}
+ */
+function areToolCallsSuccess(agentMetadata, toolName) {
+  const executionStartEvents = agentMetadata.events
+    .filter(event => event.type === 'tool.execution_start')
+    .filter(event => event.data.toolName === toolName);
+  
+  const executionCompleteEvents = agentMetadata.events
+    .filter(event => event.type === 'tool.execution_complete');
+
+  return executionStartEvents.length > 0 && executionStartEvents.every(startEvent => {
+    const toolCallId = startEvent.data.toolCallId;
+    return executionCompleteEvents.some(
+      completeEvent => completeEvent.data.toolCallId === toolCallId && completeEvent.data.success
+    );
+  });
+}
+
+/**
+ * Check if assistant messages contain a keyword
+ * @param {AgentMetadata} agentMetadata - Captured metadata
+ * @param {string} keyword - Keyword to search for
+ * @param {Object} [options] - Options
+ * @param {boolean} [options.caseSensitive=false] - Case sensitive search
+ * @returns {boolean}
+ */
+function doesAssistantMessageIncludeKeyword(agentMetadata, keyword, options = {}) {
+  // Merge all messages and message deltas
+  const allMessages = {};
+  
+  agentMetadata.events.forEach(event => {
+    if (event.type === 'assistant.message') {
+      allMessages[event.data.messageId] = event.data.content;
+    }
+    if (event.type === 'assistant.message_delta') {
+      if (allMessages[event.data.messageId]) {
+        allMessages[event.data.messageId] += event.data.deltaContent;
+      } else {
+        allMessages[event.data.messageId] = event.data.deltaContent;
+      }
+    }
+  });
+
+  return Object.values(allMessages).some(message => {
+    if (options.caseSensitive) {
+      return message.includes(keyword);
+    }
+    return message.toLowerCase().includes(keyword.toLowerCase());
+  });
+}
+
+/**
+ * Get all tool calls made during the session
+ * @param {AgentMetadata} agentMetadata - Captured metadata
+ * @param {string} [toolName] - Optional filter by tool name
+ * @returns {Array} - Array of tool call events
+ */
+function getToolCalls(agentMetadata, toolName = null) {
+  let calls = agentMetadata.events.filter(event => event.type === 'tool.execution_start');
+  
+  if (toolName) {
+    calls = calls.filter(event => event.data.toolName === toolName);
+  }
+  
+  return calls;
+}
+
+/**
+ * Check if integration tests should be skipped
+ * @returns {boolean}
+ */
+function shouldSkipIntegrationTests() {
+  return process.env.SKIP_INTEGRATION_TESTS === 'true' || process.env.CI === 'true';
+}
+
+module.exports = {
+  run,
+  isSkillInvoked,
+  areToolCallsSuccess,
+  doesAssistantMessageIncludeKeyword,
+  getToolCalls,
+  shouldSkipIntegrationTests
+};


### PR DESCRIPTION
## Summary

Adds real agent-based integration testing support using `@github/copilot-sdk`, inspired by PR #617.

## What's New

### Integration Test Runner (`utils/agent-runner.js`)
- `run(config)` - Execute Copilot agent sessions with prompts
- `isSkillInvoked(metadata, skillName)` - Check if skill was activated
- `areToolCallsSuccess(metadata, toolName)` - Verify tool calls succeeded
- `doesAssistantMessageIncludeKeyword(metadata, keyword)` - Search responses

### Example Integration Tests
- `azure-role-selector/integration.test.js` - Tests role recommendation prompts
- `azure-validation/integration.test.js` - Tests naming constraint prompts
- `_template/integration.test.js` - Template for new skills

### npm Scripts
| Script | Purpose |
|--------|---------|
| `test:unit` | Run unit/trigger tests only (fast, no auth) |
| `test:integration` | Run integration tests (requires Copilot CLI) |
| `test:ci` | CI-safe tests (skips integration) |

## Prerequisites for Integration Tests

```bash
npm install -g @github/copilot-cli
copilot  # authenticate
```

## Test Results

Unit tests: **33 passed** ✅

Integration tests require authentication and are skipped in CI.

## Related

- Builds on PR #613 (skills testing framework)
- Inspired by PR #617 (@JasonYeMSFT's integration test approach)

/cc @JasonYeMSFT - This consolidates the integration test approach from your PR #617 into our existing `tests/` framework. Happy to coordinate!