### PR TITLE
Replicate non-interactive mode

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -292,9 +292,7 @@ export async function run(config: TestConfig): Promise<AgentMetadata> {
       await config.setup(testWorkspace);
     }
 
-    // Copilot client with yolo mode and non-interactive session.
-    // Enables longer chats with full conversation history for the skill.
-    // -p must come first before other args.
+    // Copilot client with yolo mode
     const cliArgs: string[] = config.nonInteractive ? ["--yolo"] : [];
     if (process.env.DEBUG)
     {


### PR DESCRIPTION
Found out that -p flag does nothing in the sdk. SO to avoid the tests getting back questions tell it back once "Go with the recommended".