### PR TITLE
fix: Workflow commit step path and graceful failure

### DIFF
--- a/.github/workflows/test-all-skills.yml
+++ b/.github/workflows/test-all-skills.yml
@@ -159,12 +159,12 @@ jobs:
         continue-on-error: true
         working-directory: .
         run: |
+          if git diff --quiet tests/README.md; then
+            echo "No changes to README.md"
+            exit 0
+          fi
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add tests/README.md
-          if git diff --staged --quiet; then
-            echo "No changes to commit"
-          else
-            git commit -m "docs: update skills coverage grid [skip ci]"
-            git push || echo "::warning::Could not push changes - branch protection may be enabled"
-          fi
+          git commit -m "docs: update skills coverage grid [skip ci]"
+          git push || echo "::warning::Could not push changes - branch protection may be enabled"


### PR DESCRIPTION
## Problem

The `Commit README updates` step fails because:
1. The job has `working-directory: tests` as default, but `git add tests/README.md` looks for `tests/tests/README.md`
2. Branch protection may block direct pushes from the action

## Solution

- Add `working-directory: .` to run git commands from repo root
- Add `continue-on-error: true` so the workflow doesn't fail if push is blocked
- Emit a warning instead of failing when push is blocked

## Changes

```yaml
- name: Commit README updates
  continue-on-error: true
  working-directory: .
  run: |
    ...
    git push || echo "::warning::Could not push changes - branch protection may be enabled"
```

Relates to #619