### PR TITLE
Add instructions about skills

### DIFF
--- a/.github/instructions/skill-files.instructions.md
+++ b/.github/instructions/skill-files.instructions.md
@@ -62,5 +62,5 @@ If including executable scripts:
 
 ## Related Resources
 
-- Reference the [skill-authoring skill](.github/skills/skill-authoring/SKILL.md) for detailed guidelines
+- Reference the [skill-authoring skill](../skills/skill-authoring/SKILL.md) for detailed guidelines
 - Follow the [agentskills.io specification](https://agentskills.io/specification)


### PR DESCRIPTION
Add instructions about SKILL.md files, distilled from CONTRIBUTING.md and our various skills and agents around creating new skills. The intent is to provide specific guidelines that are visible to Copilot during both generation (whatever process that uses) and review.