### PR TITLE
Refine entra-app skill

### DIFF
--- a/plugin/skills/entra-app-registration/SKILL.md
+++ b/plugin/skills/entra-app-registration/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: entra-app-registration
-description: Expert in Microsoft Entra app registration. Use this skill to help with understanding OAuth protocol, Entra concepts, creating the first Entra app registration and integrating OAuth flow in an example console application.
+description: |
+  Guides Microsoft Entra ID app registration, OAuth 2.0 authentication, and MSAL integration.
+  USE FOR: create app registration, register Azure AD app, configure OAuth, set up authentication, add API permissions, generate service principal, MSAL example, console app auth, Entra ID setup, Azure AD authentication.
+  DO NOT USE FOR: Azure RBAC or role assignments (use azure-role-selector), Key Vault secrets (use azure-keyvault-expiration-audit), Azure resource security (use azure-security).
 ---
 
 ## Overview
@@ -41,6 +44,9 @@ Create an app registration in the Azure portal or using Azure CLI.
 4. Click "Register"
 
 **CLI Method:** See [references/CLI-COMMANDS.md](references/CLI-COMMANDS.md)
+**IaC Method:** See [references/BICEP-EXAMPLE.bicep](references/BICEP-EXAMPLE.bicep)
+
+It's highly recommended to use the IaC to manage Entra app registration if you already use IaC in your project, need a scalable solution for managing lots of app registrations or need fine-grained audit history of the configuration changes. 
 
 ### Step 2: Configure Authentication
 

--- a/plugin/skills/entra-app-registration/references/BICEP-EXAMPLE.bicep
+++ b/plugin/skills/entra-app-registration/references/BICEP-EXAMPLE.bicep
@@ -1,0 +1,199 @@
+// Bicep template for Microsoft Entra App Registration
+// Requires: Bicep v0.21.1+ with Microsoft Graph extension enabled
+
+extension 'br:mcr.microsoft.com/bicep/extensions/microsoftgraph/v1.0:1.0.0'
+
+@description('Display name for the application')
+param appDisplayName string = 'MyEntraApp'
+
+@description('Sign-in audience for the application')
+@allowed([
+  'AzureADMyOrg'
+  'AzureADMultipleOrgs'
+  'AzureADandPersonalMicrosoftAccount'
+  'PersonalMicrosoftAccount'
+])
+param signInAudience string = 'AzureADMyOrg'
+
+@description('Redirect URIs for web application')
+param webRedirectUris array = [
+  'https://localhost:5001/signin-oidc'
+  'https://myapp.azurewebsites.net/signin-oidc'
+]
+
+@description('Redirect URIs for single-page application')
+param spaRedirectUris array = [
+  'http://localhost:3000'
+  'https://myapp.azurewebsites.net'
+]
+
+@description('Tags for the application')
+param tags array = [
+  'Production'
+  'WebApp'
+]
+
+// App Registration
+resource appRegistration 'Microsoft.Graph/applications@v1.0' = {
+  displayName: appDisplayName
+  uniqueName: toLower(replace(appDisplayName, ' ', '-'))
+  signInAudience: signInAudience
+  tags: tags
+
+  // Application identification
+  identifierUris: [
+    'api://${appDisplayName}'
+  ]
+
+  // Web application settings
+  web: {
+    redirectUris: webRedirectUris
+    implicitGrantSettings: {
+      enableIdTokenIssuance: true
+      enableAccessTokenIssuance: false
+    }
+    homePageUrl: 'https://myapp.azurewebsites.net'
+    logoutUrl: 'https://myapp.azurewebsites.net/signout-oidc'
+  }
+
+  // Single-page application settings
+  spa: {
+    redirectUris: spaRedirectUris
+  }
+
+  // Public client (mobile/desktop) settings
+  publicClient: {
+    redirectUris: [
+      'http://localhost'
+      'myapp://auth'
+      'https://login.microsoftonline.com/common/oauth2/nativeclient'
+    ]
+  }
+
+  // API definition (expose an API) 
+  api: {
+    // Version of the access token affects the values present in the token claims
+    requestedAccessTokenVersion: 2
+    oauth2PermissionScopes: [
+      {
+        id: '00000000-0000-0000-0000-000000000001'
+        adminConsentDisplayName: 'Read user data'
+        adminConsentDescription: 'Allows the app to read user data on behalf of the signed-in user'
+        userConsentDisplayName: 'Read your data'
+        userConsentDescription: 'Allows the app to read your data'
+        value: 'User.Read'
+        type: 'User'
+        isEnabled: true
+      }
+      {
+        id: '00000000-0000-0000-0000-000000000002'
+        adminConsentDisplayName: 'Read and write user data'
+        adminConsentDescription: 'Allows the app to read and write user data on behalf of the signed-in user'
+        userConsentDisplayName: 'Read and write your data'
+        userConsentDescription: 'Allows the app to read and write your data'
+        value: 'User.ReadWrite'
+        type: 'User'
+        isEnabled: true
+      }
+    ]
+  }
+
+  // App roles for authorization
+  appRoles: [
+    {
+      id: '00000000-0000-0000-0000-000000000010'
+      displayName: 'Admin'
+      description: 'Administrators can manage all aspects of the app'
+      value: 'Admin'
+      allowedMemberTypes: ['User', 'Application']
+      isEnabled: true
+    }
+    {
+      id: '00000000-0000-0000-0000-000000000011'
+      displayName: 'Reader'
+      description: 'Readers can view data but not modify'
+      value: 'Reader'
+      allowedMemberTypes: ['User']
+      isEnabled: true
+    }
+  ]
+
+  // Required API permissions (Microsoft Graph)
+  requiredResourceAccess: [
+    {
+      // Microsoft Graph API
+      resourceAppId: '00000003-0000-0000-c000-000000000000'
+      resourceAccess: [
+        {
+          // User.Read - Delegated
+          id: 'e1fe6dd8-ba31-4d61-89e7-88639da4683d'
+          type: 'Scope'
+        }
+        {
+          // User.ReadBasic.All - Delegated
+          id: 'b340eb25-3456-403f-be2f-af7a0d370277'
+          type: 'Scope'
+        }
+        {
+          // Mail.Read - Delegated
+          id: '570282fd-fa5c-430d-a7fd-fc8dc98a9dca'
+          type: 'Scope'
+        }
+        {
+          // User.Read.All - Application
+          id: 'df021288-bdef-4463-88db-98f22de89214'
+          type: 'Role'
+        }
+      ]
+    }
+  ]
+
+  // Optional claims configuration
+  optionalClaims: {
+    idToken: [
+      {
+        name: 'email'
+        essential: false
+      }
+      {
+        name: 'upn'
+        essential: false
+      }
+      {
+        name: 'groups'
+        essential: false
+      }
+    ]
+    accessToken: [
+      {
+        name: 'email'
+        essential: false
+      }
+    ]
+  }
+
+  // Information URLs
+  info: {
+    marketingUrl: 'https://myapp.example.com'
+    privacyStatementUrl: 'https://myapp.example.com/privacy'
+    supportUrl: 'https://myapp.example.com/support'
+    termsOfServiceUrl: 'https://myapp.example.com/terms'
+  }
+}
+
+// Service Principal (Enterprise Application)
+resource servicePrincipal 'Microsoft.Graph/servicePrincipals@v1.0' = {
+  appId: appRegistration.appId
+  displayName: appDisplayName
+  tags: [
+    'WindowsAzureActiveDirectoryIntegratedApp'
+  ]
+  appRoleAssignmentRequired: false
+  preferredSingleSignOnMode: 'oidc'
+}
+
+// Outputs
+output applicationId string = appRegistration.appId
+output objectId string = appRegistration.id
+output servicePrincipalId string = servicePrincipal.id
+output identifierUri string = appRegistration.identifierUris[0]


### PR DESCRIPTION
Refine the frontmatter to following the common pattern. Added a Bicep template example, which is a better way to manage app registration in a few mentioned scenarios than Azure CLI.

Skill invocation test hit 5/5 for all existing tests.