### PR TITLE
docs: Add sensei compliance guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,7 +267,7 @@ _NOTE:_ If you open the repo in VS Code, you can use the "Azure Skill Brainstorm
 | After updating skill description/triggers | `Run sensei on <skill-name>` |
 | Fast iteration (skip integration tests) | `Run sensei on <skill-name> --skip-integration` |
 | Audit multiple skills | `Run sensei on <skill1>, <skill2>` |
-| Audit all low-compliance skills | `Run sensei on all Low-adherence skills` |
+| Audit all Low-adherence skills | `Run sensei on all Low-adherence skills` |
 
 #### Usage
 
@@ -299,7 +299,7 @@ description: "Execute Azure deployments after preparation and validation are com
 | Has "DO NOT USE FOR:" | ✅ | 3 anti-triggers with redirects |
 | Description < 1024 chars | ✅ | ~540 chars |
 | SKILL.md < 500 tokens | ✅ | ~450 tokens estimate |
-| Tests exist | ⚠️ | Only integration tests, missing triggers.test.ts |
+| Tests exist | ✅ | Unit, trigger, and integration tests |
 
 ### **Score: Medium-High** ✅
 ```
@@ -336,7 +336,8 @@ The scaffolded tests include parameterized test cases for:
 After sensei completes, run integration tests to verify skill invocation:
 
 ```bash
-npm run test:integration -- --testPathPattern=azure-<skillname>
+cd tests
+npm run test:integration -- --testPathPattern=<skillname>
 ```
 
 **Example output:**
@@ -362,8 +363,8 @@ Sensei evaluates skills against these compliance levels:
 
 | Score | Requirements |
 |-------|--------------|
-| **Low** | Description < 150 chars, no explicit triggers, no anti-triggers |
-| **Medium** | Description > 150 chars, has trigger keywords/phrases |
+| **Low** | Description < 150 chars (always Low), OR missing explicit triggers/anti-triggers |
+| **Medium** | Description ≥ 150 chars, has trigger keywords/phrases, may lack full `USE FOR:`/`DO NOT USE FOR:` structure |
 | **Medium-High** ⭐ | Has `USE FOR:` triggers AND `DO NOT USE FOR:` anti-triggers |
 | **High** | Medium-High + `compatibility` field documenting requirements |
 


### PR DESCRIPTION
## Summary

Adds documentation for the **sensei** skill to CONTRIBUTING.md, helping contributors understand how to validate skill frontmatter compliance before committing.

## Changes

### New Section: "Running Sensei for Compliance"

Added under **Contributing Skills** section with:

- **When to Run Sensei** - Table of use cases and commands
- **Usage** - Basic invocation example
- **Sample Output** - Real assessment and summary output from a sensei run
- **Test Scaffolding** - Explanation of auto-generated triggers.test.ts and unit.test.ts
- **Running Integration Tests** - Correct command (`npm run test:integration`)
- **Scoring Metrics** - Table showing Low/Medium/Medium-High/High criteria
- **Token Budgets** - Quick reference for limits
- **Reference Links** - Links to sensei skill and related skills

## Why

Contributors working on skills should have guidance on using sensei in the same document where they find other contribution workflows. Previously, this was only documented in the sensei skill itself.