### PR TITLE
Updates contributing on how to quickly test PR branches

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,6 +122,41 @@ Remove-Item "$env:USERPROFILE\.copilot\installed-plugins\github-copilot-for-azur
 rm ~/.copilot/installed-plugins/github-copilot-for-azure
 ```
 
+### 5. Testing Pull Requests Locally
+
+Once your symlink is set up, you can quickly test any open pull request by checking out its branch. This is especially useful during code review to verify changes work as expected.
+
+#### Using GitHub CLI
+
+Install the [GitHub CLI](https://cli.github.com/) if you haven't already, then run:
+
+```bash
+gh pr checkout <PR-NUMBER>
+```
+
+For example, to test PR #42:
+
+```bash
+gh pr checkout 42
+```
+
+This automatically:
+1. Fetches the PR branch from the contributor's fork
+2. Creates a local branch tracking the PR
+3. Updates your symlinked plugin folder with the PR's changes
+
+After checking out, restart GitHub Copilot CLI to pick up the changes and test the skill or feature.
+
+#### Switching Back
+
+To return to the main branch after testing:
+
+```bash
+git checkout main
+```
+
+> **Tip:** You can also use `gh pr checkout <PR-NUMBER> --force` to discard any local changes and switch to the PR branch.
+
 ---
 
 ## Contributing Skills


### PR DESCRIPTION
I've added a new section **"5. Testing Pull Requests Locally"** to the Local Development Setup that explains how to:

1. Use `gh pr checkout <PR-NUMBER>` to quickly switch to any open PR's branch
2. Understand that the symlink automatically picks up the PR's changes
3. Restart GitHub Copilot CLI to test the changes
4. Switch back to main when done

The section fits naturally in the numbered setup steps and includes practical examples like `gh pr checkout 42`.