### PR TITLE
Stop committing in CI

### DIFF
--- a/.github/workflows/test-all-skills.yml
+++ b/.github/workflows/test-all-skills.yml
@@ -154,17 +154,3 @@ jobs:
 
       - name: Generate coverage grid
         run: npm run coverage:grid
-
-      - name: Commit README updates
-        continue-on-error: true
-        working-directory: .
-        run: |
-          if git diff --quiet tests/README.md; then
-            echo "No changes to README.md"
-            exit 0
-          fi
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git add tests/README.md
-          git commit -m "docs: update skills coverage grid [skip ci]"
-          git push || echo "::warning::Could not push changes - branch protection may be enabled"


### PR DESCRIPTION
If we want to update the coverage grid we can easily run the script and submit a PR. This step has been tempering the git history in people's forks and causing problems.