### PR TITLE
Generate temporary files with pseudo-random names in tests

### DIFF
--- a/scripts/src/tokens/__tests__/check.test.ts
+++ b/scripts/src/tokens/__tests__/check.test.ts
@@ -2,7 +2,7 @@
  * Tests for check command - token limit validation
  */
 
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { mkdirSync, writeFileSync, rmSync, mkdtempSync, readFileSync, existsSync } from 'node:fs';
@@ -40,6 +40,13 @@ describe('check command', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
     try {
       rmSync(testRootDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    } catch (err) {
+      // Ignore cleanup errors in tests
+    }
+  });
+  afterAll(() => {
+    try {
+      rmSync(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     } catch (err) {
       // Ignore cleanup errors in tests
     }

--- a/scripts/src/tokens/__tests__/suggest.test.ts
+++ b/scripts/src/tokens/__tests__/suggest.test.ts
@@ -2,7 +2,7 @@
  * Tests for suggest command - optimization suggestions
  */
 
-import { describe, it, expect, beforeEach, afterEach, beforeAll } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'node:fs';
@@ -19,12 +19,18 @@ describe('suggest command', () => {
   beforeEach(() => {
     mkdirSync(testRootDir, { recursive: true });
   });
-
   afterEach(async () => {
     // Small delay to allow file handles to close on Windows
     await new Promise(resolve => setTimeout(resolve, 10));
     try {
       rmSync(testRootDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    } catch (err) {
+      // Ignore cleanup errors in tests
+    }
+  });
+  afterAll(() => {
+    try {
+      rmSync(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
     } catch (err) {
       // Ignore cleanup errors in tests
     }


### PR DESCRIPTION
Addresses these security alerts:
- https://github.com/microsoft/GitHub-Copilot-for-Azure/security/code-scanning/42
- https://github.com/microsoft/GitHub-Copilot-for-Azure/security/code-scanning/31

And all the alerts with number between 42 and 31.

The CVE detail suggest using random file names to mitigate the vulnerability, which is also why other tests that write temporary files aren't flagged.
https://cwe.mitre.org/data/definitions/377.html