### PR TITLE
add unit/trigger/integration tests

### DIFF
--- a/tests/azure-role-selector/integration.test.ts
+++ b/tests/azure-role-selector/integration.test.ts
@@ -98,4 +98,48 @@ describeIntegration(`${SKILL_NAME} - Integration Tests`, () => {
     expect(mentionsKeyVaultRole).toBe(true);
   });
 
+  test('generates CLI commands for role assignment', async () => {
+    let agentMetadata;
+    try {
+      agentMetadata = await run({
+        prompt: 'Generate Azure CLI command to assign Storage Blob Data Contributor role to my managed identity'
+      });
+    } catch (e: any) {
+      if (e.message?.includes('Failed to load @github/copilot-sdk')) {
+        console.log('⏭️  SDK not loadable, skipping test');
+        return;
+      }
+      throw e;
+    }
+
+    const isSkillUsed = isSkillInvoked(agentMetadata, 'azure-role-selector');
+    const mentionsCLI = doesAssistantMessageIncludeKeyword(agentMetadata, 'az role assignment');
+    const areCliToolCallsSuccess = areToolCallsSuccess(agentMetadata, 'azure__extension_cli_generate');
+
+    expect(isSkillUsed).toBe(true);
+    expect(mentionsCLI || areCliToolCallsSuccess).toBe(true);
+  });
+
+  test('provides Bicep code for role assignment', async () => {
+    let agentMetadata;
+    try {
+      agentMetadata = await run({
+        prompt: 'Show me Bicep code to assign Contributor role to a managed identity on a storage account'
+      });
+    } catch (e: any) {
+      if (e.message?.includes('Failed to load @github/copilot-sdk')) {
+        console.log('⏭️  SDK not loadable, skipping test');
+        return;
+      }
+      throw e;
+    }
+
+    const isSkillUsed = isSkillInvoked(agentMetadata, 'azure-role-selector');
+    const mentionsBicep = doesAssistantMessageIncludeKeyword(agentMetadata, 'bicep') || 
+                          doesAssistantMessageIncludeKeyword(agentMetadata, 'roleAssignment');
+
+    expect(isSkillUsed).toBe(true);
+    expect(mentionsBicep).toBe(true);
+  });
+
 });

--- a/tests/azure-role-selector/triggers.test.ts
+++ b/tests/azure-role-selector/triggers.test.ts
@@ -28,6 +28,13 @@ describe(`${SKILL_NAME} - Trigger Tests`, () => {
       'I need a custom role definition for my Azure storage account',
       'What Azure role should I use to give my function app access to Service Bus?',
       'Assign an Azure RBAC role to my identity for Cosmos DB read access',
+      'What is the least privilege role for reading from a storage queue?',
+      'I need to assign a role to my app service managed identity for database access',
+      'Generate Bicep code for assigning a role to my function app',
+      'Create a custom Azure role with specific permissions for my app',
+      'What role should I use for my identity to write to Event Hubs?',
+      'Help me find the minimal RBAC role for SQL Database read access',
+      'I want to assign a role to read secrets from Key Vault with least privilege',
     ];
 
     test.each(shouldTriggerPrompts)(
@@ -48,6 +55,13 @@ describe(`${SKILL_NAME} - Trigger Tests`, () => {
       'Configure network security groups',
       'What is the best way to deploy my web app?',
       'How do I monitor my application performance?',
+      'How do I scale my Azure App Service?',
+      'Show me available pricing tiers for Azure SQL Database',
+      'Set up a service principal for my deployment pipeline',
+      'Configure firewall rules for my storage account',
+      'How do I enable encryption at rest?',
+      'Optimize my Azure costs',
+      'Deploy my app to Azure App Service',
     ];
 
     test.each(shouldNotTriggerPrompts)(

--- a/tests/azure-role-selector/unit.test.ts
+++ b/tests/azure-role-selector/unit.test.ts
@@ -66,5 +66,59 @@ describe(`${SKILL_NAME} - Unit Tests`, () => {
     test('mentions Bicep', () => {
       expect(skill.content.toLowerCase()).toContain('bicep');
     });
+
+    test('mentions finding minimal role definition', () => {
+      expect(skill.content.toLowerCase()).toMatch(/minimal role|least privilege|role definition/);
+    });
+
+    test('mentions custom role creation', () => {
+      expect(skill.content.toLowerCase()).toContain('custom role');
+    });
+
+    test('includes azure__extension_cli_generate tool', () => {
+      expect(skill.content.toLowerCase()).toContain('azure__extension_cli_generate');
+    });
+
+    test('mentions azure__bicepschema tool', () => {
+      expect(skill.content.toLowerCase()).toContain('azure__bicepschema');
+    });
+
+    test('includes azure__get_azure_bestpractices tool', () => {
+      expect(skill.content.toLowerCase()).toContain('azure__get_azure_bestpractices');
+    });
+  });
+
+  describe('RBAC Role Assignment Workflow', () => {
+    test('describes workflow for finding roles', () => {
+      const content = skill.content.toLowerCase();
+      const hasWorkflow = content.includes('find') || content.includes('search') || content.includes('documentation');
+      expect(hasWorkflow).toBe(true);
+    });
+
+    test('mentions role assignment process', () => {
+      expect(skill.content.toLowerCase()).toMatch(/assign.*role|role.*assign/);
+    });
+
+    test('includes guidance for no built-in role scenario', () => {
+      const content = skill.content.toLowerCase();
+      const hasCustomRoleGuidance = content.includes('no built-in role') || content.includes('custom role');
+      expect(hasCustomRoleGuidance).toBe(true);
+    });
+  });
+
+  describe('Output Expectations', () => {
+    test('mentions generating CLI commands', () => {
+      expect(skill.content.toLowerCase()).toMatch(/cli command|generate.*command/);
+    });
+
+    test('mentions providing Bicep code snippet', () => {
+      expect(skill.content.toLowerCase()).toMatch(/bicep.*code|bicep.*snippet/);
+    });
+
+    test('references role assignment in Bicep', () => {
+      const content = skill.content.toLowerCase();
+      const hasBicepAssignment = content.includes('role assignment') && content.includes('bicep');
+      expect(hasBicepAssignment).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
This pull request expands the test coverage for the Azure Role Selector skill by adding new integration, trigger, and unit tests. The changes focus on ensuring the skill correctly handles role assignment scenarios, including generating CLI commands, Bicep code, and handling minimal privilege and custom roles.