### PR TITLE
fix: enable ESM support for @github/copilot-sdk in Jest integration tests

### DIFF
--- a/tests/jest.config.ts
+++ b/tests/jest.config.ts
@@ -68,7 +68,7 @@ const config: Config = {
   
   // Transform ESM modules from node_modules (copilot-sdk is ESM-only)
   transformIgnorePatterns: [
-    'node_modules/(?!(@github/copilot-sdk)/)'
+    'node_modules/(?!(@github/copilot-sdk|@github/copilot)/)'
   ],
   
   // Display individual test results

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns=\"node_modules|_template|integration\"",
-    "test:integration": "jest --testPathPattern=integration --testPathIgnorePatterns=\"node_modules|_template\"",
+    "test:integration": "NODE_OPTIONS='--experimental-vm-modules' jest --testPathPattern=integration --testPathIgnorePatterns=\"node_modules|_template\"",
     "test:verbose": "jest --verbose",
     "test:coverage": "jest --coverage --testPathIgnorePatterns=\"node_modules|_template|integration\"",
     "test:ci": "jest --ci --reporters=default --reporters=jest-junit --testPathIgnorePatterns=\"node_modules|_template|integration\"",


### PR DESCRIPTION
## Summary

Fixes integration tests to actually run real Copilot SDK sessions instead of silently skipping due to Jest ESM compatibility issues.

## Problem

The `@github/copilot-sdk` package is an ESM-only module (`"type": "module"`). When Jest tried to dynamically import it via `await import('@github/copilot-sdk')`, it would fail silently because:

1. Jest intercepts `import()` calls through its module system
2. The SDK requires native ESM support via `--experimental-vm-modules`
3. Tests were passing with 0 assertions because they caught the SDK load error and returned early

## Solution

1. **package.json**: Added `NODE_OPTIONS='--experimental-vm-modules'` to the `test:integration` script
2. **agent-runner.ts**: Use `eval('(url) => import(url)')` with a `file://` URL to bypass Jest's static import transformation
3. **jest.config.ts**: Added `@github/copilot` to `transformIgnorePatterns`

## Testing

Before this fix:
```
⏭️  SDK not loadable, skipping test
✓ invokes azure-validation skill (8ms)  # No actual test ran!
```

After this fix:
```
SDK path: .../node_modules/@github/copilot-sdk/dist/index.js
=== session event assistant.message
Assistant.message: Based on the Azure documentation... [actual response]
✓ invokes azure-validation skill (26414 ms)  # Real Copilot session!
```

## Files Changed

- `tests/package.json` - Add `--experimental-vm-modules` flag
- `tests/utils/agent-runner.ts` - Bypass Jest module interception for ESM import
- `tests/jest.config.ts` - Update transformIgnorePatterns