### PR TITLE
fix: Create PR for README coverage updates instead of direct push

### DIFF
--- a/.github/copilot-review-rules.md
+++ b/.github/copilot-review-rules.md
@@ -1,0 +1,24 @@
+# Copilot Code Review Rules
+
+## Auto-generated PRs
+
+For PRs with titles starting with `docs:` that update coverage grids or documentation:
+
+### Review Criteria
+
+1. **Accuracy**: Verify the coverage grid reflects actual test files
+2. **Formatting**: Ensure markdown tables are properly formatted
+3. **No Regressions**: Coverage should not decrease without explanation
+
+### Auto-Approve Conditions
+
+PRs updating `tests/README.md` coverage grid can be auto-approved if:
+- Only `tests/README.md` is modified
+- Changes are limited to the coverage grid table
+- No test files were deleted
+
+## General Review Guidelines
+
+- Focus on correctness over style
+- Verify links and references are valid
+- Check for accidental credential exposure

--- a/.github/workflows/test-all-skills.yml
+++ b/.github/workflows/test-all-skills.yml
@@ -132,6 +132,7 @@ jobs:
     
     permissions:
       contents: write
+      pull-requests: write
 
     defaults:
       run:
@@ -155,16 +156,35 @@ jobs:
       - name: Generate coverage grid
         run: npm run coverage:grid
 
-      - name: Commit README updates
-        continue-on-error: true
+      - name: Create PR for README updates
         working-directory: .
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if git diff --quiet tests/README.md; then
             echo "No changes to README.md"
             exit 0
           fi
+          
+          BRANCH="auto/update-coverage-grid-$(date +%Y%m%d-%H%M%S)"
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
+          git checkout -b "$BRANCH"
           git add tests/README.md
-          git commit -m "docs: update skills coverage grid [skip ci]"
-          git push || echo "::warning::Could not push changes - branch protection may be enabled"
+          git commit -m "docs: update skills coverage grid"
+          git push origin "$BRANCH"
+          
+          gh pr create \
+            --title "docs: Update skills coverage grid" \
+            --body "Automated PR to update the skills coverage grid in tests/README.md.
+
+          This PR was created by the test workflow after detecting changes to test coverage.
+
+          > [!NOTE]
+          > Copilot will review this PR automatically." \
+            --base main \
+            --head "$BRANCH"
+          
+          # Request Copilot code review
+          gh pr edit "$BRANCH" --add-reviewer "@me"
+          echo "::notice::Created PR from branch $BRANCH - Copilot review requested"


### PR DESCRIPTION
## Problem

Branch protection prevents the workflow from pushing directly to main:
```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
```

## Solution

Instead of direct push, the workflow now:
1. Creates a timestamped branch `auto/update-coverage-grid-YYYYMMDD-HHMMSS`
2. Opens a PR with the README changes
3. Requests review (Copilot can auto-review)

## New Files

- `.github/copilot-review-rules.md` - Guidelines for Copilot to review auto-generated PRs

## Workflow Changes

- Added `pull-requests: write` permission
- Replaced direct push with `gh pr create`
- Added notice output with PR link

Relates to #619