### PR TITLE
fix: join positional args into single --testNamePattern to prevent multi-suite matching

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -182,6 +182,7 @@ npm install
 | `npm run test:unit` | Run unit and trigger tests only (fast, no auth) |
 | `npm run test:integration` | Run integration tests (requires Copilot CLI auth, az auth, azd auth) |
 | `npm run test:integration -- azure-deploy` | Run integration tests for a specific skill |
+| `npm run test:integration -- azure-deploy "invokes azure-deploy skill for Azure Functions"` | Run a specific integration test matching the test name |
 | `npm run test:integration -- azure-deploy static-web-apps-deploy` | Run integration tests for a specific describe group |
 | `npm run test:skill -- azure-ai` | Run all tests for a specific skill |
 | `npm run test:ci` | Run tests for CI (excludes integration tests) |

--- a/tests/scripts/run-tests.js
+++ b/tests/scripts/run-tests.js
@@ -110,9 +110,21 @@ if (config.requiresPattern && extraArgs.length > 0) {
 } else if (config.optionalPattern && extraArgs.length > 0 && !extraArgs[0].startsWith("-")) {
     const skillPattern = extraArgs[0];
     const remaining = extraArgs.slice(1);
-    // If there's a second positional arg (not a flag), use it as --testNamePattern
+    // Collect all consecutive positional args (non-flag) into a single --testNamePattern value
     if (remaining.length > 0 && !remaining[0].startsWith("-")) {
-        jestArgs = [...jestArgs, `--testPathPattern=${skillPattern}`, `--testNamePattern=${remaining[0]}`, ...remaining.slice(1)];
+        const positionalArgs = [];
+        const flagArgs = [];
+        let foundFlag = false;
+        for (const arg of remaining) {
+            if (arg.startsWith("-") || foundFlag) {
+                foundFlag = true;
+                flagArgs.push(arg);
+            } else {
+                positionalArgs.push(arg);
+            }
+        }
+        const testNamePattern = positionalArgs.join(" ");
+        jestArgs = [...jestArgs, `--testPathPattern=${skillPattern}`, `--testNamePattern="${testNamePattern}"`, ...flagArgs];
     } else {
         jestArgs = [...jestArgs, `--testPathPattern=${skillPattern}`, ...remaining];
     }


### PR DESCRIPTION
This pull request enhances the integration test command handling to support more flexible test selection. The changes allow users to specify multiple positional arguments as part of the test name pattern, making it easier to target specific tests, and updates documentation to reflect this capability.