### PR TITLE
Improve azure-prepare and azure-validate skill guidance

### DIFF
--- a/plugin/skills/azure-prepare/references/research.md
+++ b/plugin/skills/azure-prepare/references/research.md
@@ -5,9 +5,13 @@ After architecture planning, research each selected component to gather best pra
 ## Process
 
 1. **Identify Components** — List all Azure services from architecture plan
-2. **Load Service References** — For each service, load the `services/<service>/README.md` first, then specific references as needed
-3. **Invoke Related Skills** — For deeper guidance, invoke mapped skills from the table below
-4. **Document Findings** — Record key insights in `.azure/plan.md`
+2. **Load Service References** — For each service, load `services/<service>/README.md` first, then specific references as needed
+3. **Check Resource Naming Rules** — For each resource type, check [resource naming rules](https://learn.microsoft.com/azure/azure-resource-manager/management/resource-name-rules) for valid characters, length limits, and uniqueness scopes
+4. **Load Recipe References** — Load the selected recipe's guide (e.g., [AZD](recipes/azd/README.md)) and its IAC rules, MCP best practices, and schema tools listed in its "Before Generation" table
+5. **Check Region Availability** — Verify all selected services are available in the target region per [region-availability.md](region-availability.md)
+6. **Load Runtime References** — For containerized apps, load language-specific production settings (e.g., [Node.js](runtimes/nodejs.md))
+7. **Invoke Related Skills** — For deeper guidance, invoke mapped skills from the table below
+8. **Document Findings** — Record key insights in `.azure/plan.md`
 
 ## Service-to-Reference Mapping
 

--- a/plugin/skills/azure-validate/references/recipes/azd/README.md
+++ b/plugin/skills/azure-validate/references/recipes/azd/README.md
@@ -77,13 +77,9 @@ azd env set AZURE_SUBSCRIPTION_ID <subscription-id>
 azd env set AZURE_LOCATION <location>
 ```
 
-### 6. Azure Policy Validation
+### 6. Provision Preview
 
-See [Policy Validation Guide](../../policy-validation.md) for instructions on retrieving and validating Azure policies for your subscription.
-
-### 7. Provision Preview
-
-Validate IaC is ready:
+Validate IaC is ready (must complete without error):
 
 ```bash
 azd provision --preview --no-prompt
@@ -91,13 +87,17 @@ azd provision --preview --no-prompt
 
 > 💡 **Note:** This works for both Bicep and Terraform. azd will automatically detect the provider from `azure.yaml` and run the appropriate validation (`bicep build` or `terraform plan`).
 
-### 8. Package Validation
+### 7. Package Validation
 
-Confirm all services build/package successfully:
+Confirm all services build/package successfully (must complete without error):
 
 ```bash
 azd package --no-prompt
 ```
+
+### 8. Azure Policy Validation
+
+See [Policy Validation Guide](../../policy-validation.md) for instructions on retrieving and validating Azure policies for your subscription.
 
 ## References
 


### PR DESCRIPTION
## Changes

### azure-prepare IAC rules (iac-rules.md)
- Add resource naming rules and abbreviation doc references to naming convention section
- Add replace() pattern for resources that disallow dashes (e.g., ACR)
- Add recommended Bicep outputs section for azd environment variables
- Add additive layering guidance -- apply MCP best practices first, then azd-specific rules
- Optimize tokens to stay under 1000 token reference limit

### azure-prepare research (research.md)
- Add Check Resource Naming Rules step with link to naming rules doc
- Add Load Recipe References step for IAC rules and MCP tools
- Add Check Region Availability step
- Add Load Runtime References step for containerized apps

### azure-validate azd recipe (README.md)
- Move Provision Preview and Package Validation steps up to run right after Subscription/Location Check
- Note that each command must complete without error
- Azure Policy Validation moved to final step