### PR TITLE
Encourage use of secretRef

### DIFF
--- a/plugin/skills/azure-prepare/references/services/container-apps.md
+++ b/plugin/skills/azure-prepare/references/services/container-apps.md
@@ -144,8 +144,8 @@ scale: {
 
 ## Environment Variables and Secrets
 
-> ⛔ **NEVER** use `value` for passwords, connection strings, API keys, or other sensitive data.
-> Secrets in `value` are visible in logs, Azure Portal, and ARM exports.
+> ⛔ **NEVER** use `env[].value` for passwords, connection strings, API keys, or other sensitive data.
+> Secrets in `env[].value` are stored as plain text in the Container App configuration and are visible in Azure Portal and ARM/CLI exports.
 
 ### Pattern 1: secretRef (Required for Sensitive Data)
 


### PR DESCRIPTION
Fixes #821.

Update container-apps.md to make a stronger statement about putting passwords and other sensitive information in Key Vault and then accessing it via `secretRef`, rather than putting it in plain text in environment variables.

To test, I used the following prompt:
> Pretend you're creating a todo list app that will deploy to azure container apps and access a MySQL database for data. Create the bicep files to define the necessary services and prepare to deploy to azure. DOn't create the application code, however.

I then validated that container-apps.md was read, and that the resulting Bicep used KeyVault to store secrets and `secretRef` to refer to them within the container app.