### PR TITLE
feat: add test:skills scripts for running skill tests from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "tokens": "cd scripts && npm run tokens --",
     "test": "cd scripts && npm test",
+    "test:skills": "cd tests && npm test --",
+    "test:skills:integration": "cd tests && npm run test:integration --",
     "postinstall": "cd scripts && npm install"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Adds convenience scripts to the root `package.json` for running skill tests without having to `cd tests` first.

## Problem

Running skill tests requires navigating to the `tests/` directory first:
```bash
cd tests && npm test -- --testPathPattern=azure-validation
```

The root `npm run test` runs the `scripts/` vitest tests (token analysis), not the `tests/` Jest tests (skills).

## Solution

Add two new scripts to root `package.json`:

- `test:skills` - runs Jest skill tests from `tests/` directory
- `test:skills:integration` - runs integration tests with ESM support

## Usage

```bash
# Run all skill tests
npm run test:skills

# Run specific skill tests
npm run test:skills -- --testPathPattern=azure-validation

# Run integration tests
npm run test:skills:integration -- --testPathPattern=azure-validation
```