### PR TITLE
docs: add references/recipes loading behavior documentation

### DIFF
--- a/.github/skills/sensei/references/SCORING.md
+++ b/.github/skills/sensei/references/SCORING.md
@@ -20,6 +20,16 @@ From [skill-authoring](/.github/skills/skill-authoring):
 
 **Check with:** `cd scripts && npm run tokens -- check plugin/skills/{skill}/SKILL.md`
 
+### Reference Loading Impact
+
+References load **only when explicitly linked** in SKILL.md, not on activation:
+- Use `[text](references/file.md)` to trigger loading
+- Each file loads in full (entire content, not sections)
+- No caching between requests
+- Structure with recipes/services patterns for multi-option skills
+
+See [skill-authoring REFERENCE-LOADING.md](/.github/skills/skill-authoring/references/REFERENCE-LOADING.md) for details.
+
 ## Adherence Levels
 
 ### Low Adherence

--- a/.github/skills/skill-authoring/SKILL.md
+++ b/.github/skills/skill-authoring/SKILL.md
@@ -31,7 +31,17 @@ Frontmatter: `name` (lowercase-hyphens), `description` (WHAT + WHEN)
 
 ## Progressive Disclosure
 
-Metadata (~100 tokens) loads at startup. SKILL.md (<5000 tokens) loads on activation. References load on demand. Keep SKILL.md lean.
+Metadata (~100 tokens) loads at startup. SKILL.md (<5000 tokens) loads on activation. References load **only when explicitly linked** (not on activation). Keep SKILL.md lean.
+
+## Reference Loading
+
+References are JIT (just-in-time) loaded:
+- Only files explicitly linked via `[text](references/file.md)` load
+- Each file loads in full (not sections)
+- No caching between requests - write self-contained files
+- Use recipes/services patterns for multi-option skills
+
+See [REFERENCE-LOADING.md](references/REFERENCE-LOADING.md) for details.
 
 ## Validation
 
@@ -44,5 +54,6 @@ npm run tokens -- check plugin/skills/my-skill/SKILL.md
 ## Reference Documentation
 
 - [GUIDELINES.md](references/GUIDELINES.md) - Detailed writing guidelines
+- [REFERENCE-LOADING.md](references/REFERENCE-LOADING.md) - How references load and token efficiency
 - [CHECKLIST.md](references/CHECKLIST.md) - Pre-submission checklist
 - [agentskills.io/specification](https://agentskills.io/specification) - Official spec

--- a/.github/skills/skill-authoring/references/GUIDELINES.md
+++ b/.github/skills/skill-authoring/references/GUIDELINES.md
@@ -64,6 +64,18 @@ Skills use a three-tier loading model to manage context efficiently:
 2. **Move details to references/** - Only loaded when explicitly needed
 3. **Split large content** - Multiple smaller files > one large file
 
+### Critical: How References Load
+
+References load **only when explicitly linked** - NOT when the skill activates:
+
+- ✅ `See [error guide](references/errors.md)` → Agent loads `errors.md`
+- ❌ "Error docs are in references/" → Agent won't find or load files
+
+Per the [spec clarification](https://github.com/agentskills/agentskills/issues/97):
+- References are **re-read each time referenced** (no caching)
+- Write references as **self-contained units**
+- The **entire file** loads when referenced (not just sections)
+
 ## Directory Structure
 
 ```
@@ -97,6 +109,56 @@ The `templates/` folder contains structured output formats used when the skill g
 - **When to use**: When the skill needs to format output in a specific way (e.g., cost reports, analysis summaries)
 - **Naming convention**: Use lowercase letters with hyphens (e.g., `report-template.md`, `cost-analysis.md`)
 - **Examples**: `redis-subscription-level-report.md`, `detailed-cache-analysis.md`
+
+## Advanced: Recipes and Services Patterns
+
+For skills supporting multiple tools or cloud services, use structured subfolders:
+
+### Recipes Pattern
+
+Use when skill supports multiple implementation approaches (deployment tools, IaC options):
+
+```
+skill-name/
+├── SKILL.md
+└── references/
+    ├── recipes/
+    │   ├── azd/           # Azure Developer CLI
+    │   │   ├── README.md
+    │   │   └── errors.md
+    │   ├── bicep/         # Bicep IaC
+    │   │   ├── README.md
+    │   │   └── patterns.md
+    │   └── terraform/     # Terraform IaC
+    └── common.md          # Shared across recipes
+```
+
+**Link selectively in SKILL.md:**
+```markdown
+## Choose Deployment Method
+- [Azure Developer CLI](references/recipes/azd/README.md) - Recommended
+- [Bicep](references/recipes/bicep/README.md) - IaC-first
+- [Terraform](references/recipes/terraform/README.md) - Multi-cloud
+```
+
+This ensures only the chosen recipe loads, not all options.
+
+### Services Pattern
+
+Use when skill works with multiple cloud services:
+
+```
+skill-name/
+├── SKILL.md
+└── references/
+    └── services/
+        ├── container-apps.md
+        ├── static-web-apps.md
+        ├── functions.md
+        └── cosmos-db.md
+```
+
+Each service file should be self-contained with its own config, Bicep, and troubleshooting.
 
 ## Token Budget Guidelines
 
@@ -183,5 +245,7 @@ npm run tokens -- check
 
 - [Agent Skills Specification](https://agentskills.io/specification)
 - [What Are Skills](https://agentskills.io/what-are-skills)
+- [Reference Loading Clarification (Issue #97)](https://github.com/agentskills/agentskills/issues/97)
+- [Skill Token Limits (Issue #1130)](https://github.com/github/copilot-cli/issues/1130)
 - [Example Skills](https://github.com/anthropics/skills)
 - [Reference Library](https://github.com/agentskills/agentskills/tree/main/skills-ref)

--- a/.github/skills/skill-authoring/references/REFERENCE-LOADING.md
+++ b/.github/skills/skill-authoring/references/REFERENCE-LOADING.md
@@ -1,0 +1,123 @@
+# Reference Loading Behavior
+
+This document explains how Agent Skills load reference files and best practices for structuring them efficiently.
+
+## How References Load
+
+### Just-In-Time (JIT) Loading
+
+Reference files (`references/`, `scripts/`, `assets/`) are **NOT** loaded when a skill activates. They load **only when explicitly referenced** via a markdown link or file path in the skill instructions.
+
+```markdown
+<!-- This triggers a load -->
+See [the guide](references/guide.md) for details.
+
+<!-- This does NOT trigger a load -->
+Documentation is available in the references folder.
+```
+
+### No Caching Between Requests
+
+Per [agentskills Issue #97](https://github.com/agentskills/agentskills/issues/97):
+
+> Reference files should be **fully loaded each time they are referenced**, regardless of whether they were previously read.
+
+Implications:
+- Don't assume the agent remembers previous file contents
+- Write each reference as a **self-contained unit**
+- Include necessary context within each file
+
+### Whole File Loading
+
+When a reference is loaded, the **entire file** loads - not just a section:
+
+| Link | What Loads |
+|------|------------|
+| `[guide](references/guide.md)` | Entire guide.md |
+| `[guide](references/guide.md#section-2)` | Entire guide.md (anchor is hint only) |
+
+This means:
+- Split large topics into separate files
+- Keep each file < 1,000 tokens
+- Don't create monolithic reference documents
+
+## Token Efficiency Patterns
+
+### Selective Loading with Recipes
+
+```markdown
+<!-- In SKILL.md - user picks ONE option -->
+## Deployment Method
+
+Choose your approach:
+- [AZD](references/recipes/azd/README.md) - Quick start
+- [Bicep](references/recipes/bicep/README.md) - IaC-first
+- [Terraform](references/recipes/terraform/README.md) - Multi-cloud
+
+<!-- Result: Only chosen recipe loads (~300 tokens) -->
+<!-- Not all recipes (~900 tokens) -->
+```
+
+### Avoid Reference Chains
+
+```
+❌ Bad: Multiple hops
+SKILL.md → guide.md → details.md → advanced.md
+
+✅ Good: Flat structure
+SKILL.md → guide.md
+SKILL.md → details.md
+SKILL.md → advanced.md
+```
+
+Spec recommends: **One level deep from SKILL.md**
+
+## Self-Contained Reference Example
+
+```markdown
+# AZD Deployment Errors
+
+Quick reference for Azure Developer CLI deployment issues.
+
+## Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `CONTAINER_REGISTRY_UNAUTHORIZED` | ACR login expired | `az acr login --name <registry>` |
+| `QUOTA_EXCEEDED` | Resource limits | Request increase or change region |
+
+## Troubleshooting Steps
+
+1. Check deployment logs: `azd deploy --debug`
+2. Verify authentication: `az account show`
+3. Check resource status: `azd show`
+
+## Related
+
+- [AZD Commands](README.md)
+- [Verification](verify.md)
+```
+
+Note: This file works standalone without requiring other files to be loaded first.
+
+## Skill Visibility Limits
+
+From [GitHub Copilot CLI Issue #1130](https://github.com/github/copilot-cli/issues/1130):
+
+- With many skills installed, not all appear in available skills list
+- Only ~31 of 49 skills visible in one example due to token limits
+- Hidden skills can still be invoked but aren't discoverable
+
+**Best practices:**
+- Keep `description` concise but keyword-rich
+- Front-load trigger phrases for discoverability
+- Don't rely on users seeing all skills
+
+## Summary
+
+| Behavior | Implication |
+|----------|-------------|
+| JIT loading | Only explicitly linked files load |
+| No caching | Write self-contained references |
+| Whole file loads | Split large content into small files |
+| Token limits | Structure for selective loading |

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -19,6 +19,11 @@ Load the file at `plugin/skills/{skill-name}/SKILL.md` to understand:
 - What the skill does (from content)
 - What Azure services/tools it references
 
+**Also check for references:** If the skill has a `references/` folder, note the structure:
+- `references/recipes/` - Multiple implementation approaches (azd, bicep, terraform)
+- `references/services/` - Multiple Azure services the skill supports
+- References load only when explicitly linked, so understand what paths SKILL.md links to
+
 ### Step 3: Update test files
 In each test file (`unit.test.ts`, `triggers.test.ts`), change:
 ```typescript


### PR DESCRIPTION
## Summary

Documents how Agent Skills load reference files and best practices for structuring `references/`, `recipes/`, and `services/` folders for token efficiency.

## Changes

### New Files
- `.github/skills/skill-authoring/references/REFERENCE-LOADING.md` - Comprehensive guide on JIT loading, caching behavior, and token efficiency patterns

### Updated Files
- `.github/skills/skill-authoring/SKILL.md` - Added reference loading section
- `.github/skills/skill-authoring/references/GUIDELINES.md` - Added recipes/services patterns, explicit linking requirements
- `.github/skills/sensei/references/SCORING.md` - Added reference loading impact notes
- `tests/AGENTS.md` - Added notes about reference folder structure when scaffolding

## Key Learnings Documented

| Behavior | Details |
|----------|---------|
| **When loaded** | Only when explicitly linked via `[text](references/file.md)` |
| **Caching** | None - files re-read each time referenced |
| **Granularity** | Entire file loads (not sections) |
| **On activation** | Only SKILL.md loads, NOT references |

## Token Efficiency Patterns

- **Recipes pattern**: `references/recipes/{tool}/` - only selected tool's files load
- **Services pattern**: `references/services/{service}.md` - only relevant service loads
- **Self-contained files**: Each reference should work standalone (no caching assumption)

## Research

Full research documented in gist: https://gist.github.com/spboyer/b0b56ddb340e8b489d910cbb36b728a9

Fixes #714