### PR TITLE
fix: use cross-env for Windows compatibility in test:integration

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -11,6 +11,7 @@
         "@github/copilot-sdk": "^0.1.19",
         "@types/jest": "^29.5.12",
         "@types/node": "^20.11.19",
+        "cross-env": "^7.0.3",
         "gray-matter": "^4.0.3",
         "jest": "^29.7.0",
         "jest-junit": "^16.0.0",
@@ -1676,6 +1677,25 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",

--- a/tests/package.json
+++ b/tests/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "jest",
     "test:unit": "jest --testPathIgnorePatterns=\"node_modules|_template|integration\"",
-    "test:integration": "NODE_OPTIONS='--experimental-vm-modules' jest --testPathPattern=integration --testPathIgnorePatterns=\"node_modules|_template\"",
+    "test:integration": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --testPathPattern=integration --testPathIgnorePatterns=\"node_modules|_template\"",
     "test:verbose": "jest --verbose",
     "test:coverage": "jest --coverage --testPathIgnorePatterns=\"node_modules|_template|integration\"",
     "test:ci": "jest --ci --reporters=default --reporters=jest-junit --testPathIgnorePatterns=\"node_modules|_template|integration\"",
@@ -19,6 +19,7 @@
     "@github/copilot-sdk": "^0.1.19",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.19",
+    "cross-env": "^7.0.3",
     "gray-matter": "^4.0.3",
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",


### PR DESCRIPTION
## Summary
Fixes integration tests failing on Windows due to shell-incompatible `NODE_OPTIONS='...'` syntax.

## Problem
The `test:integration` script in `tests/package.json` used Unix-style environment variable syntax:
```
NODE_OPTIONS='--experimental-vm-modules' jest ...
```

This works on macOS/Linux but fails on Windows:
```
'NODE_OPTIONS' is not recognized as an internal or external command,
operable program or batch file.
```

## Solution
Added `cross-env` package and updated the script to:
```
cross-env NODE_OPTIONS=--experimental-vm-modules jest ...
```

This provides cross-platform support for setting environment variables in npm scripts.

## Changes
- Added `cross-env@^7.0.3` to devDependencies
- Updated `test:integration` script to use `cross-env`

## Testing
- Verified tests still run on macOS
- Windows users can now run `npm run test:integration` successfully