### PR TITLE
Fix label in skill bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/skill_bug_report.yml
@@ -4,7 +4,7 @@ description: Report a bug related to Azure skills in GitHub Copilot for Azure
 type: "Bug"
 labels:
   - "bug"
-  - "skill"
+  - "skills"
 body:
   - type: checkboxes
     id: pre-flight


### PR DESCRIPTION
Updated label from 'skill' to 'skills' in bug report template.