### PR TITLE
Add eslint to scripts project

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,12 +28,20 @@ jobs:
         working-directory: ./tests
         run: npm ci
 
+      - name: Install scripts dependencies
+        working-directory: ./scripts
+        run: npm ci
+
       - name: Typecheck
         working-directory: ./tests
         run: npm run typecheck
 
       - name: Lint test
         working-directory: ./tests
+        run: npm run lint
+
+      - name: Lint scripts
+        working-directory: ./scripts
         run: npm run lint
 
   # Token limit check and comparison for markdown files

--- a/scripts/eslint.config.mjs
+++ b/scripts/eslint.config.mjs
@@ -1,0 +1,47 @@
+import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config"
+import tseslint from "typescript-eslint";
+
+const tsFiles = ["**/*.ts"];
+
+export default defineConfig(
+    // Global ignores
+    {
+        ignores: [
+            "node_modules/**",
+            "dist/**",
+        ],
+    },
+    // TypeScript files - use TypeScript parser with project
+    {
+        files: tsFiles,
+        extends: [
+            eslint.configs.recommended,
+            ...tseslint.configs.recommended,
+        ],
+        languageOptions: {
+            parserOptions: {
+                project: "./tsconfig.eslint.json",
+                tsconfigRootDir: import.meta.dirname,
+            },
+        },
+        rules: {
+            // General rules
+            "no-console": "off",
+            "prefer-const": "error",
+            "no-var": "error",
+            "eqeqeq": ["error", "always", { null: "ignore" }],
+            "quotes": ["error", "double", { "avoidEscape": true }],
+
+            // TypeScript rules
+            "@typescript-eslint/no-unused-vars": ["error", {
+                argsIgnorePattern: "^_",
+                varsIgnorePattern: "^_"
+            }],
+            "@typescript-eslint/no-floating-promises": "error",
+            "@typescript-eslint/await-thenable": "error",
+            "@typescript-eslint/no-explicit-any": "warn",
+            "@typescript-eslint/no-require-imports": "warn"
+        },
+    },
+);

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -8,12 +8,15 @@
       "name": "@github-copilot-for-azure/scripts",
       "version": "1.0.0",
       "devDependencies": {
+        "@eslint/js": "^9.0.0",
         "@types/micromatch": "^4.0.10",
         "@types/node": "^25.1.0",
         "@vitest/coverage-v8": "^4.0.18",
+        "eslint": "^9.0.0",
         "micromatch": "^4.0.8",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
+        "typescript-eslint": "^8.0.0",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -510,6 +513,202 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
+      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+      "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.7",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.1",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "dev": true,
@@ -909,6 +1108,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/micromatch": {
       "version": "4.0.10",
       "resolved": "https://registry.npmjs.org/@types/micromatch/-/micromatch-4.0.10.tgz",
@@ -925,6 +1131,275 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.56.0.tgz",
+      "integrity": "sha512-lRyPDLzNCuae71A3t9NEINBiTn7swyOhvUj3MyUOxb8x6g6vPEFoOU+ZRmGMusNC3X3YMhqMIX7i8ShqhT74Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/type-utils": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.0.tgz",
+      "integrity": "sha512-IgSWvLobTDOjnaxAfDTIHaECbkNlAlKv2j5SjpB2v7QHKv1FIfjwMy8FsDbVfDX/KjmCmYICcw7uGaXLhtsLNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.0.tgz",
+      "integrity": "sha512-M3rnyL1vIQOMeWxTWIW096/TtVP+8W3p/XnaFflhmcFp+U4zlxUxWj4XwNs6HbDeTtN4yun0GNTTDBw/SvufKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.0",
+        "@typescript-eslint/types": "^8.56.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.0.tgz",
+      "integrity": "sha512-7UiO/XwMHquH+ZzfVCfUNkIXlp/yQjjnlYUyYz7pfvlK3/EyyN6BK+emDmGNyQLBtLGaYrTAI6KOw8tFucWL2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.0.tgz",
+      "integrity": "sha512-bSJoIIt4o3lKXD3xmDh9chZcjCz5Lk8xS7Rxn+6l5/pKrDpkCwtQNQQwZ2qRPk7TkUYhrq3WPIHXOXlbXP0itg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.56.0.tgz",
+      "integrity": "sha512-qX2L3HWOU2nuDs6GzglBeuFXviDODreS58tLY/BALPC7iu3Fa+J7EOTwnX9PdNBxUI7Uh0ntP0YWGnxCkXzmfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.0.tgz",
+      "integrity": "sha512-DBsLPs3GsWhX5HylbP9HNG15U0bnwut55Lx12bHB9MpXxQ+R5GC8MwQe+N1UFXxAeQDvEsEDY6ZYwX03K7Z6HQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.0.tgz",
+      "integrity": "sha512-ex1nTUMWrseMltXUHmR2GAQ4d+WjkZCT4f+4bVsps8QEdh0vlBsaCokKTPlnqBFqqGaxilDNJG7b8dolW2m43Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.0",
+        "@typescript-eslint/tsconfig-utils": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/visitor-keys": "8.56.0",
+        "debug": "^4.4.3",
+        "minimatch": "^9.0.5",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.0.tgz",
+      "integrity": "sha512-RZ3Qsmi2nFGsS+n+kjLAYDPVlrzf7UhTffrDIKr+h2yzAlYP/y5ZulU0yeDEPItos2Ph46JAL5P/On3pe7kDIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.0",
+        "@typescript-eslint/types": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.0.tgz",
+      "integrity": "sha512-q+SL+b+05Ud6LbEE35qe4A99P+htKTKVbyiNEe45eCbJFyh/HVK9QXwlrbz+Q4L8SOW4roxSVwXYj4DMBT7Ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.0.tgz",
+      "integrity": "sha512-A0XeIi7CXU7nPlfHS9loMYEKxUaONu/hTEzHTGba9Huu94Cq1hPivf+DE5erJozZOky0LfvXAyrV/tcswpLI0Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -1053,6 +1528,69 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "dev": true,
@@ -1071,6 +1609,24 @@
         "js-tokens": "^9.0.1"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1084,6 +1640,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "dev": true,
@@ -1091,6 +1657,90 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
@@ -1137,12 +1787,179 @@
         "@esbuild/win32-x64": "0.27.2"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.2",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
+      "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.1",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.1",
+        "@eslint/js": "9.39.2",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/estree-walker": {
       "version": "3.0.3",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/expect-type": {
@@ -1152,6 +1969,27 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1169,6 +2007,19 @@
         }
       }
     },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1181,6 +2032,44 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1208,6 +2097,32 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "dev": true,
@@ -1221,6 +2136,66 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -1230,6 +2205,13 @@
       "engines": {
         "node": ">=0.12.0"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -1266,6 +2248,87 @@
     },
     "node_modules/js-tokens": {
       "version": "9.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -1328,6 +2391,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "dev": true,
@@ -1345,6 +2428,13 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "dev": true,
@@ -1353,6 +2443,89 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1400,6 +2573,36 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -1464,6 +2667,29 @@
         "node": ">=10"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "dev": true,
@@ -1486,6 +2712,19 @@
       "version": "3.10.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -1547,6 +2786,19 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/ts-api-utils": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
     "node_modules/tsx": {
       "version": "4.21.0",
       "dev": true,
@@ -1565,6 +2817,19 @@
         "fsevents": "~2.3.3"
       }
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "dev": true,
@@ -1577,10 +2842,44 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typescript-eslint": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.56.0.tgz",
+      "integrity": "sha512-c7toRLrotJ9oixgdW7liukZpsnq5CZ7PuKztubGYlNppuTqhIoWfhgHo/7EU0v06gS2l/x0i2NEFK1qMIf0rIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.56.0",
+        "@typescript-eslint/parser": "8.56.0",
+        "@typescript-eslint/typescript-estree": "8.56.0",
+        "@typescript-eslint/utils": "8.56.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -1731,6 +3030,22 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "dev": true,
@@ -1744,6 +3059,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -11,9 +11,14 @@
     "verify-local": "node --import tsx src/verify-local.ts",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "lint": "eslint",
+    "lint:fix": "eslint --fix"
   },
   "devDependencies": {
+    "@eslint/js": "^9.0.0",
+    "eslint": "^9.0.0",
+    "typescript-eslint": "^8.0.0",
     "@types/micromatch": "^4.0.10",
     "@types/node": "^25.1.0",
     "@vitest/coverage-v8": "^4.0.18",

--- a/scripts/src/local/cli.ts
+++ b/scripts/src/local/cli.ts
@@ -10,17 +10,17 @@
  *   npm run local help     # Show help
  */
 
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { setup } from './commands/setup.js';
-import { verify } from './commands/verify.js';
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { setup } from "./commands/setup.js";
+import { verify } from "./commands/verify.js";
 
-const COMMANDS = ['setup', 'verify', 'help'] as const;
+const COMMANDS = ["setup", "verify", "help"] as const;
 type Command = typeof COMMANDS[number];
 
 function getRepoRoot(): string {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
-  return resolve(scriptDir, '../../..');
+  return resolve(scriptDir, "../../..");
 }
 
 function printHelp(): void {
@@ -49,25 +49,25 @@ Examples:
 
 function main(): void {
   const args = process.argv.slice(2);
-  const command = (args[0] ?? 'help') as Command;
+  const command = (args[0] ?? "help") as Command;
   const commandArgs = args.slice(1);
   const rootDir = getRepoRoot();
 
   if (!COMMANDS.includes(command)) {
     console.error(`Unknown command: ${command}`);
-    console.error(`Available commands: ${COMMANDS.join(', ')}`);
+    console.error(`Available commands: ${COMMANDS.join(", ")}`);
     process.exitCode = 1;
     return;
   }
 
   switch (command) {
-    case 'setup':
+    case "setup":
       setup(rootDir, commandArgs);
       break;
-    case 'verify':
+    case "verify":
       verify(rootDir, commandArgs);
       break;
-    case 'help':
+    case "help":
       printHelp();
       break;
   }

--- a/scripts/src/local/commands/setup.ts
+++ b/scripts/src/local/commands/setup.ts
@@ -5,12 +5,12 @@
  * directly at the local plugin directory for development.
  */
 
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 
-const MARKETPLACE_NAME = 'github-copilot-for-azure';
-const PLUGIN_NAME = 'azure';
+const MARKETPLACE_NAME = "github-copilot-for-azure";
+const PLUGIN_NAME = "azure";
 
 interface Marketplace {
   source: {
@@ -39,16 +39,16 @@ interface SetupOptions {
 
 function parseArgs(args: string[]): SetupOptions {
   return {
-    force: args.includes('--force') || args.includes('-f'),
+    force: args.includes("--force") || args.includes("-f"),
   };
 }
 
 function getCopilotDir(): string {
-  return join(homedir(), '.copilot');
+  return join(homedir(), ".copilot");
 }
 
 function getCopilotConfigPath(): string {
-  return join(getCopilotDir(), 'config.json');
+  return join(getCopilotDir(), "config.json");
 }
 
 function readCopilotConfig(): CopilotConfig | null {
@@ -57,7 +57,7 @@ function readCopilotConfig(): CopilotConfig | null {
     return null;
   }
   try {
-    return JSON.parse(readFileSync(configPath, 'utf-8'));
+    return JSON.parse(readFileSync(configPath, "utf-8"));
   } catch {
     return null;
   }
@@ -74,11 +74,11 @@ function writeCopilotConfig(config: CopilotConfig): boolean {
     }
     
     // Backup first
-    const backupPath = configPath + '.bak';
+    const backupPath = configPath + ".bak";
     if (existsSync(configPath)) {
       writeFileSync(backupPath, readFileSync(configPath));
     }
-    writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
+    writeFileSync(configPath, JSON.stringify(config, null, 2), "utf-8");
     return true;
   } catch {
     return false;
@@ -88,8 +88,8 @@ function writeCopilotConfig(config: CopilotConfig): boolean {
 function getExpectedMarketplace(): Marketplace {
   return {
     source: {
-      source: 'github',
-      repo: 'microsoft/github-copilot-for-azure',
+      source: "github",
+      repo: "microsoft/github-copilot-for-azure",
     },
   };
 }
@@ -105,7 +105,7 @@ function createExpectedPlugin(cachePath: string): InstalledPlugin {
 }
 
 function normalizePath(path: string): string {
-  return path.toLowerCase().replace(/\\/g, '/');
+  return path.toLowerCase().replace(/\\/g, "/");
 }
 
 function isMarketplaceCorrect(config: CopilotConfig): boolean {
@@ -128,35 +128,35 @@ function isPluginCorrect(config: CopilotConfig, expectedCachePath: string): bool
 
 export function setup(rootDir: string, args: string[]): void {
   const options = parseArgs(args);
-  const localPluginPath = join(rootDir, 'plugin');
+  const localPluginPath = join(rootDir, "plugin");
   const configPath = getCopilotConfigPath();
 
-  console.log('\n🔧 Local Development Setup\n');
-  console.log('────────────────────────────────────────────────────────────');
+  console.log("\n🔧 Local Development Setup\n");
+  console.log("────────────────────────────────────────────────────────────");
 
   // Check local plugin exists
-  console.log(`\n📁 Local plugin path:`);
+  console.log("\n📁 Local plugin path:");
   console.log(`   ${localPluginPath}`);
   if (!existsSync(localPluginPath)) {
-    console.log('   ❌ Not found\n');
-    console.error('Error: Local plugin directory not found.');
+    console.log("   ❌ Not found\n");
+    console.error("Error: Local plugin directory not found.");
     process.exitCode = 1;
     return;
   }
-  console.log('   ✅ Exists');
+  console.log("   ✅ Exists");
 
   // Read or create config
-  console.log(`\n📄 Copilot config:`);
+  console.log("\n📄 Copilot config:");
   console.log(`   ${configPath}`);
   
   let config = readCopilotConfig();
   const configExisted = config !== null;
   
   if (!config) {
-    console.log('   📂 Creating new config...');
+    console.log("   📂 Creating new config...");
     config = {};
   } else {
-    console.log('   ✅ Exists');
+    console.log("   ✅ Exists");
   }
 
   // Check if already configured correctly
@@ -164,14 +164,14 @@ export function setup(rootDir: string, args: string[]): void {
   const pluginOk = isPluginCorrect(config, localPluginPath);
 
   if (marketplaceOk && pluginOk) {
-    console.log('\n✅ Already configured correctly!');
-    console.log('────────────────────────────────────────────────────────────');
-    console.log('\n✅ Setup complete! Config is already pointing to local repo.\n');
+    console.log("\n✅ Already configured correctly!");
+    console.log("────────────────────────────────────────────────────────────");
+    console.log("\n✅ Setup complete! Config is already pointing to local repo.\n");
     return;
   }
 
   // Show what needs to be updated
-  console.log('\n📝 Configuration changes needed:');
+  console.log("\n📝 Configuration changes needed:");
   
   if (!marketplaceOk) {
     console.log(`   • Add/update marketplace: ${MARKETPLACE_NAME}`);
@@ -182,7 +182,7 @@ export function setup(rootDir: string, args: string[]): void {
       p => p.name === PLUGIN_NAME && p.marketplace === MARKETPLACE_NAME
     );
     if (existingPlugin) {
-      console.log(`   • Update plugin cache_path from:`);
+      console.log("   • Update plugin cache_path from:");
       console.log(`     ${existingPlugin.cache_path}`);
       console.log(`     to: ${localPluginPath}`);
     } else {
@@ -196,8 +196,8 @@ export function setup(rootDir: string, args: string[]): void {
       p => p.name === PLUGIN_NAME
     );
     if (existingPlugin && normalizePath(existingPlugin.cache_path) !== normalizePath(localPluginPath)) {
-      console.log('\n   ⚠️  Plugin already exists with different cache_path.');
-      console.log('   Use --force to update.\n');
+      console.log("\n   ⚠️  Plugin already exists with different cache_path.");
+      console.log("   Use --force to update.\n");
       process.exitCode = 1;
       return;
     }
@@ -234,17 +234,17 @@ export function setup(rootDir: string, args: string[]): void {
   }
 
   // Write config
-  console.log('\n💾 Writing config...');
+  console.log("\n💾 Writing config...");
   if (!writeCopilotConfig(config)) {
-    console.log('   ❌ Failed to write config\n');
+    console.log("   ❌ Failed to write config\n");
     process.exitCode = 1;
     return;
   }
-  console.log('   ✅ Config updated');
+  console.log("   ✅ Config updated");
 
-  console.log('\n────────────────────────────────────────────────────────────');
-  console.log('\n✅ Setup complete!\n');
-  console.log('   Your config now points to the local plugin. Changes to skills');
-  console.log('   will be picked up by Copilot CLI (restart CLI after changes).\n');
+  console.log("\n────────────────────────────────────────────────────────────");
+  console.log("\n✅ Setup complete!\n");
+  console.log("   Your config now points to the local plugin. Changes to skills");
+  console.log("   will be picked up by Copilot CLI (restart CLI after changes).\n");
   console.log('   Run "npm run local verify" to confirm the setup.\n');
 }

--- a/scripts/src/local/commands/verify.ts
+++ b/scripts/src/local/commands/verify.ts
@@ -14,13 +14,13 @@ import {
   readFileSync,
   readdirSync,
   rmSync
-} from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
-import { setup } from './setup.js';
+} from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { setup } from "./setup.js";
 
-const MARKETPLACE_NAME = 'github-copilot-for-azure';
-const PLUGIN_NAME = 'azure';
+const MARKETPLACE_NAME = "github-copilot-for-azure";
+const PLUGIN_NAME = "azure";
 
 interface Marketplace {
   source?: {
@@ -51,13 +51,13 @@ interface VerifyOptions {
 
 function parseArgs(args: string[]): VerifyOptions {
   return {
-    fix: args.includes('--fix'),
-    verbose: args.includes('--verbose') || args.includes('-v'),
+    fix: args.includes("--fix"),
+    verbose: args.includes("--verbose") || args.includes("-v"),
   };
 }
 
 function getCopilotConfigPath(): string {
-  return join(homedir(), '.copilot', 'config.json');
+  return join(homedir(), ".copilot", "config.json");
 }
 
 interface ConfigReadResult {
@@ -72,7 +72,7 @@ function readCopilotConfig(): ConfigReadResult {
     return { config: null, fileExists: false };
   }
   try {
-    return { config: JSON.parse(readFileSync(configPath, 'utf-8')), fileExists: true };
+    return { config: JSON.parse(readFileSync(configPath, "utf-8")), fileExists: true };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return { config: null, error: `Failed to parse config: ${message}`, fileExists: true };
@@ -80,7 +80,7 @@ function readCopilotConfig(): ConfigReadResult {
 }
 
 function normalizePath(path: string): string {
-  return path.toLowerCase().replace(/\\/g, '/');
+  return path.toLowerCase().replace(/\\/g, "/");
 }
 
 interface MarketplaceCheckResult {
@@ -98,8 +98,8 @@ function checkMarketplace(config: CopilotConfig): MarketplaceCheckResult {
   }
 
   const hasCorrectSource =
-    marketplace.source?.source === 'github' &&
-    marketplace.source?.repo === 'microsoft/github-copilot-for-azure';
+    marketplace.source?.source === "github" &&
+    marketplace.source?.repo === "microsoft/github-copilot-for-azure";
 
   return {
     passed: hasCorrectSource,
@@ -148,11 +148,11 @@ function checkPlugin(config: CopilotConfig, expectedCachePath: string): PluginCh
 }
 
 function checkNestedInstall(localPath: string): { passed: boolean; error?: string } {
-  const nestedPluginPath = join(localPath, 'azure');
+  const nestedPluginPath = join(localPath, "azure");
 
   if (existsSync(nestedPluginPath)) {
     // Check if it has skills (confirming it's an installed plugin copy)
-    const nestedSkillsPath = join(nestedPluginPath, 'skills');
+    const nestedSkillsPath = join(nestedPluginPath, "skills");
     if (existsSync(nestedSkillsPath)) {
       return {
         passed: false,
@@ -169,13 +169,13 @@ function checkPluginContent(pluginPath: string, verbose: boolean): { passed: boo
   const details: string[] = [];
 
   if (!existsSync(pluginPath)) {
-    return { passed: false, details: ['Plugin directory does not exist'] };
+    return { passed: false, details: ["Plugin directory does not exist"] };
   }
 
   // Check for essential files
   const essentialPaths = [
-    'README.md',
-    'skills',
+    "README.md",
+    "skills",
   ];
 
   let allExist = true;
@@ -192,19 +192,19 @@ function checkPluginContent(pluginPath: string, verbose: boolean): { passed: boo
   }
 
   // Count skills
-  const skillsPath = join(pluginPath, 'skills');
+  const skillsPath = join(pluginPath, "skills");
   if (existsSync(skillsPath)) {
     try {
       const skills = readdirSync(skillsPath, { withFileTypes: true })
-        .filter(d => d.isDirectory() && !d.name.startsWith('_'))
+        .filter(d => d.isDirectory() && !d.name.startsWith("_"))
         .map(d => d.name);
       details.push(`📦 ${skills.length} skills found`);
       if (verbose && skills.length > 0) {
-        const preview = skills.slice(0, 5).join(', ');
-        details.push(`   ${preview}${skills.length > 5 ? `, ... (+${skills.length - 5} more)` : ''}`);
+        const preview = skills.slice(0, 5).join(", ");
+        details.push(`   ${preview}${skills.length > 5 ? `, ... (+${skills.length - 5} more)` : ""}`);
       }
     } catch {
-      details.push('⚠️  Could not enumerate skills');
+      details.push("⚠️  Could not enumerate skills");
     }
   }
 
@@ -213,24 +213,24 @@ function checkPluginContent(pluginPath: string, verbose: boolean): { passed: boo
 
 export function verify(rootDir: string, args: string[]): void {
   const options = parseArgs(args);
-  const localPluginPath = join(rootDir, 'plugin');
+  const localPluginPath = join(rootDir, "plugin");
   const configPath = getCopilotConfigPath();
 
-  console.log('\n🔍 Verifying Local Plugin Setup\n');
-  console.log('────────────────────────────────────────────────────────────');
+  console.log("\n🔍 Verifying Local Plugin Setup\n");
+  console.log("────────────────────────────────────────────────────────────");
 
   // Check local plugin exists
-  console.log(`\n📁 Local plugin:`);
+  console.log("\n📁 Local plugin:");
   console.log(`   ${localPluginPath}`);
   if (!existsSync(localPluginPath)) {
-    console.log('   ❌ Not found\n');
+    console.log("   ❌ Not found\n");
     process.exitCode = 1;
     return;
   }
-  console.log('   ✅ Exists');
+  console.log("   ✅ Exists");
 
   // Check config file
-  console.log(`\n📄 Copilot config:`);
+  console.log("\n📄 Copilot config:");
   console.log(`   ${configPath}`);
 
   const configResult = readCopilotConfig();
@@ -242,9 +242,9 @@ export function verify(rootDir: string, args: string[]): void {
   }
 
   if (!configResult.config) {
-    console.log('   ❌ Config file not found');
+    console.log("   ❌ Config file not found");
     if (options.fix) {
-      console.log('\n   🔧 Running setup...\n');
+      console.log("\n   🔧 Running setup...\n");
       setup(rootDir, []);
       return;
     }
@@ -252,22 +252,22 @@ export function verify(rootDir: string, args: string[]): void {
     process.exitCode = 1;
     return;
   }
-  console.log('   ✅ Exists');
+  console.log("   ✅ Exists");
 
-  console.log('\n────────────────────────────────────────────────────────────');
+  console.log("\n────────────────────────────────────────────────────────────");
 
   // Test 1: Check for nested plugin install
-  console.log('\n🧪 Test 1: Nested Plugin Check');
+  console.log("\n🧪 Test 1: Nested Plugin Check");
   const nestedCheck = checkNestedInstall(localPluginPath);
 
   if (nestedCheck.passed) {
-    console.log('   ✅ No nested plugin install detected');
+    console.log("   ✅ No nested plugin install detected");
   } else {
     console.log(`   ❌ ${nestedCheck.error}`);
   }
 
   // Test 2: Check marketplace configuration
-  console.log('\n🧪 Test 2: Marketplace Configuration');
+  console.log("\n🧪 Test 2: Marketplace Configuration");
   const marketplaceCheck = checkMarketplace(configResult.config);
 
   if (marketplaceCheck.passed) {
@@ -276,16 +276,16 @@ export function verify(rootDir: string, args: string[]): void {
     if (!marketplaceCheck.exists) {
       console.log(`   ❌ Marketplace "${MARKETPLACE_NAME}" not found in config`);
     } else {
-      console.log(`   ❌ Marketplace has incorrect source configuration`);
+      console.log("   ❌ Marketplace has incorrect source configuration");
       if (marketplaceCheck.actual?.source) {
         console.log(`      Current: source="${marketplaceCheck.actual.source.source}", repo="${marketplaceCheck.actual.source.repo}"`);
       }
-      console.log(`      Expected: source="github", repo="microsoft/github-copilot-for-azure"`);
+      console.log("      Expected: source=\"github\", repo=\"microsoft/github-copilot-for-azure\"");
     }
   }
 
   // Test 3: Check plugin configuration
-  console.log('\n🧪 Test 3: Plugin Configuration');
+  console.log("\n🧪 Test 3: Plugin Configuration");
   const pluginCheck = checkPlugin(configResult.config, localPluginPath);
 
   if (pluginCheck.passed) {
@@ -296,30 +296,30 @@ export function verify(rootDir: string, args: string[]): void {
       console.log(`   ❌ Plugin "${PLUGIN_NAME}" not found in installed_plugins`);
     } else {
       if (!pluginCheck.hasCorrectCachePath) {
-        console.log(`   ❌ Plugin cache_path is incorrect`);
+        console.log("   ❌ Plugin cache_path is incorrect");
         console.log(`      Current:  ${pluginCheck.actual?.cache_path}`);
         console.log(`      Expected: ${pluginCheck.expectedCachePath}`);
       }
       if (!pluginCheck.isEnabled) {
-        console.log(`   ⚠️  Plugin is disabled`);
+        console.log("   ⚠️  Plugin is disabled");
       }
     }
   }
 
   // Test 4: Check plugin content
-  console.log('\n🧪 Test 4: Plugin Content Check');
+  console.log("\n🧪 Test 4: Plugin Content Check");
   const contentCheck = checkPluginContent(localPluginPath, options.verbose);
 
   if (contentCheck.passed) {
-    console.log('   ✅ Plugin directory has expected structure');
+    console.log("   ✅ Plugin directory has expected structure");
   } else {
-    console.log('   ❌ Plugin directory structure issues:');
+    console.log("   ❌ Plugin directory structure issues:");
   }
   for (const detail of contentCheck.details) {
     console.log(`      ${detail}`);
   }
 
-  console.log('\n────────────────────────────────────────────────────────────');
+  console.log("\n────────────────────────────────────────────────────────────");
 
   // Summary
   const allPassed = nestedCheck.passed &&
@@ -328,21 +328,21 @@ export function verify(rootDir: string, args: string[]): void {
     contentCheck.passed;
 
   if (allPassed) {
-    console.log('\n✅ VERIFICATION PASSED\n');
-    console.log('   Config is correctly pointing to local plugin.');
-    console.log('   Changes to skills will be picked up by Copilot CLI.\n');
+    console.log("\n✅ VERIFICATION PASSED\n");
+    console.log("   Config is correctly pointing to local plugin.");
+    console.log("   Changes to skills will be picked up by Copilot CLI.\n");
   } else {
-    console.log('\n❌ VERIFICATION FAILED\n');
+    console.log("\n❌ VERIFICATION FAILED\n");
 
     if (!nestedCheck.passed) {
-      console.log('   ⚠️  Nested plugin install detected (plugin/azure/).');
-      console.log('      This shadows your local skills. Remove it to use local development.');
+      console.log("   ⚠️  Nested plugin install detected (plugin/azure/).");
+      console.log("      This shadows your local skills. Remove it to use local development.");
       if (options.fix) {
-        const nestedPath = join(localPluginPath, 'azure');
+        const nestedPath = join(localPluginPath, "azure");
         console.log(`\n   🔧 Removing nested plugin at ${nestedPath}...`);
         try {
           rmSync(nestedPath, { recursive: true });
-          console.log('   ✅ Removed nested plugin');
+          console.log("   ✅ Removed nested plugin");
         } catch (error) {
           console.log(`   ❌ Failed to remove: ${error instanceof Error ? error.message : error}`);
         }
@@ -350,20 +350,20 @@ export function verify(rootDir: string, args: string[]): void {
     }
 
     if (!marketplaceCheck.passed || !pluginCheck.passed) {
-      console.log('   ⚠️  Config needs to be updated.');
+      console.log("   ⚠️  Config needs to be updated.");
       if (options.fix) {
-        console.log('\n   🔧 Running setup to fix config...\n');
-        setup(rootDir, ['--force']);
+        console.log("\n   🔧 Running setup to fix config...\n");
+        setup(rootDir, ["--force"]);
 
         // Re-verify after fix
-        console.log('\n   🔄 Re-running verification...\n');
-        verify(rootDir, args.filter(a => a !== '--fix'));
+        console.log("\n   🔄 Re-running verification...\n");
+        verify(rootDir, args.filter(a => a !== "--fix"));
         return;
       }
     }
 
     if (!contentCheck.passed) {
-      console.log('   ⚠️  Plugin directory is missing expected content.');
+      console.log("   ⚠️  Plugin directory is missing expected content.");
     }
 
     if (!options.fix) {

--- a/scripts/src/references/__tests__/references.test.ts
+++ b/scripts/src/references/__tests__/references.test.ts
@@ -2,13 +2,13 @@
  * Tests for reference validation
  */
 
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
 
-const TEST_SKILLS_DIR = resolve(__dirname, '__test_skills__');
+const TEST_SKILLS_DIR = resolve(__dirname, "__test_skills__");
 
-describe('Reference Validator', () => {
+describe("Reference Validator", () => {
   beforeAll(() => {
     // Clean up any existing test directory
     if (existsSync(TEST_SKILLS_DIR)) {
@@ -23,120 +23,120 @@ describe('Reference Validator', () => {
     }
   });
 
-  describe('orphaned file detection', () => {
-    it('detects orphaned files in references directory', () => {
+  describe("orphaned file detection", () => {
+    it("detects orphaned files in references directory", () => {
       // Create a test skill with orphaned files
-      const skillDir = resolve(TEST_SKILLS_DIR, 'test-skill');
-      const referencesDir = resolve(skillDir, 'references');
+      const skillDir = resolve(TEST_SKILLS_DIR, "test-skill");
+      const referencesDir = resolve(skillDir, "references");
 
       mkdirSync(referencesDir, { recursive: true });
 
       // Create SKILL.md with a link to one reference file
       writeFileSync(
-        resolve(skillDir, 'SKILL.md'),
-        '# Test Skill\n\nSee [reference](references/linked.md) for more info.\n'
+        resolve(skillDir, "SKILL.md"),
+        "# Test Skill\n\nSee [reference](references/linked.md) for more info.\n"
       );
 
       // Create a linked reference file
       writeFileSync(
-        resolve(referencesDir, 'linked.md'),
-        '# Linked Reference\n\nThis file is linked from SKILL.md.\n'
+        resolve(referencesDir, "linked.md"),
+        "# Linked Reference\n\nThis file is linked from SKILL.md.\n"
       );
 
       // Create an orphaned reference file
       writeFileSync(
-        resolve(referencesDir, 'orphaned.md'),
-        '# Orphaned Reference\n\nThis file is NOT linked from SKILL.md.\n'
+        resolve(referencesDir, "orphaned.md"),
+        "# Orphaned Reference\n\nThis file is NOT linked from SKILL.md.\n"
       );
 
       // Run the validator (we'll need to modify the command to accept a custom skills dir)
       // For now, just verify the structure was created correctly
-      expect(existsSync(resolve(skillDir, 'SKILL.md'))).toBe(true);
-      expect(existsSync(resolve(referencesDir, 'linked.md'))).toBe(true);
-      expect(existsSync(resolve(referencesDir, 'orphaned.md'))).toBe(true);
+      expect(existsSync(resolve(skillDir, "SKILL.md"))).toBe(true);
+      expect(existsSync(resolve(referencesDir, "linked.md"))).toBe(true);
+      expect(existsSync(resolve(referencesDir, "orphaned.md"))).toBe(true);
     });
 
-    it('handles transitive references correctly', () => {
+    it("handles transitive references correctly", () => {
       // Create a test skill with transitive references
-      const skillDir = resolve(TEST_SKILLS_DIR, 'test-skill-transitive');
-      const referencesDir = resolve(skillDir, 'references');
+      const skillDir = resolve(TEST_SKILLS_DIR, "test-skill-transitive");
+      const referencesDir = resolve(skillDir, "references");
 
       mkdirSync(referencesDir, { recursive: true });
 
       // Create SKILL.md with a link to first reference
       writeFileSync(
-        resolve(skillDir, 'SKILL.md'),
-        '# Test Skill\n\nSee [reference](references/first.md) for more info.\n'
+        resolve(skillDir, "SKILL.md"),
+        "# Test Skill\n\nSee [reference](references/first.md) for more info.\n"
       );
 
       // Create first reference that links to second
       writeFileSync(
-        resolve(referencesDir, 'first.md'),
-        '# First Reference\n\nSee also [second reference](second.md).\n'
+        resolve(referencesDir, "first.md"),
+        "# First Reference\n\nSee also [second reference](second.md).\n"
       );
 
       // Create second reference (should NOT be orphaned due to transitive link)
       writeFileSync(
-        resolve(referencesDir, 'second.md'),
-        '# Second Reference\n\nThis is transitively linked.\n'
+        resolve(referencesDir, "second.md"),
+        "# Second Reference\n\nThis is transitively linked.\n"
       );
 
       // Create an orphaned reference
       writeFileSync(
-        resolve(referencesDir, 'orphaned.md'),
-        '# Orphaned Reference\n\nThis file is truly orphaned.\n'
+        resolve(referencesDir, "orphaned.md"),
+        "# Orphaned Reference\n\nThis file is truly orphaned.\n"
       );
 
-      expect(existsSync(resolve(referencesDir, 'first.md'))).toBe(true);
-      expect(existsSync(resolve(referencesDir, 'second.md'))).toBe(true);
-      expect(existsSync(resolve(referencesDir, 'orphaned.md'))).toBe(true);
+      expect(existsSync(resolve(referencesDir, "first.md"))).toBe(true);
+      expect(existsSync(resolve(referencesDir, "second.md"))).toBe(true);
+      expect(existsSync(resolve(referencesDir, "orphaned.md"))).toBe(true);
     });
 
-    it('ignores files outside references directory', () => {
+    it("ignores files outside references directory", () => {
       // Create a test skill with files outside references
-      const skillDir = resolve(TEST_SKILLS_DIR, 'test-skill-outside');
-      const referencesDir = resolve(skillDir, 'references');
+      const skillDir = resolve(TEST_SKILLS_DIR, "test-skill-outside");
+      const referencesDir = resolve(skillDir, "references");
 
       mkdirSync(referencesDir, { recursive: true });
 
       // Create SKILL.md
       writeFileSync(
-        resolve(skillDir, 'SKILL.md'),
-        '# Test Skill\n\nThis is a skill without reference links.\n'
+        resolve(skillDir, "SKILL.md"),
+        "# Test Skill\n\nThis is a skill without reference links.\n"
       );
 
       // Create a file in the root (should NOT be reported as orphaned)
       writeFileSync(
-        resolve(skillDir, 'README.md'),
-        '# README\n\nThis is not in references.\n'
+        resolve(skillDir, "README.md"),
+        "# README\n\nThis is not in references.\n"
       );
 
       // Create an orphaned file in references (should be reported)
       writeFileSync(
-        resolve(referencesDir, 'orphaned.md'),
-        '# Orphaned\n\nThis should be reported.\n'
+        resolve(referencesDir, "orphaned.md"),
+        "# Orphaned\n\nThis should be reported.\n"
       );
 
-      expect(existsSync(resolve(skillDir, 'README.md'))).toBe(true);
-      expect(existsSync(resolve(referencesDir, 'orphaned.md'))).toBe(true);
+      expect(existsSync(resolve(skillDir, "README.md"))).toBe(true);
+      expect(existsSync(resolve(referencesDir, "orphaned.md"))).toBe(true);
     });
   });
 
-  describe('link validation', () => {
-    it('validates that referenced files exist', () => {
-      const skillDir = resolve(TEST_SKILLS_DIR, 'test-skill-broken');
-      const referencesDir = resolve(skillDir, 'references');
+  describe("link validation", () => {
+    it("validates that referenced files exist", () => {
+      const skillDir = resolve(TEST_SKILLS_DIR, "test-skill-broken");
+      const referencesDir = resolve(skillDir, "references");
 
       mkdirSync(referencesDir, { recursive: true });
 
       // Create SKILL.md with a broken link
       writeFileSync(
-        resolve(skillDir, 'SKILL.md'),
-        '# Test Skill\n\nSee [reference](references/missing.md) for more info.\n'
+        resolve(skillDir, "SKILL.md"),
+        "# Test Skill\n\nSee [reference](references/missing.md) for more info.\n"
       );
 
-      expect(existsSync(resolve(skillDir, 'SKILL.md'))).toBe(true);
-      expect(existsSync(resolve(referencesDir, 'missing.md'))).toBe(false);
+      expect(existsSync(resolve(skillDir, "SKILL.md"))).toBe(true);
+      expect(existsSync(resolve(referencesDir, "missing.md"))).toBe(false);
     });
   });
 });

--- a/scripts/src/references/cli.ts
+++ b/scripts/src/references/cli.ts
@@ -15,19 +15,19 @@
  *   npm run references <skill>      # Validate a single skill
  */
 
-import { dirname, resolve, relative, normalize } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import { dirname, resolve, relative, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 
 // ── Paths ────────────────────────────────────────────────────────────────────
 
 function getRepoRoot(): string {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
-  return resolve(scriptDir, '../../..');
+  return resolve(scriptDir, "../../..");
 }
 
 const REPO_ROOT = getRepoRoot();
-const SKILLS_DIR = resolve(REPO_ROOT, 'plugin', 'skills');
+const SKILLS_DIR = resolve(REPO_ROOT, "plugin", "skills");
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -69,10 +69,10 @@ const LINK_RE = /\[(?:[^\]]*)\]\(([^)]+)\)/g;
 
 function isIgnoredLink(rawTarget: string): boolean {
   const trimmed = rawTarget.trim();
-  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) return true;
-  if (trimmed.startsWith('mailto:')) return true;
-  if (trimmed.startsWith('mdc:')) return true;
-  if (trimmed.startsWith('#')) return true; // pure fragment
+  if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return true;
+  if (trimmed.startsWith("mailto:")) return true;
+  if (trimmed.startsWith("mdc:")) return true;
+  if (trimmed.startsWith("#")) return true; // pure fragment
   return false;
 }
 
@@ -83,9 +83,9 @@ function isIgnoredLink(rawTarget: string): boolean {
 function cleanTarget(rawTarget: string): string {
   let target = rawTarget.trim();
   // Remove optional title ("title" or 'title') at the end
-  target = target.replace(/\s+["'][^"']*["']\s*$/, '');
+  target = target.replace(/\s+["'][^"']*["']\s*$/, "");
   // Remove fragment
-  target = target.replace(/#.*$/, '');
+  target = target.replace(/#.*$/, "");
   return target.trim();
 }
 
@@ -107,7 +107,7 @@ function findMarkdownFiles(dir: string): string[] {
         const stat = statSync(fullPath);
         if (stat.isDirectory()) {
           walk(fullPath);
-        } else if (entry.endsWith('.md')) {
+        } else if (entry.endsWith(".md")) {
           results.push(fullPath);
         }
       } catch {
@@ -125,7 +125,7 @@ function findMarkdownFiles(dir: string): string[] {
  * directories, but recursively for files).
  */
 function findReferenceFiles(skillDir: string): string[] {
-  const referencesDir = resolve(skillDir, 'references');
+  const referencesDir = resolve(skillDir, "references");
   if (!existsSync(referencesDir)) {
     return [];
   }
@@ -164,10 +164,10 @@ function findReferenceFiles(skillDir: string): string[] {
  * Extract all local markdown links from a file that need to be followed for
  * orphan detection. Returns resolved absolute paths.
  */
-function extractLocalLinks(mdFile: string, skillDir: string): string[] {
+function extractLocalLinks(mdFile: string, _skillDir: string): string[] {
   const links: string[] = [];
-  const content = readFileSync(mdFile, 'utf-8');
-  const lines = content.split('\n');
+  const content = readFileSync(mdFile, "utf-8");
+  const lines = content.split("\n");
 
   for (const line of lines) {
     let match: RegExpExecArray | null;
@@ -178,7 +178,7 @@ function extractLocalLinks(mdFile: string, skillDir: string): string[] {
       if (isIgnoredLink(rawTarget)) continue;
 
       const target = cleanTarget(rawTarget);
-      if (target === '') continue;
+      if (target === "") continue;
 
       const fileDir = dirname(mdFile);
       const resolved = resolve(fileDir, target);
@@ -201,8 +201,8 @@ function extractLocalLinks(mdFile: string, skillDir: string): string[] {
 
 function validateFile(mdFile: string, skillDir: string): LinkIssue[] {
   const issues: LinkIssue[] = [];
-  const content = readFileSync(mdFile, 'utf-8');
-  const lines = content.split('\n');
+  const content = readFileSync(mdFile, "utf-8");
+  const lines = content.split("\n");
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -214,7 +214,7 @@ function validateFile(mdFile: string, skillDir: string): LinkIssue[] {
       if (isIgnoredLink(rawTarget)) continue;
 
       const target = cleanTarget(rawTarget);
-      if (target === '') continue; // pure fragment after cleaning
+      if (target === "") continue; // pure fragment after cleaning
 
       const fileDir = dirname(mdFile);
       const resolved = resolve(fileDir, target);
@@ -249,12 +249,12 @@ function validateFile(mdFile: string, skillDir: string): LinkIssue[] {
       const normalizedResolved = normalize(resolved).toLowerCase();
       const normalizedSkillDir = normalize(skillDir).toLowerCase();
 
-      const insideSkill = normalizedResolved.startsWith(normalizedSkillDir + '\\')
-        || normalizedResolved.startsWith(normalizedSkillDir + '/')
+      const insideSkill = normalizedResolved.startsWith(normalizedSkillDir + "\\")
+        || normalizedResolved.startsWith(normalizedSkillDir + "/")
         || normalizedResolved === normalizedSkillDir;
 
       if (!insideSkill) {
-        const rel = relative(SKILLS_DIR, resolved).replace(/\\/g, '/');
+        const rel = relative(SKILLS_DIR, resolved).replace(/\\/g, "/");
         issues.push({
           file: mdFile,
           line: i + 1,
@@ -284,7 +284,7 @@ function validateSkill(skillName: string): ValidationResult {
   const queue: string[] = [];
 
   // Start from SKILL.md if it exists
-  const skillMd = resolve(skillDir, 'SKILL.md');
+  const skillMd = resolve(skillDir, "SKILL.md");
   if (existsSync(skillMd)) {
     queue.push(skillMd);
     visited.add(normalize(skillMd).toLowerCase());
@@ -300,7 +300,7 @@ function validateSkill(skillName: string): ValidationResult {
       if (!visited.has(normalizedLink)) {
         visited.add(normalizedLink);
         // Only follow markdown links
-        if (link.endsWith('.md')) {
+        if (link.endsWith(".md")) {
           queue.push(link);
         }
       }
@@ -314,7 +314,7 @@ function validateSkill(skillName: string): ValidationResult {
   for (const refFile of referenceFiles) {
     const normalizedRefFile = normalize(refFile).toLowerCase();
     if (!visited.has(normalizedRefFile)) {
-      const relPath = relative(skillDir, refFile).replace(/\\/g, '/');
+      const relPath = relative(skillDir, refFile).replace(/\\/g, "/");
       orphanedFiles.push({
         file: refFile,
         reason: `File exists in references directory but is not linked from SKILL.md: ${relPath}`,
@@ -337,7 +337,7 @@ function listSkills(): string[] {
 }
 
 function formatPath(absPath: string): string {
-  return relative(REPO_ROOT, absPath).replace(/\\/g, '/');
+  return relative(REPO_ROOT, absPath).replace(/\\/g, "/");
 }
 
 function main(): void {
@@ -351,7 +351,7 @@ function main(): void {
     const skillDir = resolve(SKILLS_DIR, requestedSkill);
     if (!existsSync(skillDir) || !statSync(skillDir).isDirectory()) {
       console.error(`\n❌ Skill "${requestedSkill}" not found in ${formatPath(SKILLS_DIR)}\n`);
-      console.error('Available skills:');
+      console.error("Available skills:");
       for (const s of listSkills()) {
         console.error(`  - ${s}`);
       }
@@ -360,8 +360,8 @@ function main(): void {
     }
   }
 
-  console.log('\n🔗 Markdown Reference Validator\n');
-  console.log('────────────────────────────────────────────────────────────');
+  console.log("\n🔗 Markdown Reference Validator\n");
+  console.log("────────────────────────────────────────────────────────────");
 
   let totalIssues = 0;
   let totalOrphanedFiles = 0;
@@ -398,7 +398,7 @@ function main(): void {
     }
   }
 
-  console.log('\n────────────────────────────────────────────────────────────');
+  console.log("\n────────────────────────────────────────────────────────────");
 
   const allIssuesCount = totalIssues + totalOrphanedFiles;
   if (allIssuesCount === 0) {
@@ -410,7 +410,7 @@ function main(): void {
     } else if (totalOrphanedFiles > 0) {
       message += ` (${totalOrphanedFiles} orphaned file(s))`;
     }
-    message += '.\n';
+    message += ".\n";
     console.log(message);
     process.exitCode = 1;
   }

--- a/scripts/src/tokens/__tests__/check.test.ts
+++ b/scripts/src/tokens/__tests__/check.test.ts
@@ -2,34 +2,34 @@
  * Tests for check command - token limit validation
  */
 
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { mkdirSync, writeFileSync, rmSync, mkdtempSync, readFileSync, existsSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync, readFileSync, existsSync } from "node:fs";
 
 // We'll test the internal functions by importing them
 // First, let's create test fixtures
 
-const TEST_DIR_PREFIX = join(tmpdir(), '__test_fixtures__');
+const TEST_DIR_PREFIX = join(tmpdir(), "__test_fixtures__");
 const TEST_CONFIG = {
   defaults: {
-    'SKILL.md': 10,
-    '*.md': 50
+    "SKILL.md": 10,
+    "*.md": 50
   },
   overrides: {
-    'special.md': 100
+    "special.md": 100
   }
 };
 
-describe('check command', () => {
+describe("check command", () => {
   let testDir: string;
   let testRootDir: string;
   let testSubDir: string;
   beforeAll(() => {
     // Create test directory structure
     testDir = mkdtempSync(TEST_DIR_PREFIX);
-    testRootDir = join(testDir, 'root');
-    testSubDir = join(testRootDir, 'subdir');
+    testRootDir = join(testDir, "root");
+    testSubDir = join(testRootDir, "subdir");
   });
   beforeEach(() => {
     mkdirSync(testRootDir, { recursive: true });
@@ -40,118 +40,118 @@ describe('check command', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
     try {
       rmSync(testRootDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    } catch (err) {
+    } catch {
       // Ignore cleanup errors in tests
     }
   });
   afterAll(() => {
     try {
       rmSync(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    } catch (err) {
+    } catch {
       // Ignore cleanup errors in tests
     }
   });
 
-  describe('token limit checking', () => {
-    it('detects files exceeding limits', () => {
+  describe("token limit checking", () => {
+    it("detects files exceeding limits", () => {
       // Create a file that exceeds the limit
       // 50 token limit = 200 characters for *.md
-      const longContent = 'a'.repeat(300);  // 75 tokens, over 50 limit
-      writeFileSync(join(testRootDir, 'large.md'), longContent);
+      const longContent = "a".repeat(300);  // 75 tokens, over 50 limit
+      writeFileSync(join(testRootDir, "large.md"), longContent);
 
       // Create config
       writeFileSync(
-        join(testRootDir, '.token-limits.json'),
+        join(testRootDir, ".token-limits.json"),
         JSON.stringify(TEST_CONFIG)
       );
 
       // File exists and has content
-      const content = readFileSync(join(testRootDir, 'large.md'), 'utf-8');
+      const content = readFileSync(join(testRootDir, "large.md"), "utf-8");
       expect(content.length).toBe(300);
     });
 
-    it('respects pattern-specific limits', () => {
+    it("respects pattern-specific limits", () => {
       // SKILL.md has lower limit (10 tokens = 40 chars)
-      const skillContent = 'a'.repeat(100);  // 25 tokens, over 10 limit
-      writeFileSync(join(testRootDir, 'SKILL.md'), skillContent);
+      const skillContent = "a".repeat(100);  // 25 tokens, over 10 limit
+      writeFileSync(join(testRootDir, "SKILL.md"), skillContent);
 
       // Regular md file with same content would be under limit
-      writeFileSync(join(testRootDir, 'readme.md'), skillContent);
+      writeFileSync(join(testRootDir, "readme.md"), skillContent);
 
-      const skillFile = readFileSync(join(testRootDir, 'SKILL.md'), 'utf-8');
-      const readmeFile = readFileSync(join(testRootDir, 'readme.md'), 'utf-8');
+      const skillFile = readFileSync(join(testRootDir, "SKILL.md"), "utf-8");
+      const readmeFile = readFileSync(join(testRootDir, "readme.md"), "utf-8");
 
       expect(skillFile.length).toBe(100);
       expect(readmeFile.length).toBe(100);
     });
 
-    it('uses override limits when specified', () => {
+    it("uses override limits when specified", () => {
       // special.md has override limit of 100 tokens = 400 chars
-      const content = 'a'.repeat(350);  // 88 tokens, under 100 limit
-      writeFileSync(join(testRootDir, 'special.md'), content);
+      const content = "a".repeat(350);  // 88 tokens, under 100 limit
+      writeFileSync(join(testRootDir, "special.md"), content);
 
-      const file = readFileSync(join(testRootDir, 'special.md'), 'utf-8');
+      const file = readFileSync(join(testRootDir, "special.md"), "utf-8");
       expect(file.length).toBe(350);
     });
   });
 
-  describe('glob pattern matching', () => {
-    it('matches exact filenames', () => {
-      writeFileSync(join(testRootDir, 'SKILL.md'), '# Skill');
-      writeFileSync(join(testSubDir, 'SKILL.md'), '# Nested Skill');
+  describe("glob pattern matching", () => {
+    it("matches exact filenames", () => {
+      writeFileSync(join(testRootDir, "SKILL.md"), "# Skill");
+      writeFileSync(join(testSubDir, "SKILL.md"), "# Nested Skill");
 
       // Both files should exist
-      expect(existsSync(join(testRootDir, 'SKILL.md'))).toBe(true);
-      expect(existsSync(join(testSubDir, 'SKILL.md'))).toBe(true);
+      expect(existsSync(join(testRootDir, "SKILL.md"))).toBe(true);
+      expect(existsSync(join(testSubDir, "SKILL.md"))).toBe(true);
     });
 
-    it('matches wildcard patterns', () => {
-      writeFileSync(join(testRootDir, 'readme.md'), '# README');
-      writeFileSync(join(testRootDir, 'guide.md'), '# Guide');
+    it("matches wildcard patterns", () => {
+      writeFileSync(join(testRootDir, "readme.md"), "# README");
+      writeFileSync(join(testRootDir, "guide.md"), "# Guide");
 
       // Both match *.md pattern
-      expect(existsSync(join(testRootDir, 'readme.md'))).toBe(true);
-      expect(existsSync(join(testRootDir, 'guide.md'))).toBe(true);
+      expect(existsSync(join(testRootDir, "readme.md"))).toBe(true);
+      expect(existsSync(join(testRootDir, "guide.md"))).toBe(true);
     });
 
-    it('matches globstar patterns', () => {
-      mkdirSync(join(testRootDir, 'references'), { recursive: true });
-      writeFileSync(join(testRootDir, 'references', 'api.md'), '# API');
+    it("matches globstar patterns", () => {
+      mkdirSync(join(testRootDir, "references"), { recursive: true });
+      writeFileSync(join(testRootDir, "references", "api.md"), "# API");
 
-      expect(existsSync(join(testRootDir, 'references', 'api.md'))).toBe(true);
+      expect(existsSync(join(testRootDir, "references", "api.md"))).toBe(true);
     });
   });
 
-  describe('config loading', () => {
-    it('uses default config when no config file exists', () => {
+  describe("config loading", () => {
+    it("uses default config when no config file exists", () => {
       // No .token-limits.json created
-      const configExists = existsSync(join(testRootDir, '.token-limits.json'));
+      const configExists = existsSync(join(testRootDir, ".token-limits.json"));
       expect(configExists).toBe(false);
     });
 
-    it('loads custom config from .token-limits.json', () => {
+    it("loads custom config from .token-limits.json", () => {
       writeFileSync(
-        join(testRootDir, '.token-limits.json'),
+        join(testRootDir, ".token-limits.json"),
         JSON.stringify(TEST_CONFIG)
       );
 
       const config = JSON.parse(
-        readFileSync(join(testRootDir, '.token-limits.json'), 'utf-8')
+        readFileSync(join(testRootDir, ".token-limits.json"), "utf-8")
       );
 
-      expect(config.defaults['SKILL.md']).toBe(10);
-      expect(config.overrides['special.md']).toBe(100);
+      expect(config.defaults["SKILL.md"]).toBe(10);
+      expect(config.overrides["special.md"]).toBe(100);
     });
   });
 
-  describe('output formats', () => {
-    it('generates valid JSON output', () => {
+  describe("output formats", () => {
+    it("generates valid JSON output", () => {
       const report = {
         timestamp: new Date().toISOString(),
         totalFiles: 5,
         exceededCount: 2,
         results: [
-          { file: 'test.md', tokens: 100, limit: 50, exceeded: true, pattern: '*.md' }
+          { file: "test.md", tokens: 100, limit: 50, exceeded: true, pattern: "*.md" }
         ]
       };
 
@@ -163,17 +163,17 @@ describe('check command', () => {
       expect(parsed.results[0].exceeded).toBe(true);
     });
 
-    it('generates valid markdown output', () => {
+    it("generates valid markdown output", () => {
       const markdownLines = [
-        '## 📊 Token Limit Check Report',
-        '',
-        '**Checked:** 5 files',
-        '**Exceeded:** 2 files'
+        "## 📊 Token Limit Check Report",
+        "",
+        "**Checked:** 5 files",
+        "**Exceeded:** 2 files"
       ];
 
-      const output = markdownLines.join('\n');
-      expect(output).toContain('Token Limit Check Report');
-      expect(output).toContain('5 files');
+      const output = markdownLines.join("\n");
+      expect(output).toContain("Token Limit Check Report");
+      expect(output).toContain("5 files");
     });
   });
 });

--- a/scripts/src/tokens/__tests__/cli.test.ts
+++ b/scripts/src/tokens/__tests__/cli.test.ts
@@ -2,58 +2,58 @@
  * Tests for CLI router
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 
-const COMMANDS = ['count', 'check', 'compare', 'suggest', 'help'] as const;
+const COMMANDS = ["count", "check", "compare", "suggest", "help"] as const;
 type Command = typeof COMMANDS[number];
 
-describe('CLI router', () => {
-  describe('command parsing', () => {
-    it('recognizes all valid commands', () => {
-      expect(COMMANDS.includes('count')).toBe(true);
-      expect(COMMANDS.includes('check')).toBe(true);
-      expect(COMMANDS.includes('compare')).toBe(true);
-      expect(COMMANDS.includes('suggest')).toBe(true);
-      expect(COMMANDS.includes('help')).toBe(true);
+describe("CLI router", () => {
+  describe("command parsing", () => {
+    it("recognizes all valid commands", () => {
+      expect(COMMANDS.includes("count")).toBe(true);
+      expect(COMMANDS.includes("check")).toBe(true);
+      expect(COMMANDS.includes("compare")).toBe(true);
+      expect(COMMANDS.includes("suggest")).toBe(true);
+      expect(COMMANDS.includes("help")).toBe(true);
     });
 
-    it('defaults to help when no command provided', () => {
+    it("defaults to help when no command provided", () => {
       const args: string[] = [];
-      const command = (args[0] ?? 'help') as Command;
+      const command = (args[0] ?? "help") as Command;
       
-      expect(command).toBe('help');
+      expect(command).toBe("help");
     });
 
-    it('extracts command from first argument', () => {
-      const args = ['check', '--json'];
+    it("extracts command from first argument", () => {
+      const args = ["check", "--json"];
       const command = args[0] as Command;
       const commandArgs = args.slice(1);
       
-      expect(command).toBe('check');
-      expect(commandArgs).toEqual(['--json']);
+      expect(command).toBe("check");
+      expect(commandArgs).toEqual(["--json"]);
     });
 
-    it('passes remaining args to command', () => {
-      const args = ['suggest', 'docs/', '--verbose'];
+    it("passes remaining args to command", () => {
+      const args = ["suggest", "docs/", "--verbose"];
       const command = args[0];
       const commandArgs = args.slice(1);
       
-      expect(command).toBe('suggest');
-      expect(commandArgs).toEqual(['docs/', '--verbose']);
+      expect(command).toBe("suggest");
+      expect(commandArgs).toEqual(["docs/", "--verbose"]);
     });
   });
 
-  describe('command validation', () => {
-    it('accepts valid commands', () => {
-      const validCommands = ['count', 'check', 'compare', 'suggest', 'help'];
+  describe("command validation", () => {
+    it("accepts valid commands", () => {
+      const validCommands = ["count", "check", "compare", "suggest", "help"];
       
       for (const cmd of validCommands) {
         expect(COMMANDS.includes(cmd as Command)).toBe(true);
       }
     });
 
-    it('rejects invalid commands', () => {
-      const invalidCommands = ['invalid', 'unknown', 'foo', ''];
+    it("rejects invalid commands", () => {
+      const invalidCommands = ["invalid", "unknown", "foo", ""];
       
       for (const cmd of invalidCommands) {
         expect(COMMANDS.includes(cmd as Command)).toBe(false);
@@ -61,99 +61,99 @@ describe('CLI router', () => {
     });
   });
 
-  describe('argument parsing for subcommands', () => {
-    describe('count args', () => {
-      it('parses --output flag', () => {
-        const args = ['--output', 'metadata.json'];
-        const outputIndex = args.indexOf('--output');
-        const hasOutputValue = outputIndex !== -1 && args[outputIndex + 1] && !args[outputIndex + 1].startsWith('--');
+  describe("argument parsing for subcommands", () => {
+    describe("count args", () => {
+      it("parses --output flag", () => {
+        const args = ["--output", "metadata.json"];
+        const outputIndex = args.indexOf("--output");
+        const hasOutputValue = outputIndex !== -1 && args[outputIndex + 1] && !args[outputIndex + 1].startsWith("--");
         const outputPath = hasOutputValue ? args[outputIndex + 1] : null;
         
-        expect(outputPath).toBe('metadata.json');
+        expect(outputPath).toBe("metadata.json");
       });
 
-      it('parses --json flag', () => {
-        const args = ['--json'];
-        const jsonOnly = args.includes('--json');
+      it("parses --json flag", () => {
+        const args = ["--json"];
+        const jsonOnly = args.includes("--json");
         
         expect(jsonOnly).toBe(true);
       });
     });
 
-    describe('check args', () => {
-      it('parses --markdown flag', () => {
-        const args = ['--markdown'];
-        const markdownOutput = args.includes('--markdown');
+    describe("check args", () => {
+      it("parses --markdown flag", () => {
+        const args = ["--markdown"];
+        const markdownOutput = args.includes("--markdown");
         
         expect(markdownOutput).toBe(true);
       });
 
-      it('parses file paths', () => {
-        const args = ['docs/readme.md', 'plugin/skills/SKILL.md', '--json'];
-        const filesArg = args.filter(a => !a.startsWith('--'));
+      it("parses file paths", () => {
+        const args = ["docs/readme.md", "plugin/skills/SKILL.md", "--json"];
+        const filesArg = args.filter(a => !a.startsWith("--"));
         
-        expect(filesArg).toEqual(['docs/readme.md', 'plugin/skills/SKILL.md']);
+        expect(filesArg).toEqual(["docs/readme.md", "plugin/skills/SKILL.md"]);
       });
     });
 
-    describe('compare args', () => {
-      it('parses --base flag', () => {
-        const args = ['--base', 'main', '--head', 'HEAD'];
-        let baseRef = 'main';
-        let headRef = 'HEAD';
+    describe("compare args", () => {
+      it("parses --base flag", () => {
+        const args = ["--base", "main", "--head", "HEAD"];
+        let baseRef = "main";
+        let headRef = "HEAD";
         
         for (let i = 0; i < args.length; i++) {
           const arg = args[i], next = args[i + 1];
-          if (arg === '--base' && next && !next.startsWith('--')) { baseRef = next; i++; }
-          else if (arg === '--head' && next && !next.startsWith('--')) { headRef = next; i++; }
+          if (arg === "--base" && next && !next.startsWith("--")) { baseRef = next; i++; }
+          else if (arg === "--head" && next && !next.startsWith("--")) { headRef = next; i++; }
         }
         
-        expect(baseRef).toBe('main');
-        expect(headRef).toBe('HEAD');
+        expect(baseRef).toBe("main");
+        expect(headRef).toBe("HEAD");
       });
 
-      it('parses --all flag', () => {
-        const args = ['--all', '--base', 'develop'];
-        const allFiles = args.includes('--all');
+      it("parses --all flag", () => {
+        const args = ["--all", "--base", "develop"];
+        const allFiles = args.includes("--all");
         
         expect(allFiles).toBe(true);
       });
 
-      it('uses defaults when flags not provided', () => {
+      it("uses defaults when flags not provided", () => {
         const args: string[] = [];
-        let baseRef = 'main';
-        let headRef = 'HEAD';
+        let baseRef = "main";
+        let headRef = "HEAD";
         
         for (let i = 0; i < args.length; i++) {
           const arg = args[i], next = args[i + 1];
-          if (arg === '--base' && next) { baseRef = next; }
-          if (arg === '--head' && next) { headRef = next; }
+          if (arg === "--base" && next) { baseRef = next; }
+          if (arg === "--head" && next) { headRef = next; }
         }
         
-        expect(baseRef).toBe('main');
-        expect(headRef).toBe('HEAD');
+        expect(baseRef).toBe("main");
+        expect(headRef).toBe("HEAD");
       });
     });
 
-    describe('suggest args', () => {
-      it('extracts target path', () => {
-        const args = ['docs/', '--verbose'];
-        const targetArg = args.filter(a => !a.startsWith('--'))[0];
+    describe("suggest args", () => {
+      it("extracts target path", () => {
+        const args = ["docs/", "--verbose"];
+        const targetArg = args.filter(a => !a.startsWith("--"))[0];
         
-        expect(targetArg).toBe('docs/');
+        expect(targetArg).toBe("docs/");
       });
 
-      it('handles no target path', () => {
-        const args = ['--verbose'];
-        const targetArg = args.filter(a => !a.startsWith('--'))[0];
+      it("handles no target path", () => {
+        const args = ["--verbose"];
+        const targetArg = args.filter(a => !a.startsWith("--"))[0];
         
         expect(targetArg).toBeUndefined();
       });
     });
   });
 
-  describe('help text', () => {
-    it('includes all commands in help', () => {
+  describe("help text", () => {
+    it("includes all commands in help", () => {
       const helpText = `
 📊 Token Management CLI
 
@@ -167,23 +167,23 @@ Commands:
   help      Show this help message
 `;
       
-      expect(helpText).toContain('count');
-      expect(helpText).toContain('check');
-      expect(helpText).toContain('compare');
-      expect(helpText).toContain('suggest');
-      expect(helpText).toContain('help');
+      expect(helpText).toContain("count");
+      expect(helpText).toContain("check");
+      expect(helpText).toContain("compare");
+      expect(helpText).toContain("suggest");
+      expect(helpText).toContain("help");
     });
 
-    it('includes usage examples', () => {
+    it("includes usage examples", () => {
       const examples = [
-        'npm run tokens count',
-        'npm run tokens check',
-        'npm run tokens compare',
-        'npm run tokens suggest'
+        "npm run tokens count",
+        "npm run tokens check",
+        "npm run tokens compare",
+        "npm run tokens suggest"
       ];
       
       for (const example of examples) {
-        expect(example).toContain('npm run tokens');
+        expect(example).toContain("npm run tokens");
       }
     });
   });

--- a/scripts/src/tokens/__tests__/compare.test.ts
+++ b/scripts/src/tokens/__tests__/compare.test.ts
@@ -2,156 +2,156 @@
  * Tests for compare command - git-based token comparison
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 
 // Test the git ref validation logic
-const GIT_REF_PATTERN = /^[a-zA-Z0-9._\-\/~^]+$/;
+const GIT_REF_PATTERN = /^[a-zA-Z0-9._\-/~^]+$/;
 const MAX_REF_LENGTH = 256;
 
 function isValidGitRef(ref: string): boolean {
   return GIT_REF_PATTERN.test(ref) && ref.length < MAX_REF_LENGTH;
 }
 
-describe('compare command', () => {
-  describe('git ref validation', () => {
-    it('accepts valid branch names', () => {
-      expect(isValidGitRef('main')).toBe(true);
-      expect(isValidGitRef('develop')).toBe(true);
-      expect(isValidGitRef('feature/new-feature')).toBe(true);
-      expect(isValidGitRef('release-1.0.0')).toBe(true);
-      expect(isValidGitRef('fix_bug_123')).toBe(true);
+describe("compare command", () => {
+  describe("git ref validation", () => {
+    it("accepts valid branch names", () => {
+      expect(isValidGitRef("main")).toBe(true);
+      expect(isValidGitRef("develop")).toBe(true);
+      expect(isValidGitRef("feature/new-feature")).toBe(true);
+      expect(isValidGitRef("release-1.0.0")).toBe(true);
+      expect(isValidGitRef("fix_bug_123")).toBe(true);
     });
 
-    it('accepts valid commit refs', () => {
-      expect(isValidGitRef('HEAD')).toBe(true);
-      expect(isValidGitRef('HEAD~1')).toBe(true);
-      expect(isValidGitRef('HEAD~10')).toBe(true);
-      expect(isValidGitRef('HEAD^')).toBe(true);
-      expect(isValidGitRef('abc123def')).toBe(true);
+    it("accepts valid commit refs", () => {
+      expect(isValidGitRef("HEAD")).toBe(true);
+      expect(isValidGitRef("HEAD~1")).toBe(true);
+      expect(isValidGitRef("HEAD~10")).toBe(true);
+      expect(isValidGitRef("HEAD^")).toBe(true);
+      expect(isValidGitRef("abc123def")).toBe(true);
     });
 
-    it('accepts origin prefixed refs', () => {
-      expect(isValidGitRef('origin/main')).toBe(true);
-      expect(isValidGitRef('origin/feature/test')).toBe(true);
-      expect(isValidGitRef('upstream/develop')).toBe(true);
+    it("accepts origin prefixed refs", () => {
+      expect(isValidGitRef("origin/main")).toBe(true);
+      expect(isValidGitRef("origin/feature/test")).toBe(true);
+      expect(isValidGitRef("upstream/develop")).toBe(true);
     });
 
-    it('accepts tag refs', () => {
-      expect(isValidGitRef('v1.0.0')).toBe(true);
-      expect(isValidGitRef('release-2023.01')).toBe(true);
+    it("accepts tag refs", () => {
+      expect(isValidGitRef("v1.0.0")).toBe(true);
+      expect(isValidGitRef("release-2023.01")).toBe(true);
     });
 
-    it('rejects refs with shell metacharacters', () => {
-      expect(isValidGitRef('main; rm -rf /')).toBe(false);
-      expect(isValidGitRef('main && echo pwned')).toBe(false);
-      expect(isValidGitRef('$(whoami)')).toBe(false);
-      expect(isValidGitRef('`id`')).toBe(false);
-      expect(isValidGitRef('main|cat /etc/passwd')).toBe(false);
+    it("rejects refs with shell metacharacters", () => {
+      expect(isValidGitRef("main; rm -rf /")).toBe(false);
+      expect(isValidGitRef("main && echo pwned")).toBe(false);
+      expect(isValidGitRef("$(whoami)")).toBe(false);
+      expect(isValidGitRef("`id`")).toBe(false);
+      expect(isValidGitRef("main|cat /etc/passwd")).toBe(false);
     });
 
-    it('rejects refs with spaces', () => {
-      expect(isValidGitRef('main branch')).toBe(false);
-      expect(isValidGitRef(' main')).toBe(false);
-      expect(isValidGitRef('main ')).toBe(false);
+    it("rejects refs with spaces", () => {
+      expect(isValidGitRef("main branch")).toBe(false);
+      expect(isValidGitRef(" main")).toBe(false);
+      expect(isValidGitRef("main ")).toBe(false);
     });
 
-    it('rejects refs with quotes', () => {
+    it("rejects refs with quotes", () => {
       expect(isValidGitRef("main'")).toBe(false);
       expect(isValidGitRef('main"')).toBe(false);
     });
 
-    it('rejects refs with special characters', () => {
-      expect(isValidGitRef('main!')).toBe(false);
-      expect(isValidGitRef('main#')).toBe(false);
-      expect(isValidGitRef('main$var')).toBe(false);
-      expect(isValidGitRef('main%')).toBe(false);
-      expect(isValidGitRef('main*')).toBe(false);
-      expect(isValidGitRef('main?')).toBe(false);
+    it("rejects refs with special characters", () => {
+      expect(isValidGitRef("main!")).toBe(false);
+      expect(isValidGitRef("main#")).toBe(false);
+      expect(isValidGitRef("main$var")).toBe(false);
+      expect(isValidGitRef("main%")).toBe(false);
+      expect(isValidGitRef("main*")).toBe(false);
+      expect(isValidGitRef("main?")).toBe(false);
     });
 
-    it('rejects empty refs', () => {
-      expect(isValidGitRef('')).toBe(false);
+    it("rejects empty refs", () => {
+      expect(isValidGitRef("")).toBe(false);
     });
 
-    it('rejects refs exceeding max length', () => {
-      const longRef = 'a'.repeat(256);
+    it("rejects refs exceeding max length", () => {
+      const longRef = "a".repeat(256);
       expect(isValidGitRef(longRef)).toBe(false);
 
-      const validLongRef = 'a'.repeat(255);
+      const validLongRef = "a".repeat(255);
       expect(isValidGitRef(validLongRef)).toBe(true);
     });
   });
 
-  describe('diff formatting', () => {
+  describe("diff formatting", () => {
     function formatDiff(diff: number): string {
       if (diff > 0) return `+${diff.toLocaleString()}`;
       if (diff < 0) return diff.toLocaleString();
-      return '0';
+      return "0";
     }
 
     function formatPercent(percent: number): string {
       if (percent > 0) return `+${percent}%`;
       if (percent < 0) return `${percent}%`;
-      return '0%';
+      return "0%";
     }
 
-    it('formats positive diffs with plus sign', () => {
-      expect(formatDiff(100)).toBe('+100');
-      expect(formatDiff(1000)).toBe('+1,000');
+    it("formats positive diffs with plus sign", () => {
+      expect(formatDiff(100)).toBe("+100");
+      expect(formatDiff(1000)).toBe("+1,000");
     });
 
-    it('formats negative diffs with minus sign', () => {
-      expect(formatDiff(-100)).toBe('-100');
-      expect(formatDiff(-1000)).toBe('-1,000');
+    it("formats negative diffs with minus sign", () => {
+      expect(formatDiff(-100)).toBe("-100");
+      expect(formatDiff(-1000)).toBe("-1,000");
     });
 
-    it('formats zero diff', () => {
-      expect(formatDiff(0)).toBe('0');
+    it("formats zero diff", () => {
+      expect(formatDiff(0)).toBe("0");
     });
 
-    it('formats positive percent with plus sign', () => {
-      expect(formatPercent(50)).toBe('+50%');
+    it("formats positive percent with plus sign", () => {
+      expect(formatPercent(50)).toBe("+50%");
     });
 
-    it('formats negative percent', () => {
-      expect(formatPercent(-25)).toBe('-25%');
+    it("formats negative percent", () => {
+      expect(formatPercent(-25)).toBe("-25%");
     });
 
-    it('formats zero percent', () => {
-      expect(formatPercent(0)).toBe('0%');
+    it("formats zero percent", () => {
+      expect(formatPercent(0)).toBe("0%");
     });
   });
 
-  describe('change emoji selection', () => {
+  describe("change emoji selection", () => {
     function getChangeEmoji(diff: number, percent: number): string {
-      if (diff === 0) return '➖';
-      if (diff < 0) return '📉';
-      if (percent > 50) return '🔴';
-      if (percent > 20) return '🟠';
-      return '📈';
+      if (diff === 0) return "➖";
+      if (diff < 0) return "📉";
+      if (percent > 50) return "🔴";
+      if (percent > 20) return "🟠";
+      return "📈";
     }
 
-    it('returns neutral emoji for no change', () => {
-      expect(getChangeEmoji(0, 0)).toBe('➖');
+    it("returns neutral emoji for no change", () => {
+      expect(getChangeEmoji(0, 0)).toBe("➖");
     });
 
-    it('returns decrease emoji for negative diff', () => {
-      expect(getChangeEmoji(-100, -10)).toBe('📉');
+    it("returns decrease emoji for negative diff", () => {
+      expect(getChangeEmoji(-100, -10)).toBe("📉");
     });
 
-    it('returns red emoji for large increase (>50%)', () => {
-      expect(getChangeEmoji(100, 51)).toBe('🔴');
-      expect(getChangeEmoji(100, 100)).toBe('🔴');
+    it("returns red emoji for large increase (>50%)", () => {
+      expect(getChangeEmoji(100, 51)).toBe("🔴");
+      expect(getChangeEmoji(100, 100)).toBe("🔴");
     });
 
-    it('returns orange emoji for medium increase (>20%)', () => {
-      expect(getChangeEmoji(100, 21)).toBe('🟠');
-      expect(getChangeEmoji(100, 50)).toBe('🟠');
+    it("returns orange emoji for medium increase (>20%)", () => {
+      expect(getChangeEmoji(100, 21)).toBe("🟠");
+      expect(getChangeEmoji(100, 50)).toBe("🟠");
     });
 
-    it('returns increase emoji for small increase', () => {
-      expect(getChangeEmoji(100, 10)).toBe('📈');
-      expect(getChangeEmoji(100, 20)).toBe('📈');
+    it("returns increase emoji for small increase", () => {
+      expect(getChangeEmoji(100, 10)).toBe("📈");
+      expect(getChangeEmoji(100, 20)).toBe("📈");
     });
   });
 });

--- a/scripts/src/tokens/__tests__/count.test.ts
+++ b/scripts/src/tokens/__tests__/count.test.ts
@@ -2,13 +2,13 @@
  * Tests for count command - token counting
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { join } from 'node:path';
-import { mkdirSync, writeFileSync, rmSync, readFileSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { join } from "node:path";
+import { mkdirSync, writeFileSync, rmSync, readFileSync } from "node:fs";
 
-const TEST_DIR = join(process.cwd(), '__test_fixtures_count__');
+const TEST_DIR = join(process.cwd(), "__test_fixtures_count__");
 
-describe('count command', () => {
+describe("count command", () => {
   beforeEach(() => {
     mkdirSync(TEST_DIR, { recursive: true });
   });
@@ -18,207 +18,207 @@ describe('count command', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
     try {
       rmSync(TEST_DIR, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    } catch (err) {
+    } catch {
       // Ignore cleanup errors in tests
     }
   });
 
-  describe('token counting', () => {
-    it('counts tokens for a single file', () => {
-      const content = 'a'.repeat(100);  // 100 chars = 25 tokens
-      writeFileSync(join(TEST_DIR, 'test.md'), content);
-      
-      const fileContent = readFileSync(join(TEST_DIR, 'test.md'), 'utf-8');
+  describe("token counting", () => {
+    it("counts tokens for a single file", () => {
+      const content = "a".repeat(100);  // 100 chars = 25 tokens
+      writeFileSync(join(TEST_DIR, "test.md"), content);
+
+      const fileContent = readFileSync(join(TEST_DIR, "test.md"), "utf-8");
       const tokens = Math.ceil(fileContent.length / 4);
-      
+
       expect(tokens).toBe(25);
     });
 
-    it('counts lines correctly', () => {
-      const content = 'line1\nline2\nline3\n';
-      writeFileSync(join(TEST_DIR, 'multiline.md'), content);
-      
-      const fileContent = readFileSync(join(TEST_DIR, 'multiline.md'), 'utf-8');
-      const lines = fileContent.split('\n').length;
-      
+    it("counts lines correctly", () => {
+      const content = "line1\nline2\nline3\n";
+      writeFileSync(join(TEST_DIR, "multiline.md"), content);
+
+      const fileContent = readFileSync(join(TEST_DIR, "multiline.md"), "utf-8");
+      const lines = fileContent.split("\n").length;
+
       expect(lines).toBe(4);  // 3 lines + 1 empty after trailing newline
     });
 
-    it('counts characters correctly', () => {
-      const content = 'Hello, World!';
-      writeFileSync(join(TEST_DIR, 'hello.md'), content);
-      
-      const fileContent = readFileSync(join(TEST_DIR, 'hello.md'), 'utf-8');
-      
+    it("counts characters correctly", () => {
+      const content = "Hello, World!";
+      writeFileSync(join(TEST_DIR, "hello.md"), content);
+
+      const fileContent = readFileSync(join(TEST_DIR, "hello.md"), "utf-8");
+
       expect(fileContent.length).toBe(13);
     });
   });
 
-  describe('file discovery', () => {
-    it('finds all markdown files in directory', () => {
+  describe("file discovery", () => {
+    it("finds all markdown files in directory", () => {
       // Clean directory first to avoid leftover files from other tests
       rmSync(TEST_DIR, { recursive: true, force: true });
       mkdirSync(TEST_DIR, { recursive: true });
-      
-      writeFileSync(join(TEST_DIR, 'readme.md'), '# README');
-      writeFileSync(join(TEST_DIR, 'guide.md'), '# Guide');
-      writeFileSync(join(TEST_DIR, 'script.ts'), 'console.log("test")');
-      
-      const { readdirSync } = require('node:fs');
-      const files = readdirSync(TEST_DIR).filter((f: string) => f.endsWith('.md'));
-      
+
+      writeFileSync(join(TEST_DIR, "readme.md"), "# README");
+      writeFileSync(join(TEST_DIR, "guide.md"), "# Guide");
+      writeFileSync(join(TEST_DIR, "script.ts"), 'console.log("test")');
+
+      const { readdirSync } = require("node:fs");
+      const files = readdirSync(TEST_DIR).filter((f: string) => f.endsWith(".md"));
+
       expect(files.length).toBe(2);
-      expect(files).toContain('readme.md');
-      expect(files).toContain('guide.md');
+      expect(files).toContain("readme.md");
+      expect(files).toContain("guide.md");
     });
 
-    it('finds markdown files recursively', () => {
-      writeFileSync(join(TEST_DIR, 'root.md'), '# Root');
-      mkdirSync(join(TEST_DIR, 'docs'), { recursive: true });
-      writeFileSync(join(TEST_DIR, 'docs', 'nested.md'), '# Nested');
-      
+    it("finds markdown files recursively", () => {
+      writeFileSync(join(TEST_DIR, "root.md"), "# Root");
+      mkdirSync(join(TEST_DIR, "docs"), { recursive: true });
+      writeFileSync(join(TEST_DIR, "docs", "nested.md"), "# Nested");
+
       const allFiles: string[] = [];
-      
+
       function findMdFiles(dir: string) {
-        const { readdirSync, statSync } = require('node:fs');
+        const { readdirSync, statSync } = require("node:fs");
         const entries = readdirSync(dir);
         for (const entry of entries) {
           const fullPath = join(dir, entry);
           if (statSync(fullPath).isDirectory()) {
             findMdFiles(fullPath);
-          } else if (entry.endsWith('.md')) {
+          } else if (entry.endsWith(".md")) {
             allFiles.push(fullPath);
           }
         }
       }
-      
+
       findMdFiles(TEST_DIR);
       expect(allFiles.length).toBe(2);
     });
 
-    it('excludes node_modules directory', () => {
+    it("excludes node_modules directory", () => {
       // Clean and recreate test directory
       rmSync(TEST_DIR, { recursive: true, force: true });
       mkdirSync(TEST_DIR, { recursive: true });
-      
-      writeFileSync(join(TEST_DIR, 'root.md'), '# Root');
-      mkdirSync(join(TEST_DIR, 'node_modules', 'package'), { recursive: true });
-      writeFileSync(join(TEST_DIR, 'node_modules', 'package', 'readme.md'), '# Package');
-      
-      const EXCLUDED_DIRS = ['node_modules', '.git'];
+
+      writeFileSync(join(TEST_DIR, "root.md"), "# Root");
+      mkdirSync(join(TEST_DIR, "node_modules", "package"), { recursive: true });
+      writeFileSync(join(TEST_DIR, "node_modules", "package", "readme.md"), "# Package");
+
+      const EXCLUDED_DIRS = ["node_modules", ".git"];
       const allFiles: string[] = [];
-      
+
       function findMdFiles(dir: string) {
-        const { readdirSync, statSync } = require('node:fs');
+        const { readdirSync, statSync } = require("node:fs");
         const entries = readdirSync(dir);
         for (const entry of entries) {
           if (EXCLUDED_DIRS.includes(entry)) continue;
           const fullPath = join(dir, entry);
           if (statSync(fullPath).isDirectory()) {
             findMdFiles(fullPath);
-          } else if (entry.endsWith('.md')) {
+          } else if (entry.endsWith(".md")) {
             allFiles.push(fullPath);
           }
         }
       }
-      
+
       findMdFiles(TEST_DIR);
       expect(allFiles.length).toBe(1);  // Only root.md, not the one in node_modules
     });
 
-    it('handles .mdx files', () => {
-      writeFileSync(join(TEST_DIR, 'component.mdx'), '# MDX Component');
-      
-      const { readdirSync } = require('node:fs');
-      const files = readdirSync(TEST_DIR).filter((f: string) => 
-        f.endsWith('.md') || f.endsWith('.mdx')
+    it("handles .mdx files", () => {
+      writeFileSync(join(TEST_DIR, "component.mdx"), "# MDX Component");
+
+      const { readdirSync } = require("node:fs");
+      const files = readdirSync(TEST_DIR).filter((f: string) =>
+        f.endsWith(".md") || f.endsWith(".mdx")
       );
-      
-      expect(files).toContain('component.mdx');
+
+      expect(files).toContain("component.mdx");
     });
   });
 
-  describe('metadata generation', () => {
-    it('generates correct metadata structure', () => {
-      writeFileSync(join(TEST_DIR, 'file1.md'), 'a'.repeat(100));
-      writeFileSync(join(TEST_DIR, 'file2.md'), 'b'.repeat(200));
-      
+  describe("metadata generation", () => {
+    it("generates correct metadata structure", () => {
+      writeFileSync(join(TEST_DIR, "file1.md"), "a".repeat(100));
+      writeFileSync(join(TEST_DIR, "file2.md"), "b".repeat(200));
+
       const metadata = {
         generatedAt: new Date().toISOString(),
         totalTokens: 75,  // 25 + 50
         totalFiles: 2,
         files: {
-          'file1.md': { tokens: 25, characters: 100, lines: 1, lastUpdated: new Date().toISOString() },
-          'file2.md': { tokens: 50, characters: 200, lines: 1, lastUpdated: new Date().toISOString() }
+          "file1.md": { tokens: 25, characters: 100, lines: 1, lastUpdated: new Date().toISOString() },
+          "file2.md": { tokens: 50, characters: 200, lines: 1, lastUpdated: new Date().toISOString() }
         }
       };
-      
+
       expect(metadata.totalFiles).toBe(2);
       expect(metadata.totalTokens).toBe(75);
       expect(Object.keys(metadata.files).length).toBe(2);
     });
 
-    it('uses forward slashes for paths', () => {
-      const windowsPath = 'docs\\guide\\file.md';
-      const normalized = windowsPath.replace(/\\/g, '/');
-      
-      expect(normalized).toBe('docs/guide/file.md');
+    it("uses forward slashes for paths", () => {
+      const windowsPath = "docs\\guide\\file.md";
+      const normalized = windowsPath.replace(/\\/g, "/");
+
+      expect(normalized).toBe("docs/guide/file.md");
     });
   });
 
-  describe('output formats', () => {
-    it('generates valid JSON output', () => {
+  describe("output formats", () => {
+    it("generates valid JSON output", () => {
       const metadata = {
-        generatedAt: '2024-01-01T00:00:00.000Z',
+        generatedAt: "2024-01-01T00:00:00.000Z",
         totalTokens: 100,
         totalFiles: 5,
         files: {}
       };
-      
+
       const json = JSON.stringify(metadata, null, 2);
       const parsed = JSON.parse(json);
-      
+
       expect(parsed.totalTokens).toBe(100);
       expect(parsed.totalFiles).toBe(5);
     });
 
-    it('sorts files by token count in summary', () => {
+    it("sorts files by token count in summary", () => {
       const files = {
-        'small.md': { tokens: 10 },
-        'large.md': { tokens: 100 },
-        'medium.md': { tokens: 50 }
+        "small.md": { tokens: 10 },
+        "large.md": { tokens: 100 },
+        "medium.md": { tokens: 50 }
       };
-      
+
       const sorted = Object.entries(files)
         .sort(([, a], [, b]) => b.tokens - a.tokens);
-      
-      expect(sorted[0][0]).toBe('large.md');
-      expect(sorted[1][0]).toBe('medium.md');
-      expect(sorted[2][0]).toBe('small.md');
+
+      expect(sorted[0][0]).toBe("large.md");
+      expect(sorted[1][0]).toBe("medium.md");
+      expect(sorted[2][0]).toBe("small.md");
     });
   });
 
-  describe('file writing', () => {
-    it('writes metadata to specified output path', () => {
-      const outputPath = join(TEST_DIR, 'token-metadata.json');
+  describe("file writing", () => {
+    it("writes metadata to specified output path", () => {
+      const outputPath = join(TEST_DIR, "token-metadata.json");
       const metadata = { totalTokens: 100, totalFiles: 5 };
-      
+
       writeFileSync(outputPath, JSON.stringify(metadata, null, 2));
-      
-      const written = JSON.parse(readFileSync(outputPath, 'utf-8'));
+
+      const written = JSON.parse(readFileSync(outputPath, "utf-8"));
       expect(written.totalTokens).toBe(100);
     });
 
-    it('handles absolute paths', () => {
-      const { isAbsolute } = require('node:path');
-      const isWindows = process.platform === 'win32';
-      
-      expect(isAbsolute('/absolute/path')).toBe(true);
+    it("handles absolute paths", () => {
+      const { isAbsolute } = require("node:path");
+      const isWindows = process.platform === "win32";
+
+      expect(isAbsolute("/absolute/path")).toBe(true);
       // Windows-style paths are only absolute on Windows
       if (isWindows) {
-        expect(isAbsolute('C:\\absolute\\path')).toBe(true);
+        expect(isAbsolute("C:\\absolute\\path")).toBe(true);
       }
-      expect(isAbsolute('relative/path')).toBe(false);
+      expect(isAbsolute("relative/path")).toBe(false);
     });
   });
 });

--- a/scripts/src/tokens/__tests__/integration/check.integration.test.ts
+++ b/scripts/src/tokens/__tests__/integration/check.integration.test.ts
@@ -2,23 +2,25 @@
  * Integration tests for check command - actual command execution
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { join } from 'node:path';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
-import { check } from '../../commands/check.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "node:path";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { check } from "../../commands/check.js";
 
-const TEST_DIR = join(process.cwd(), '__integration_check__');
+const TEST_DIR = join(process.cwd(), "__integration_check__");
 
-describe('check command integration', () => {
+describe("check command integration", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
-  
+
   beforeEach(() => {
     // Clean and create test directory structure
     try {
       rmSync(TEST_DIR, { recursive: true, force: true });
-    } catch {}
-    mkdirSync(join(TEST_DIR, '.github', 'skills'), { recursive: true });
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    } catch {
+      // Ignore clean up errors in tests
+    }
+    mkdirSync(join(TEST_DIR, ".github", "skills"), { recursive: true });
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { });
   });
 
   afterEach(async () => {
@@ -26,67 +28,67 @@ describe('check command integration', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
     try {
       rmSync(TEST_DIR, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    } catch (err) {
+    } catch {
       // Ignore cleanup errors in tests
     }
     consoleSpy.mockRestore();
   });
 
-  it('validates files against token limits', () => {
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'SKILL.md'), 'a'.repeat(100));
-    
+  it("validates files against token limits", () => {
+    writeFileSync(join(TEST_DIR, ".github", "skills", "SKILL.md"), "a".repeat(100));
+
     check(TEST_DIR, []);
-    
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Token Limit Check'));
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Token Limit Check"));
   });
 
-  it('detects files exceeding limits', () => {
+  it("detects files exceeding limits", () => {
     // Create file that exceeds 500 token SKILL.md limit
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'SKILL.md'), 'a'.repeat(2500)); // 625 tokens > 500 limit
-    
+    writeFileSync(join(TEST_DIR, ".github", "skills", "SKILL.md"), "a".repeat(2500)); // 625 tokens > 500 limit
+
     check(TEST_DIR, []);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
-    expect(output).toContain('exceeding');
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
+    expect(output).toContain("exceeding");
   });
 
-  it('outputs markdown format when --markdown flag is provided', () => {
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'test.md'), 'test');
-    
-    check(TEST_DIR, ['--markdown']);
-    
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('## 📊 Token Limit Check Report'));
+  it("outputs markdown format when --markdown flag is provided", () => {
+    writeFileSync(join(TEST_DIR, ".github", "skills", "test.md"), "test");
+
+    check(TEST_DIR, ["--markdown"]);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("## 📊 Token Limit Check Report"));
   });
 
-  it('outputs JSON when --json flag is provided', () => {
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'test.md'), 'test');
-    
-    check(TEST_DIR, ['--json']);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
+  it("outputs JSON when --json flag is provided", () => {
+    writeFileSync(join(TEST_DIR, ".github", "skills", "test.md"), "test");
+
+    check(TEST_DIR, ["--json"]);
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
     expect(() => JSON.parse(output)).not.toThrow();
   });
 
-  it('checks specific files when provided as arguments', () => {
-    const testFile = join(TEST_DIR, '.github', 'skills', 'specific.md');
-    writeFileSync(testFile, 'specific content');
-    
+  it("checks specific files when provided as arguments", () => {
+    const testFile = join(TEST_DIR, ".github", "skills", "specific.md");
+    writeFileSync(testFile, "specific content");
+
     check(TEST_DIR, [testFile]);
-    
+
     expect(consoleSpy).toHaveBeenCalled();
   });
 
-  it('loads custom config from .token-limits.json', () => {
+  it("loads custom config from .token-limits.json", () => {
     const config = {
-      defaults: { '*.md': 10 },
+      defaults: { "*.md": 10 },
       overrides: {}
     };
-    writeFileSync(join(TEST_DIR, '.token-limits.json'), JSON.stringify(config));
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'test.md'), 'a'.repeat(100)); // Will exceed 10 token limit
-    
+    writeFileSync(join(TEST_DIR, ".token-limits.json"), JSON.stringify(config));
+    writeFileSync(join(TEST_DIR, ".github", "skills", "test.md"), "a".repeat(100)); // Will exceed 10 token limit
+
     check(TEST_DIR, []);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
-    expect(output).toContain('exceeding');
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
+    expect(output).toContain("exceeding");
   });
 });

--- a/scripts/src/tokens/__tests__/integration/cli.integration.test.ts
+++ b/scripts/src/tokens/__tests__/integration/cli.integration.test.ts
@@ -2,15 +2,15 @@
  * Integration tests for CLI - command routing
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 
-describe('CLI integration', () => {
-  it('imports successfully', async () => {
+describe("CLI integration", () => {
+  it("imports successfully", async () => {
     // Verify all commands can be imported
-    const { count } = await import('../../commands/count.js');
-    const { check } = await import('../../commands/check.js');
-    const { suggest } = await import('../../commands/suggest.js');
-    const { compare } = await import('../../commands/compare.js');
+    const { count } = await import("../../commands/count.js");
+    const { check } = await import("../../commands/check.js");
+    const { suggest } = await import("../../commands/suggest.js");
+    const { compare } = await import("../../commands/compare.js");
     
     expect(count).toBeDefined();
     expect(check).toBeDefined();

--- a/scripts/src/tokens/__tests__/integration/compare.integration.test.ts
+++ b/scripts/src/tokens/__tests__/integration/compare.integration.test.ts
@@ -2,27 +2,27 @@
  * Integration tests for compare command - actual command execution
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { join } from 'node:path';
-import { mkdirSync, writeFileSync, rmSync, existsSync } from 'node:fs';
-import { execSync } from 'node:child_process';
-import { compare } from '../../commands/compare.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "node:path";
+import { mkdirSync, writeFileSync, rmSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { compare } from "../../commands/compare.js";
 
-const TEST_DIR = join(process.cwd(), '__integration_compare__');
+const TEST_DIR = join(process.cwd(), "__integration_compare__");
 
-describe('compare command integration', () => {
+describe("compare command integration", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
-  
+
   beforeEach(() => {
     // Create test directory structure
-    mkdirSync(join(TEST_DIR, '.github', 'skills'), { recursive: true });
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    
+    mkdirSync(join(TEST_DIR, ".github", "skills"), { recursive: true });
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { });
+
     // Initialize git repo if not already
     try {
-      execSync('git init', { cwd: TEST_DIR, stdio: 'pipe' });
-      execSync('git config user.email "test@example.com"', { cwd: TEST_DIR, stdio: 'pipe' });
-      execSync('git config user.name "Test User"', { cwd: TEST_DIR, stdio: 'pipe' });
+      execSync("git init", { cwd: TEST_DIR, stdio: "pipe" });
+      execSync('git config user.email "test@example.com"', { cwd: TEST_DIR, stdio: "pipe" });
+      execSync('git config user.name "Test User"', { cwd: TEST_DIR, stdio: "pipe" });
     } catch {
       // Already initialized or git not available
     }
@@ -33,74 +33,74 @@ describe('compare command integration', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
     try {
       rmSync(TEST_DIR, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    } catch (err) {
+    } catch {
       // Ignore cleanup errors in tests
     }
     consoleSpy.mockRestore();
   });
 
-  it('compares tokens between refs', () => {
+  it("compares tokens between refs", () => {
     // Create initial file and commit
-    const testFile = join(TEST_DIR, '.github', 'skills', 'test.md');
-    writeFileSync(testFile, 'initial content');
-    
+    const testFile = join(TEST_DIR, ".github", "skills", "test.md");
+    writeFileSync(testFile, "initial content");
+
     try {
-      execSync('git add .', { cwd: TEST_DIR, stdio: 'pipe' });
-      execSync('git commit -m "initial"', { cwd: TEST_DIR, stdio: 'pipe' });
-      
+      execSync("git add .", { cwd: TEST_DIR, stdio: "pipe" });
+      execSync('git commit -m "initial"', { cwd: TEST_DIR, stdio: "pipe" });
+
       // Modify file
-      writeFileSync(testFile, 'modified content with more text');
-      
+      writeFileSync(testFile, "modified content with more text");
+
       compare(TEST_DIR, []);
-      
-      const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
-      expect(output).toContain('TOKEN CHANGE REPORT');
+
+      const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
+      expect(output).toContain("TOKEN CHANGE REPORT");
     } catch {
       // Git operations might fail in test environment, that's ok
       expect(true).toBe(true);
     }
   });
 
-  it('outputs markdown format when --markdown flag is provided', () => {
-    compare(TEST_DIR, ['--markdown']);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
-    expect(output).toContain('## 📊 Token Change Report');
+  it("outputs markdown format when --markdown flag is provided", () => {
+    compare(TEST_DIR, ["--markdown"]);
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
+    expect(output).toContain("## 📊 Token Change Report");
   });
 
-  it('outputs JSON when --json flag is provided', () => {
-    compare(TEST_DIR, ['--json']);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
+  it("outputs JSON when --json flag is provided", () => {
+    compare(TEST_DIR, ["--json"]);
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
     expect(() => JSON.parse(output)).not.toThrow();
   });
 
-  it('compares with custom base ref', () => {
-    compare(TEST_DIR, ['--base', 'HEAD~1']);
-    
+  it("compares with custom base ref", () => {
+    compare(TEST_DIR, ["--base", "HEAD~1"]);
+
     expect(consoleSpy).toHaveBeenCalled();
   });
 
-  it('compares with custom head ref', () => {
-    compare(TEST_DIR, ['--head', 'HEAD']);
-    
+  it("compares with custom head ref", () => {
+    compare(TEST_DIR, ["--head", "HEAD"]);
+
     expect(consoleSpy).toHaveBeenCalled();
   });
 
-  it('scans all files when --all flag is provided', () => {
-    if (existsSync(join(TEST_DIR, '.github', 'skills'))) {
-      writeFileSync(join(TEST_DIR, '.github', 'skills', 'test.md'), 'test');
+  it("scans all files when --all flag is provided", () => {
+    if (existsSync(join(TEST_DIR, ".github", "skills"))) {
+      writeFileSync(join(TEST_DIR, ".github", "skills", "test.md"), "test");
     }
-    
-    compare(TEST_DIR, ['--all']);
-    
+
+    compare(TEST_DIR, ["--all"]);
+
     expect(consoleSpy).toHaveBeenCalled();
   });
 
-  it('validates git ref format', () => {
+  it("validates git ref format", () => {
     // This will attempt to use the ref, git will reject invalid ones
-    compare(TEST_DIR, ['--base', 'main']);
-    
+    compare(TEST_DIR, ["--base", "main"]);
+
     // Should not crash with shell injection attempts
     expect(consoleSpy).toHaveBeenCalled();
   });

--- a/scripts/src/tokens/__tests__/integration/count.integration.test.ts
+++ b/scripts/src/tokens/__tests__/integration/count.integration.test.ts
@@ -2,26 +2,28 @@
  * Integration tests for count command - actual command execution
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { join } from 'node:path';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
-import { count } from '../../commands/count.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "node:path";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { count } from "../../commands/count.js";
 
-const TEST_DIR = join(process.cwd(), '__integration_count__');
+const TEST_DIR = join(process.cwd(), "__integration_count__");
 
-describe('count command integration', () => {
+describe("count command integration", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
-  
+
   beforeEach(() => {
     // Clean and create test directory structure
     try {
       rmSync(TEST_DIR, { recursive: true, force: true });
-    } catch {}
-    mkdirSync(join(TEST_DIR, '.github', 'skills'), { recursive: true });
-    mkdirSync(join(TEST_DIR, 'plugin', 'skills'), { recursive: true });
-    
+    } catch {
+      // Ignore clean up errors in tests
+    }
+    mkdirSync(join(TEST_DIR, ".github", "skills"), { recursive: true });
+    mkdirSync(join(TEST_DIR, "plugin", "skills"), { recursive: true });
+
     // Spy on console.log to capture output
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { });
   });
 
   afterEach(async () => {
@@ -29,60 +31,60 @@ describe('count command integration', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
     try {
       rmSync(TEST_DIR, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    } catch (err) {
+    } catch {
       // Ignore cleanup errors in tests
     }
     consoleSpy.mockRestore();
   });
 
-  it('counts tokens in default directories', () => {
+  it("counts tokens in default directories", () => {
     // Create test files
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'test.md'), 'a'.repeat(400)); // 100 tokens
-    writeFileSync(join(TEST_DIR, 'plugin', 'skills', 'another.md'), 'b'.repeat(800)); // 200 tokens
-    
+    writeFileSync(join(TEST_DIR, ".github", "skills", "test.md"), "a".repeat(400)); // 100 tokens
+    writeFileSync(join(TEST_DIR, "plugin", "skills", "another.md"), "b".repeat(800)); // 200 tokens
+
     count(TEST_DIR, []);
-    
+
     // Verify console output
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Token Count Summary'));
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Total Files'));
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Total Tokens'));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Token Count Summary"));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Total Files"));
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Total Tokens"));
   });
 
-  it('generates JSON output when --json flag is provided', () => {
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'test.md'), 'test content');
-    
-    count(TEST_DIR, ['--json']);
-    
+  it("generates JSON output when --json flag is provided", () => {
+    writeFileSync(join(TEST_DIR, ".github", "skills", "test.md"), "test content");
+
+    count(TEST_DIR, ["--json"]);
+
     // Should output JSON
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
     expect(() => JSON.parse(output)).not.toThrow();
   });
 
-  it('writes to output file when --output is specified', () => {
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'test.md'), 'test');
-    const outputPath = join(TEST_DIR, 'output.json');
-    
-    count(TEST_DIR, ['--output', outputPath]);
-    
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Token metadata written'));
+  it("writes to output file when --output is specified", () => {
+    writeFileSync(join(TEST_DIR, ".github", "skills", "test.md"), "test");
+    const outputPath = join(TEST_DIR, "output.json");
+
+    count(TEST_DIR, ["--output", outputPath]);
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Token metadata written"));
   });
 
-  it('rejects output paths outside repository', () => {
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  it("rejects output paths outside repository", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => { });
     const originalExitCode = process.exitCode;
-    
-    count(TEST_DIR, ['--output', '/etc/passwd']);
-    
+
+    count(TEST_DIR, ["--output", "/etc/passwd"]);
+
     expect(process.exitCode).toBe(1);
-    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('must be within the repository'));
-    
+    expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("must be within the repository"));
+
     process.exitCode = originalExitCode;
     errorSpy.mockRestore();
   });
 
-  it('handles empty directories gracefully', () => {
+  it("handles empty directories gracefully", () => {
     count(TEST_DIR, []);
-    
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Token Count Summary'));
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Token Count Summary"));
   });
 });

--- a/scripts/src/tokens/__tests__/integration/suggest.integration.test.ts
+++ b/scripts/src/tokens/__tests__/integration/suggest.integration.test.ts
@@ -2,23 +2,25 @@
  * Integration tests for suggest command - actual command execution
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { join } from 'node:path';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
-import { suggest } from '../../commands/suggest.js';
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { join } from "node:path";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { suggest } from "../../commands/suggest.js";
 
-const TEST_DIR = join(process.cwd(), '__integration_suggest__');
+const TEST_DIR = join(process.cwd(), "__integration_suggest__");
 
-describe('suggest command integration', () => {
+describe("suggest command integration", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
-  
+
   beforeEach(() => {
     // Clean and create test directory structure
     try {
       rmSync(TEST_DIR, { recursive: true, force: true });
-    } catch {}
-    mkdirSync(join(TEST_DIR, '.github', 'skills'), { recursive: true });
-    consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    } catch {
+      // Ignore clean up errors in tests
+    }
+    mkdirSync(join(TEST_DIR, ".github", "skills"), { recursive: true });
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => { });
   });
 
   afterEach(async () => {
@@ -26,86 +28,86 @@ describe('suggest command integration', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
     try {
       rmSync(TEST_DIR, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    } catch (err) {
+    } catch {
       // Ignore cleanup errors in tests
     }
     consoleSpy.mockRestore();
   });
 
-  it('analyzes files and provides suggestions', () => {
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'test.md'), 'In order to test this file');
-    
+  it("analyzes files and provides suggestions", () => {
+    writeFileSync(join(TEST_DIR, ".github", "skills", "test.md"), "In order to test this file");
+
     suggest(TEST_DIR, []);
-    
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Analyzing'));
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Analyzing"));
   });
 
-  it('detects verbose phrases', () => {
-    const verboseContent = 'In order to complete this task, due to the fact that we need it.';
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'verbose.md'), verboseContent);
-    
-    suggest(TEST_DIR, [join(TEST_DIR, '.github', 'skills', 'verbose.md')]);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
-    expect(output).toContain('Verbose');
+  it("detects verbose phrases", () => {
+    const verboseContent = "In order to complete this task, due to the fact that we need it.";
+    writeFileSync(join(TEST_DIR, ".github", "skills", "verbose.md"), verboseContent);
+
+    suggest(TEST_DIR, [join(TEST_DIR, ".github", "skills", "verbose.md")]);
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
+    expect(output).toContain("Verbose");
   });
 
-  it('detects excessive emojis', () => {
-    const emojiContent = '🎉🎊🎈🎁 Welcome to our project! 🚀✨💫';
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'emoji.md'), emojiContent);
-    
-    suggest(TEST_DIR, [join(TEST_DIR, '.github', 'skills', 'emoji.md')]);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
-    expect(output).toContain('emoji');
+  it("detects excessive emojis", () => {
+    const emojiContent = "🎉🎊🎈🎁 Welcome to our project! 🚀✨💫";
+    writeFileSync(join(TEST_DIR, ".github", "skills", "emoji.md"), emojiContent);
+
+    suggest(TEST_DIR, [join(TEST_DIR, ".github", "skills", "emoji.md")]);
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
+    expect(output).toContain("emoji");
   });
 
-  it('detects large code blocks', () => {
-    const largeCodeBlock = '```javascript\n' + 'const x = 1;\n'.repeat(15) + '```';
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'code.md'), largeCodeBlock);
-    
-    suggest(TEST_DIR, [join(TEST_DIR, '.github', 'skills', 'code.md')]);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
-    expect(output).toContain('code block');
+  it("detects large code blocks", () => {
+    const largeCodeBlock = "```javascript\n" + "const x = 1;\n".repeat(15) + "```";
+    writeFileSync(join(TEST_DIR, ".github", "skills", "code.md"), largeCodeBlock);
+
+    suggest(TEST_DIR, [join(TEST_DIR, ".github", "skills", "code.md")]);
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
+    expect(output).toContain("code block");
   });
 
-  it('prioritizes files exceeding limits', () => {
+  it("prioritizes files exceeding limits", () => {
     // Create file under limit with suggestions
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'good.md'), 'In order to be brief');
+    writeFileSync(join(TEST_DIR, ".github", "skills", "good.md"), "In order to be brief");
     // Create file over limit
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'SKILL.md'), 'a'.repeat(2500)); // >500 limit
-    
+    writeFileSync(join(TEST_DIR, ".github", "skills", "SKILL.md"), "a".repeat(2500)); // >500 limit
+
     suggest(TEST_DIR, []);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
-    expect(output).toContain('exceeding');
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
+    expect(output).toContain("exceeding");
   });
 
-  it('shows summary for multiple files', () => {
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'file1.md'), 'In order to test');
-    writeFileSync(join(TEST_DIR, '.github', 'skills', 'file2.md'), 'Due to the fact that');
-    
+  it("shows summary for multiple files", () => {
+    writeFileSync(join(TEST_DIR, ".github", "skills", "file1.md"), "In order to test");
+    writeFileSync(join(TEST_DIR, ".github", "skills", "file2.md"), "Due to the fact that");
+
     suggest(TEST_DIR, []);
-    
-    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join('');
-    expect(output).toContain('SUMMARY');
-    expect(output).toContain('Files analyzed');
+
+    const output = consoleSpy.mock.calls.map((call: any) => call[0]).join("");
+    expect(output).toContain("SUMMARY");
+    expect(output).toContain("Files analyzed");
   });
 
-  it('handles no markdown files gracefully', () => {
+  it("handles no markdown files gracefully", () => {
     suggest(TEST_DIR, []);
-    
-    expect(consoleSpy).toHaveBeenCalledWith('No markdown files found.');
+
+    expect(consoleSpy).toHaveBeenCalledWith("No markdown files found.");
   });
 
-  it('analyzes specific target directory', () => {
-    const targetDir = join(TEST_DIR, 'custom');
+  it("analyzes specific target directory", () => {
+    const targetDir = join(TEST_DIR, "custom");
     mkdirSync(targetDir, { recursive: true });
-    writeFileSync(join(targetDir, 'test.md'), 'test content');
-    
+    writeFileSync(join(targetDir, "test.md"), "test content");
+
     suggest(TEST_DIR, [targetDir]);
-    
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('Analyzing'));
+
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("Analyzing"));
   });
 });

--- a/scripts/src/tokens/__tests__/suggest.test.ts
+++ b/scripts/src/tokens/__tests__/suggest.test.ts
@@ -2,19 +2,19 @@
  * Tests for suggest command - optimization suggestions
  */
 
-import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from 'vitest';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
-import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from "vitest";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from "node:fs";
 
-const TEST_DIR_PREFIX = join(tmpdir(), '__test_fixtures_suggest__');
+const TEST_DIR_PREFIX = join(tmpdir(), "__test_fixtures_suggest__");
 
-describe('suggest command', () => {
+describe("suggest command", () => {
   let testDir: string;
   let testRootDir: string;
   beforeAll(() => {
     testDir = mkdtempSync(TEST_DIR_PREFIX);
-    testRootDir = join(testDir, 'root');
+    testRootDir = join(testDir, "root");
   });
   beforeEach(() => {
     mkdirSync(testRootDir, { recursive: true });
@@ -24,39 +24,39 @@ describe('suggest command', () => {
     await new Promise(resolve => setTimeout(resolve, 10));
     try {
       rmSync(testRootDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    } catch (err) {
+    } catch {
       // Ignore cleanup errors in tests
     }
   });
   afterAll(() => {
     try {
       rmSync(testDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
-    } catch (err) {
+    } catch {
       // Ignore cleanup errors in tests
     }
   });
 
-  describe('emoji detection', () => {
-    it('detects decorative emojis', () => {
+  describe("emoji detection", () => {
+    it("detects decorative emojis", () => {
       const EMOJI_REGEX = /[\u{1F300}-\u{1F9FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/gu;
 
-      const textWithEmojis = '🚀 Welcome to our project! 🎉🎊🎈';
+      const textWithEmojis = "🚀 Welcome to our project! 🎉🎊🎈";
       const emojis = textWithEmojis.match(EMOJI_REGEX);
 
       expect(emojis).not.toBeNull();
       expect(emojis!.length).toBe(4);
     });
 
-    it('allows functional emojis (✅❌⚠️)', () => {
-      const content = '✅ Passed\n❌ Failed\n⚠️ Warning';
+    it("allows functional emojis (✅❌⚠️)", () => {
+      const content = "✅ Passed\n❌ Failed\n⚠️ Warning";
       // These are in the allowed range but we still detect them
       // The suggest command filters to only flag when there are > 2 emojis
-      expect(content).toContain('✅');
-      expect(content).toContain('❌');
+      expect(content).toContain("✅");
+      expect(content).toContain("❌");
     });
 
-    it('flags lines with multiple emojis', () => {
-      const line = '🎉🎊🎈 Celebration!';
+    it("flags lines with multiple emojis", () => {
+      const line = "🎉🎊🎈 Celebration!";
       const EMOJI_REGEX = /[\u{1F300}-\u{1F9FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/gu;
       const emojis = line.match(EMOJI_REGEX);
 
@@ -64,64 +64,64 @@ describe('suggest command', () => {
     });
   });
 
-  describe('verbose phrase detection', () => {
+  describe("verbose phrase detection", () => {
     const VERBOSE_PHRASES: Record<string, string> = {
-      'in order to': 'to',
-      'due to the fact that': 'because',
-      'in the event that': 'if',
-      'has the ability to': 'can',
-      'at the present time': 'now',
+      "in order to": "to",
+      "due to the fact that": "because",
+      "in the event that": "if",
+      "has the ability to": "can",
+      "at the present time": "now",
     };
 
-    it('detects common verbose phrases', () => {
-      const content = 'In order to complete this task, you need to...';
+    it("detects common verbose phrases", () => {
+      const content = "In order to complete this task, you need to...";
       const lowerContent = content.toLowerCase();
 
       const found = Object.keys(VERBOSE_PHRASES).filter(phrase =>
         lowerContent.includes(phrase)
       );
 
-      expect(found).toContain('in order to');
+      expect(found).toContain("in order to");
     });
 
-    it('suggests concise alternatives', () => {
-      expect(VERBOSE_PHRASES['in order to']).toBe('to');
-      expect(VERBOSE_PHRASES['due to the fact that']).toBe('because');
-      expect(VERBOSE_PHRASES['has the ability to']).toBe('can');
+    it("suggests concise alternatives", () => {
+      expect(VERBOSE_PHRASES["in order to"]).toBe("to");
+      expect(VERBOSE_PHRASES["due to the fact that"]).toBe("because");
+      expect(VERBOSE_PHRASES["has the ability to"]).toBe("can");
     });
 
-    it('calculates token savings', () => {
-      const verbose = 'in order to';
-      const concise = 'to';
+    it("calculates token savings", () => {
+      const verbose = "in order to";
+      const concise = "to";
       const savings = Math.ceil((verbose.length - concise.length) / 4);
 
       expect(savings).toBe(3);  // (11 - 2) / 4 = 2.25, rounded up to 3
     });
   });
 
-  describe('large code block detection', () => {
-    it('detects code blocks over 10 lines', () => {
+  describe("large code block detection", () => {
+    it("detects code blocks over 10 lines", () => {
       const lines = [
-        '```javascript',
-        'const a = 1;',
-        'const b = 2;',
-        'const c = 3;',
-        'const d = 4;',
-        'const e = 5;',
-        'const f = 6;',
-        'const g = 7;',
-        'const h = 8;',
-        'const i = 9;',
-        'const j = 10;',
-        'const k = 11;',
-        '```'
+        "```javascript",
+        "const a = 1;",
+        "const b = 2;",
+        "const c = 3;",
+        "const d = 4;",
+        "const e = 5;",
+        "const f = 6;",
+        "const g = 7;",
+        "const h = 8;",
+        "const i = 9;",
+        "const j = 10;",
+        "const k = 11;",
+        "```"
       ];
 
       let inBlock = false;
       let blockLines = 0;
 
       for (const line of lines) {
-        if (line.startsWith('```')) {
+        if (line.startsWith("```")) {
           if (!inBlock) {
             inBlock = true;
             blockLines = 0;
@@ -137,19 +137,19 @@ describe('suggest command', () => {
       expect(blockLines > 10).toBe(true);
     });
 
-    it('does not flag small code blocks', () => {
+    it("does not flag small code blocks", () => {
       const lines = [
-        '```bash',
-        'npm install',
-        'npm run build',
-        '```'
+        "```bash",
+        "npm install",
+        "npm run build",
+        "```"
       ];
 
       let blockLines = 0;
       let inBlock = false;
 
       for (const line of lines) {
-        if (line.startsWith('```')) {
+        if (line.startsWith("```")) {
           inBlock = !inBlock;
         } else if (inBlock) {
           blockLines++;
@@ -161,28 +161,28 @@ describe('suggest command', () => {
     });
   });
 
-  describe('large table detection', () => {
-    it('detects tables with more than 10 rows', () => {
+  describe("large table detection", () => {
+    it("detects tables with more than 10 rows", () => {
       const lines = [
-        '| Header 1 | Header 2 |',
-        '|----------|----------|',
-        '| Row 1 | Data |',
-        '| Row 2 | Data |',
-        '| Row 3 | Data |',
-        '| Row 4 | Data |',
-        '| Row 5 | Data |',
-        '| Row 6 | Data |',
-        '| Row 7 | Data |',
-        '| Row 8 | Data |',
-        '| Row 9 | Data |',
-        '| Row 10 | Data |',
-        '| Row 11 | Data |',
+        "| Header 1 | Header 2 |",
+        "|----------|----------|",
+        "| Row 1 | Data |",
+        "| Row 2 | Data |",
+        "| Row 3 | Data |",
+        "| Row 4 | Data |",
+        "| Row 5 | Data |",
+        "| Row 6 | Data |",
+        "| Row 7 | Data |",
+        "| Row 8 | Data |",
+        "| Row 9 | Data |",
+        "| Row 10 | Data |",
+        "| Row 11 | Data |",
       ];
 
       let tableRows = 0;
 
       for (const line of lines) {
-        const isTableRow = line.trim().startsWith('|') && line.trim().endsWith('|');
+        const isTableRow = line.trim().startsWith("|") && line.trim().endsWith("|");
         const isSeparator = /^\|[\s\-:|]+\|$/.test(line.trim());
 
         if (isTableRow && !isSeparator) {
@@ -196,8 +196,8 @@ describe('suggest command', () => {
     });
   });
 
-  describe('file analysis', () => {
-    it('calculates potential savings', () => {
+  describe("file analysis", () => {
+    it("calculates potential savings", () => {
       const suggestions = [
         { estimatedSavings: 10 },
         { estimatedSavings: 20 },
@@ -208,30 +208,30 @@ describe('suggest command', () => {
       expect(totalSavings).toBe(35);
     });
 
-    it('sorts suggestions by line number', () => {
+    it("sorts suggestions by line number", () => {
       const suggestions = [
-        { line: 50, issue: 'C' },
-        { line: 10, issue: 'A' },
-        { line: 30, issue: 'B' }
+        { line: 50, issue: "C" },
+        { line: 10, issue: "A" },
+        { line: 30, issue: "B" }
       ];
 
       suggestions.sort((a, b) => a.line - b.line);
 
-      expect(suggestions[0].issue).toBe('A');
-      expect(suggestions[1].issue).toBe('B');
-      expect(suggestions[2].issue).toBe('C');
+      expect(suggestions[0].issue).toBe("A");
+      expect(suggestions[1].issue).toBe("B");
+      expect(suggestions[2].issue).toBe("C");
     });
   });
 
-  describe('markdown file scanning', () => {
-    it('finds markdown files recursively', () => {
+  describe("markdown file scanning", () => {
+    it("finds markdown files recursively", () => {
       // Create test structure
-      writeFileSync(join(testRootDir, 'readme.md'), '# Readme');
-      mkdirSync(join(testRootDir, 'docs'), { recursive: true });
-      writeFileSync(join(testRootDir, 'docs', 'guide.md'), '# Guide');
+      writeFileSync(join(testRootDir, "readme.md"), "# Readme");
+      mkdirSync(join(testRootDir, "docs"), { recursive: true });
+      writeFileSync(join(testRootDir, "docs", "guide.md"), "# Guide");
 
       const files: string[] = [];
-      const { readdirSync } = require('node:fs');
+      const { readdirSync } = require("node:fs");
 
       function scan(dir: string) {
         const entries = readdirSync(dir, { withFileTypes: true });
@@ -239,7 +239,7 @@ describe('suggest command', () => {
           const fullPath = join(dir, entry.name);
           if (entry.isDirectory()) {
             scan(fullPath);
-          } else if (entry.name.endsWith('.md')) {
+          } else if (entry.name.endsWith(".md")) {
             files.push(fullPath);
           }
         }
@@ -250,12 +250,12 @@ describe('suggest command', () => {
       expect(files.length).toBe(2);
     });
 
-    it('excludes node_modules and .git', () => {
-      const EXCLUDED_DIRS = ['node_modules', '.git', 'dist', 'coverage'];
+    it("excludes node_modules and .git", () => {
+      const EXCLUDED_DIRS = ["node_modules", ".git", "dist", "coverage"];
 
-      expect(EXCLUDED_DIRS.includes('node_modules')).toBe(true);
-      expect(EXCLUDED_DIRS.includes('.git')).toBe(true);
-      expect(EXCLUDED_DIRS.includes('src')).toBe(false);
+      expect(EXCLUDED_DIRS.includes("node_modules")).toBe(true);
+      expect(EXCLUDED_DIRS.includes(".git")).toBe(true);
+      expect(EXCLUDED_DIRS.includes("src")).toBe(false);
     });
   });
 });

--- a/scripts/src/tokens/__tests__/types.test.ts
+++ b/scripts/src/tokens/__tests__/types.test.ts
@@ -2,7 +2,7 @@
  * Tests for shared types and utility functions
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect } from "vitest";
 import {
   estimateTokens,
   isMarkdownFile,
@@ -11,191 +11,191 @@ import {
   matchesPattern,
   EXCLUDED_DIRS,
   MARKDOWN_EXTENSIONS
-} from '../commands/types.js';
+} from "../commands/types.js";
 
-describe('estimateTokens', () => {
-  it('estimates ~4 characters per token', () => {
-    expect(estimateTokens('test')).toBe(1);      // 4 chars = 1 token
-    expect(estimateTokens('testing1')).toBe(2);  // 8 chars = 2 tokens
-    expect(estimateTokens('')).toBe(0);          // empty = 0 tokens
+describe("estimateTokens", () => {
+  it("estimates ~4 characters per token", () => {
+    expect(estimateTokens("test")).toBe(1);      // 4 chars = 1 token
+    expect(estimateTokens("testing1")).toBe(2);  // 8 chars = 2 tokens
+    expect(estimateTokens("")).toBe(0);          // empty = 0 tokens
   });
 
-  it('rounds up partial tokens', () => {
-    expect(estimateTokens('hi')).toBe(1);        // 2 chars rounds to 1
-    expect(estimateTokens('hello')).toBe(2);     // 5 chars rounds to 2
+  it("rounds up partial tokens", () => {
+    expect(estimateTokens("hi")).toBe(1);        // 2 chars rounds to 1
+    expect(estimateTokens("hello")).toBe(2);     // 5 chars rounds to 2
   });
 
-  it('handles long content', () => {
-    const content = 'a'.repeat(1000);
+  it("handles long content", () => {
+    const content = "a".repeat(1000);
     expect(estimateTokens(content)).toBe(250);   // 1000/4 = 250
   });
 
-  it('handles unicode characters', () => {
-    const emoji = '🚀🔥💡';  // Each emoji is 2+ bytes
+  it("handles unicode characters", () => {
+    const emoji = "🚀🔥💡";  // Each emoji is 2+ bytes
     const tokens = estimateTokens(emoji);
     expect(tokens).toBeGreaterThan(0);
   });
 
-  it('handles multiline content', () => {
-    const content = 'line1\nline2\nline3';
+  it("handles multiline content", () => {
+    const content = "line1\nline2\nline3";
     expect(estimateTokens(content)).toBe(5);     // 17 chars = 5 tokens (rounded up)
   });
 });
 
-describe('isMarkdownFile', () => {
-  it('returns true for .md files', () => {
-    expect(isMarkdownFile('README.md')).toBe(true);
-    expect(isMarkdownFile('path/to/file.md')).toBe(true);
-    expect(isMarkdownFile('SKILL.md')).toBe(true);
+describe("isMarkdownFile", () => {
+  it("returns true for .md files", () => {
+    expect(isMarkdownFile("README.md")).toBe(true);
+    expect(isMarkdownFile("path/to/file.md")).toBe(true);
+    expect(isMarkdownFile("SKILL.md")).toBe(true);
   });
 
-  it('returns true for .mdx files', () => {
-    expect(isMarkdownFile('component.mdx')).toBe(true);
-    expect(isMarkdownFile('path/to/doc.mdx')).toBe(true);
+  it("returns true for .mdx files", () => {
+    expect(isMarkdownFile("component.mdx")).toBe(true);
+    expect(isMarkdownFile("path/to/doc.mdx")).toBe(true);
   });
 
-  it('is case insensitive', () => {
-    expect(isMarkdownFile('README.MD')).toBe(true);
-    expect(isMarkdownFile('file.Md')).toBe(true);
-    expect(isMarkdownFile('doc.MDX')).toBe(true);
+  it("is case insensitive", () => {
+    expect(isMarkdownFile("README.MD")).toBe(true);
+    expect(isMarkdownFile("file.Md")).toBe(true);
+    expect(isMarkdownFile("doc.MDX")).toBe(true);
   });
 
-  it('returns false for non-markdown files', () => {
-    expect(isMarkdownFile('script.ts')).toBe(false);
-    expect(isMarkdownFile('package.json')).toBe(false);
-    expect(isMarkdownFile('image.png')).toBe(false);
-    expect(isMarkdownFile('readme.txt')).toBe(false);
+  it("returns false for non-markdown files", () => {
+    expect(isMarkdownFile("script.ts")).toBe(false);
+    expect(isMarkdownFile("package.json")).toBe(false);
+    expect(isMarkdownFile("image.png")).toBe(false);
+    expect(isMarkdownFile("readme.txt")).toBe(false);
   });
 
-  it('returns false for files without extension', () => {
-    expect(isMarkdownFile('Makefile')).toBe(false);
-    expect(isMarkdownFile('LICENSE')).toBe(false);
+  it("returns false for files without extension", () => {
+    expect(isMarkdownFile("Makefile")).toBe(false);
+    expect(isMarkdownFile("LICENSE")).toBe(false);
   });
 
-  it('handles edge cases', () => {
-    expect(isMarkdownFile('.md')).toBe(false);   // Just extension - no filename
-    expect(isMarkdownFile('file.md.bak')).toBe(false);  // Wrong ending
-  });
-});
-
-describe('normalizePath', () => {
-  it('converts backslashes to forward slashes', () => {
-    expect(normalizePath('path\\to\\file.md')).toBe('path/to/file.md');
-    expect(normalizePath('C:\\Users\\test')).toBe('C:/Users/test');
-  });
-
-  it('leaves forward slashes unchanged', () => {
-    expect(normalizePath('path/to/file.md')).toBe('path/to/file.md');
-  });
-
-  it('handles mixed slashes', () => {
-    expect(normalizePath('path\\to/mixed\\file.md')).toBe('path/to/mixed/file.md');
-  });
-
-  it('handles empty string', () => {
-    expect(normalizePath('')).toBe('');
-  });
-
-  it('handles paths with no slashes', () => {
-    expect(normalizePath('file.md')).toBe('file.md');
+  it("handles edge cases", () => {
+    expect(isMarkdownFile(".md")).toBe(false);   // Just extension - no filename
+    expect(isMarkdownFile("file.md.bak")).toBe(false);  // Wrong ending
   });
 });
 
-describe('EXCLUDED_DIRS', () => {
-  it('contains common directories to exclude', () => {
-    expect(EXCLUDED_DIRS).toContain('node_modules');
-    expect(EXCLUDED_DIRS).toContain('.git');
-    expect(EXCLUDED_DIRS).toContain('dist');
-    expect(EXCLUDED_DIRS).toContain('coverage');
+describe("normalizePath", () => {
+  it("converts backslashes to forward slashes", () => {
+    expect(normalizePath("path\\to\\file.md")).toBe("path/to/file.md");
+    expect(normalizePath("C:\\Users\\test")).toBe("C:/Users/test");
   });
 
-  it('is a readonly array', () => {
+  it("leaves forward slashes unchanged", () => {
+    expect(normalizePath("path/to/file.md")).toBe("path/to/file.md");
+  });
+
+  it("handles mixed slashes", () => {
+    expect(normalizePath("path\\to/mixed\\file.md")).toBe("path/to/mixed/file.md");
+  });
+
+  it("handles empty string", () => {
+    expect(normalizePath("")).toBe("");
+  });
+
+  it("handles paths with no slashes", () => {
+    expect(normalizePath("file.md")).toBe("file.md");
+  });
+});
+
+describe("EXCLUDED_DIRS", () => {
+  it("contains common directories to exclude", () => {
+    expect(EXCLUDED_DIRS).toContain("node_modules");
+    expect(EXCLUDED_DIRS).toContain(".git");
+    expect(EXCLUDED_DIRS).toContain("dist");
+    expect(EXCLUDED_DIRS).toContain("coverage");
+  });
+
+  it("is a readonly array", () => {
     expect(Array.isArray(EXCLUDED_DIRS)).toBe(true);
     expect(EXCLUDED_DIRS.length).toBe(4);
   });
 });
 
-describe('MARKDOWN_EXTENSIONS', () => {
-  it('contains expected extensions', () => {
-    expect(MARKDOWN_EXTENSIONS).toContain('.md');
-    expect(MARKDOWN_EXTENSIONS).toContain('.mdx');
+describe("MARKDOWN_EXTENSIONS", () => {
+  it("contains expected extensions", () => {
+    expect(MARKDOWN_EXTENSIONS).toContain(".md");
+    expect(MARKDOWN_EXTENSIONS).toContain(".mdx");
   });
 
-  it('has correct length', () => {
+  it("has correct length", () => {
     expect(MARKDOWN_EXTENSIONS.length).toBe(2);
   });
 });
 
-describe('getErrorMessage', () => {
-  it('extracts message from Error instances', () => {
-    const error = new Error('Test error message');
-    expect(getErrorMessage(error)).toBe('Test error message');
+describe("getErrorMessage", () => {
+  it("extracts message from Error instances", () => {
+    const error = new Error("Test error message");
+    expect(getErrorMessage(error)).toBe("Test error message");
   });
 
-  it('handles Error with empty message', () => {
-    const error = new Error('');
-    expect(getErrorMessage(error)).toBe('');
+  it("handles Error with empty message", () => {
+    const error = new Error("");
+    expect(getErrorMessage(error)).toBe("");
   });
 
-  it('converts string errors to strings', () => {
-    expect(getErrorMessage('String error')).toBe('String error');
+  it("converts string errors to strings", () => {
+    expect(getErrorMessage("String error")).toBe("String error");
   });
 
-  it('converts number errors to strings', () => {
-    expect(getErrorMessage(404)).toBe('404');
+  it("converts number errors to strings", () => {
+    expect(getErrorMessage(404)).toBe("404");
   });
 
-  it('converts null to string', () => {
-    expect(getErrorMessage(null)).toBe('null');
+  it("converts null to string", () => {
+    expect(getErrorMessage(null)).toBe("null");
   });
 
-  it('converts undefined to string', () => {
-    expect(getErrorMessage(undefined)).toBe('undefined');
+  it("converts undefined to string", () => {
+    expect(getErrorMessage(undefined)).toBe("undefined");
   });
 
-  it('converts object errors to strings', () => {
-    expect(getErrorMessage({ code: 'ERR_UNKNOWN' })).toBe('[object Object]');
+  it("converts object errors to strings", () => {
+    expect(getErrorMessage({ code: "ERR_UNKNOWN" })).toBe("[object Object]");
   });
 
-  it('handles custom error classes', () => {
+  it("handles custom error classes", () => {
     class CustomError extends Error {
       constructor(message: string) {
         super(message);
-        this.name = 'CustomError';
+        this.name = "CustomError";
       }
     }
-    const error = new CustomError('Custom error');
-    expect(getErrorMessage(error)).toBe('Custom error');
+    const error = new CustomError("Custom error");
+    expect(getErrorMessage(error)).toBe("Custom error");
   });
 });
 
-describe('matchesPattern', () => {
-  it('matches simple filename patterns', () => {
-    expect(matchesPattern('SKILL.md', 'SKILL.md')).toBe(true);
-    expect(matchesPattern('path/to/SKILL.md', 'SKILL.md')).toBe(true);
-    expect(matchesPattern('README.md', 'SKILL.md')).toBe(false);
+describe("matchesPattern", () => {
+  it("matches simple filename patterns", () => {
+    expect(matchesPattern("SKILL.md", "SKILL.md")).toBe(true);
+    expect(matchesPattern("path/to/SKILL.md", "SKILL.md")).toBe(true);
+    expect(matchesPattern("README.md", "SKILL.md")).toBe(false);
   });
 
-  it('matches wildcard patterns', () => {
-    expect(matchesPattern('README.md', '*.md')).toBe(true);
-    expect(matchesPattern('path/README.md', '**/*.md')).toBe(true);
-    expect(matchesPattern('random.md', '*.md')).toBe(true);
-    expect(matchesPattern('file.txt', '*.md')).toBe(false);
+  it("matches wildcard patterns", () => {
+    expect(matchesPattern("README.md", "*.md")).toBe(true);
+    expect(matchesPattern("path/README.md", "**/*.md")).toBe(true);
+    expect(matchesPattern("random.md", "*.md")).toBe(true);
+    expect(matchesPattern("file.txt", "*.md")).toBe(false);
   });
 
-  it('matches globstar patterns', () => {
+  it("matches globstar patterns", () => {
     // Note: references/**/*.md requires at least one directory between references and file
-    expect(matchesPattern('references/sub/file.md', 'references/**/*.md')).toBe(true);
-    expect(matchesPattern('other/file.md', 'references/**/*.md')).toBe(false);
+    expect(matchesPattern("references/sub/file.md", "references/**/*.md")).toBe(true);
+    expect(matchesPattern("other/file.md", "references/**/*.md")).toBe(false);
   });
 
-  it('normalizes path separators', () => {
-    expect(matchesPattern('path\\to\\SKILL.md', 'SKILL.md')).toBe(true);
-    expect(matchesPattern('references\\sub\\file.md', 'references/**/*.md')).toBe(true);
+  it("normalizes path separators", () => {
+    expect(matchesPattern("path\\to\\SKILL.md", "SKILL.md")).toBe(true);
+    expect(matchesPattern("references\\sub\\file.md", "references/**/*.md")).toBe(true);
   });
 
-  it('handles paths without leading slash', () => {
-    expect(matchesPattern('SKILL.md', 'SKILL.md')).toBe(true);
-    expect(matchesPattern('plugin/skills/SKILL.md', 'SKILL.md')).toBe(true);
+  it("handles paths without leading slash", () => {
+    expect(matchesPattern("SKILL.md", "SKILL.md")).toBe(true);
+    expect(matchesPattern("plugin/skills/SKILL.md", "SKILL.md")).toBe(true);
   });
 });

--- a/scripts/src/tokens/__tests__/utils.test.ts
+++ b/scripts/src/tokens/__tests__/utils.test.ts
@@ -2,200 +2,200 @@
  * Tests for utility functions in utils.ts
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from 'node:fs';
-import { join } from 'node:path';
-import { tmpdir } from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import {
   loadConfig,
   getLimitForFile,
   findMarkdownFiles
-} from '../commands/utils.js';
-import type { TokenLimitsConfig } from '../commands/types.js';
+} from "../commands/utils.js";
+import type { TokenLimitsConfig } from "../commands/types.js";
 
-describe('loadConfig', () => {
-  let TEST_DIR = '';
+describe("loadConfig", () => {
+  let TEST_DIR = "";
 
   beforeEach(() => {
-    TEST_DIR = mkdtempSync(join(tmpdir(), 'utils-test-'));
+    TEST_DIR = mkdtempSync(join(tmpdir(), "utils-test-"));
   });
 
   afterEach(() => {
     if (TEST_DIR) {
       rmSync(TEST_DIR, { recursive: true, force: true });
-      TEST_DIR = '';
+      TEST_DIR = "";
     }
   });
 
-  it('returns defaults when no config file exists', () => {
+  it("returns defaults when no config file exists", () => {
     const config = loadConfig(TEST_DIR);
     expect(config.defaults).toBeDefined();
-    expect(config.defaults['*.md']).toBeDefined();
+    expect(config.defaults["*.md"]).toBeDefined();
   });
 
-  it('loads valid configuration file', () => {
+  it("loads valid configuration file", () => {
     const testConfig = {
-      description: 'Test config',
+      description: "Test config",
       defaults: {
-        '*.md': 1500,
-        'SKILL.md': 3000
+        "*.md": 1500,
+        "SKILL.md": 3000
       },
       overrides: {
-        'special.md': 5000
+        "special.md": 5000
       }
     };
-    writeFileSync(join(TEST_DIR, '.token-limits.json'), JSON.stringify(testConfig));
+    writeFileSync(join(TEST_DIR, ".token-limits.json"), JSON.stringify(testConfig));
     
     const config = loadConfig(TEST_DIR);
-    expect(config.defaults['*.md']).toBe(1500);
-    expect(config.defaults['SKILL.md']).toBe(3000);
-    expect(config.overrides['special.md']).toBe(5000);
+    expect(config.defaults["*.md"]).toBe(1500);
+    expect(config.defaults["SKILL.md"]).toBe(3000);
+    expect(config.overrides["special.md"]).toBe(5000);
   });
 
-  it('returns defaults for invalid JSON', () => {
-    writeFileSync(join(TEST_DIR, '.token-limits.json'), 'not valid json');
+  it("returns defaults for invalid JSON", () => {
+    writeFileSync(join(TEST_DIR, ".token-limits.json"), "not valid json");
     
     const config = loadConfig(TEST_DIR);
     expect(config.defaults).toBeDefined();
-    expect(config.defaults['*.md']).toBeDefined();
+    expect(config.defaults["*.md"]).toBeDefined();
   });
 
-  it('returns defaults for config missing defaults field', () => {
-    writeFileSync(join(TEST_DIR, '.token-limits.json'), JSON.stringify({ overrides: {} }));
+  it("returns defaults for config missing defaults field", () => {
+    writeFileSync(join(TEST_DIR, ".token-limits.json"), JSON.stringify({ overrides: {} }));
     
     const config = loadConfig(TEST_DIR);
     expect(config.defaults).toBeDefined();
   });
 });
 
-describe('getLimitForFile', () => {
+describe("getLimitForFile", () => {
   const mockConfig: TokenLimitsConfig = {
     defaults: {
-      '*.md': 2000,
-      'SKILL.md': 3500,
-      'references/**/*.md': 1500
+      "*.md": 2000,
+      "SKILL.md": 3500,
+      "references/**/*.md": 1500
     },
     overrides: {
-      'plugin/skills/special/SKILL.md': 5000
+      "plugin/skills/special/SKILL.md": 5000
     }
   };
 
-  it('returns override limit for exact match', () => {
-    const result = getLimitForFile('plugin/skills/special/SKILL.md', mockConfig, '/root');
+  it("returns override limit for exact match", () => {
+    const result = getLimitForFile("plugin/skills/special/SKILL.md", mockConfig, "/root");
     expect(result.limit).toBe(5000);
-    expect(result.pattern).toBe('plugin/skills/special/SKILL.md');
+    expect(result.pattern).toBe("plugin/skills/special/SKILL.md");
   });
 
-  it('returns specific pattern limit for SKILL.md files', () => {
-    const result = getLimitForFile('plugin/skills/my-skill/SKILL.md', mockConfig, '/root');
+  it("returns specific pattern limit for SKILL.md files", () => {
+    const result = getLimitForFile("plugin/skills/my-skill/SKILL.md", mockConfig, "/root");
     expect(result.limit).toBe(3500);
-    expect(result.pattern).toBe('SKILL.md');
+    expect(result.pattern).toBe("SKILL.md");
   });
 
-  it('returns globstar pattern limit for reference files', () => {
-    const result = getLimitForFile('references/sub/GUIDE.md', mockConfig, '/root');
+  it("returns globstar pattern limit for reference files", () => {
+    const result = getLimitForFile("references/sub/GUIDE.md", mockConfig, "/root");
     expect(result.limit).toBe(1500);
-    expect(result.pattern).toBe('references/**/*.md');
+    expect(result.pattern).toBe("references/**/*.md");
   });
 
-  it('returns default limit for unmatched files', () => {
-    const result = getLimitForFile('docs/README.md', mockConfig, '/root');
+  it("returns default limit for unmatched files", () => {
+    const result = getLimitForFile("docs/README.md", mockConfig, "/root");
     expect(result.limit).toBe(2000);
-    expect(result.pattern).toBe('*.md');
+    expect(result.pattern).toBe("*.md");
   });
 
-  it('handles paths with backslashes (Windows)', () => {
-    const result = getLimitForFile('plugin\\skills\\my-skill\\SKILL.md', mockConfig, '/root');
+  it("handles paths with backslashes (Windows)", () => {
+    const result = getLimitForFile("plugin\\skills\\my-skill\\SKILL.md", mockConfig, "/root");
     expect(result.limit).toBe(3500);
   });
 
-  it('applies more specific patterns over general ones', () => {
+  it("applies more specific patterns over general ones", () => {
     const configWithMultiplePatterns: TokenLimitsConfig = {
       defaults: {
-        '*.md': 2000,
-        'SKILL.md': 3500,
-        'plugin/skills/**/SKILL.md': 4000
+        "*.md": 2000,
+        "SKILL.md": 3500,
+        "plugin/skills/**/SKILL.md": 4000
       },
       overrides: {}
     };
     
-    const result = getLimitForFile('plugin/skills/my-skill/SKILL.md', configWithMultiplePatterns, '/root');
+    const result = getLimitForFile("plugin/skills/my-skill/SKILL.md", configWithMultiplePatterns, "/root");
     // SKILL.md exact filename match wins over globstar pattern due to specificity scoring
     // (no wildcards = +10000 points)
     expect(result.limit).toBe(3500);
   });
 });
 
-describe('findMarkdownFiles', () => {
-  let TEST_DIR = '';
+describe("findMarkdownFiles", () => {
+  let TEST_DIR = "";
 
   beforeEach(() => {
-    TEST_DIR = mkdtempSync(join(tmpdir(), 'find-md-test-'));
+    TEST_DIR = mkdtempSync(join(tmpdir(), "find-md-test-"));
   });
 
   afterEach(() => {
     if (TEST_DIR) {
       rmSync(TEST_DIR, { recursive: true, force: true });
-      TEST_DIR = '';
+      TEST_DIR = "";
     }
   });
 
-  it('finds markdown files in directory', () => {
-    writeFileSync(join(TEST_DIR, 'README.md'), '# Test');
-    writeFileSync(join(TEST_DIR, 'GUIDE.md'), '# Guide');
-    writeFileSync(join(TEST_DIR, 'script.ts'), 'console.log("hi")');
+  it("finds markdown files in directory", () => {
+    writeFileSync(join(TEST_DIR, "README.md"), "# Test");
+    writeFileSync(join(TEST_DIR, "GUIDE.md"), "# Guide");
+    writeFileSync(join(TEST_DIR, "script.ts"), 'console.log("hi")');
     
     const files = findMarkdownFiles(TEST_DIR);
     expect(files.length).toBe(2);
-    expect(files.some(f => f.endsWith('README.md'))).toBe(true);
-    expect(files.some(f => f.endsWith('GUIDE.md'))).toBe(true);
+    expect(files.some(f => f.endsWith("README.md"))).toBe(true);
+    expect(files.some(f => f.endsWith("GUIDE.md"))).toBe(true);
   });
 
-  it('finds .mdx files', () => {
-    writeFileSync(join(TEST_DIR, 'component.mdx'), '# MDX');
+  it("finds .mdx files", () => {
+    writeFileSync(join(TEST_DIR, "component.mdx"), "# MDX");
     
     const files = findMarkdownFiles(TEST_DIR);
     expect(files.length).toBe(1);
-    expect(files[0].endsWith('component.mdx')).toBe(true);
+    expect(files[0].endsWith("component.mdx")).toBe(true);
   });
 
-  it('searches subdirectories recursively', () => {
-    mkdirSync(join(TEST_DIR, 'sub', 'deep'), { recursive: true });
-    writeFileSync(join(TEST_DIR, 'root.md'), '# Root');
-    writeFileSync(join(TEST_DIR, 'sub', 'sub.md'), '# Sub');
-    writeFileSync(join(TEST_DIR, 'sub', 'deep', 'deep.md'), '# Deep');
+  it("searches subdirectories recursively", () => {
+    mkdirSync(join(TEST_DIR, "sub", "deep"), { recursive: true });
+    writeFileSync(join(TEST_DIR, "root.md"), "# Root");
+    writeFileSync(join(TEST_DIR, "sub", "sub.md"), "# Sub");
+    writeFileSync(join(TEST_DIR, "sub", "deep", "deep.md"), "# Deep");
     
     const files = findMarkdownFiles(TEST_DIR);
     expect(files.length).toBe(3);
   });
 
-  it('excludes node_modules directory', () => {
-    mkdirSync(join(TEST_DIR, 'node_modules'));
-    writeFileSync(join(TEST_DIR, 'README.md'), '# Test');
-    writeFileSync(join(TEST_DIR, 'node_modules', 'pkg.md'), '# Package');
+  it("excludes node_modules directory", () => {
+    mkdirSync(join(TEST_DIR, "node_modules"));
+    writeFileSync(join(TEST_DIR, "README.md"), "# Test");
+    writeFileSync(join(TEST_DIR, "node_modules", "pkg.md"), "# Package");
     
     const files = findMarkdownFiles(TEST_DIR);
     expect(files.length).toBe(1);
-    expect(files[0].endsWith('README.md')).toBe(true);
+    expect(files[0].endsWith("README.md")).toBe(true);
   });
 
-  it('excludes .git directory', () => {
-    mkdirSync(join(TEST_DIR, '.git'));
-    writeFileSync(join(TEST_DIR, 'README.md'), '# Test');
-    writeFileSync(join(TEST_DIR, '.git', 'config.md'), '# Config');
+  it("excludes .git directory", () => {
+    mkdirSync(join(TEST_DIR, ".git"));
+    writeFileSync(join(TEST_DIR, "README.md"), "# Test");
+    writeFileSync(join(TEST_DIR, ".git", "config.md"), "# Config");
     
     const files = findMarkdownFiles(TEST_DIR);
     expect(files.length).toBe(1);
   });
 
-  it('returns empty array for non-existent directory', () => {
-    const files = findMarkdownFiles(join(TEST_DIR, 'nonexistent'));
+  it("returns empty array for non-existent directory", () => {
+    const files = findMarkdownFiles(join(TEST_DIR, "nonexistent"));
     expect(files).toEqual([]);
   });
 
-  it('returns empty array for directory with no markdown files', () => {
-    writeFileSync(join(TEST_DIR, 'script.ts'), 'code');
-    writeFileSync(join(TEST_DIR, 'data.json'), '{}');
+  it("returns empty array for directory with no markdown files", () => {
+    writeFileSync(join(TEST_DIR, "script.ts"), "code");
+    writeFileSync(join(TEST_DIR, "data.json"), "{}");
     
     const files = findMarkdownFiles(TEST_DIR);
     expect(files).toEqual([]);

--- a/scripts/src/tokens/cli.ts
+++ b/scripts/src/tokens/cli.ts
@@ -12,19 +12,19 @@
  *   npm run tokens help               # Show help
  */
 
-import { dirname, resolve } from 'node:path';
-import { fileURLToPath } from 'node:url';
-import { count } from './commands/count.js';
-import { check } from './commands/check.js';
-import { compare } from './commands/compare.js';
-import { suggest } from './commands/suggest.js';
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { count } from "./commands/count.js";
+import { check } from "./commands/check.js";
+import { compare } from "./commands/compare.js";
+import { suggest } from "./commands/suggest.js";
 
-const COMMANDS = ['count', 'check', 'compare', 'suggest', 'help'] as const;
+const COMMANDS = ["count", "check", "compare", "suggest", "help"] as const;
 type Command = typeof COMMANDS[number];
 
 function getRepoRoot(): string {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
-  return resolve(scriptDir, '../../..');
+  return resolve(scriptDir, "../../..");
 }
 
 function printHelp(): void {
@@ -63,31 +63,31 @@ Examples:
 
 function main(): void {
   const args = process.argv.slice(2);
-  const command = (args[0] ?? 'help') as Command;
+  const command = (args[0] ?? "help") as Command;
   const commandArgs = args.slice(1);
   const rootDir = getRepoRoot();
 
   if (!COMMANDS.includes(command)) {
     console.error(`Unknown command: ${command}`);
-    console.error(`Available commands: ${COMMANDS.join(', ')}`);
+    console.error(`Available commands: ${COMMANDS.join(", ")}`);
     process.exitCode = 1;
     return;
   }
 
   switch (command) {
-    case 'count':
+    case "count":
       count(rootDir, commandArgs);
       break;
-    case 'check':
+    case "check":
       check(rootDir, commandArgs);
       break;
-    case 'compare':
+    case "compare":
       compare(rootDir, commandArgs);
       break;
-    case 'suggest':
+    case "suggest":
       suggest(rootDir, commandArgs);
       break;
-    case 'help':
+    case "help":
       printHelp();
       break;
   }

--- a/scripts/src/tokens/commands/check.ts
+++ b/scripts/src/tokens/commands/check.ts
@@ -2,20 +2,20 @@
  * Check command - Token limit validation
  */
 
-import { parseArgs } from 'node:util';
-import { readFileSync, existsSync } from 'node:fs';
-import { join, relative, resolve } from 'node:path';
+import { parseArgs } from "node:util";
+import { readFileSync, existsSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
 import type { 
   ValidationResult, 
   ValidationReport
-} from './types.js';
+} from "./types.js";
 import { 
   estimateTokens,
   normalizePath,
   DEFAULT_SCAN_DIRS,
   getErrorMessage
-} from './types.js';
-import { loadConfig, getLimitForFile, findMarkdownFiles } from './utils.js';
+} from "./types.js";
+import { loadConfig, getLimitForFile, findMarkdownFiles } from "./utils.js";
 
 function validateFiles(rootDir: string, filesToCheck?: string[]): ValidationReport {
   const config = loadConfig(rootDir);
@@ -31,7 +31,7 @@ function validateFiles(rootDir: string, filesToCheck?: string[]): ValidationRepo
     
     try {
       const relativePath = normalizePath(relative(rootDir, file));
-      const content = readFileSync(file, 'utf-8');
+      const content = readFileSync(file, "utf-8");
       const tokens = estimateTokens(content);
       const { limit, pattern } = getLimitForFile(relativePath, config, rootDir);
       
@@ -49,7 +49,7 @@ function validateFiles(rootDir: string, filesToCheck?: string[]): ValidationRepo
   }
   
   if (skipped.length > 0 && process.env.DEBUG) {
-    console.error(`⚠️  Skipped ${skipped.length} file(s): ${skipped.join(', ')}`);
+    console.error(`⚠️  Skipped ${skipped.length} file(s): ${skipped.join(", ")}`);
   } else if (skipped.length > 0) {
     console.error(`⚠️  Skipped ${skipped.length} file(s)`);
   }
@@ -64,16 +64,16 @@ function validateFiles(rootDir: string, filesToCheck?: string[]): ValidationRepo
 
 function formatMarkdownReport(report: ValidationReport): string {
   const lines: string[] = [
-    '## 📊 Token Limit Check Report\n',
+    "## 📊 Token Limit Check Report\n",
     `**Checked:** ${report.totalFiles} files`,
     `**Exceeded:** ${report.exceededCount} files\n`
   ];
   
   if (report.exceededCount > 0) {
     lines.push(
-      '### ⚠️ Files Exceeding Token Limits\n',
-      '| File | Tokens | Limit | Over By |',
-      '|------|--------|-------|---------|'
+      "### ⚠️ Files Exceeding Token Limits\n",
+      "| File | Tokens | Limit | Over By |",
+      "|------|--------|-------|---------|"
     );
     
     for (const result of report.results.filter(r => r.exceeded)) {
@@ -81,24 +81,24 @@ function formatMarkdownReport(report: ValidationReport): string {
       lines.push(`| \`${result.file}\` | ${result.tokens} | ${result.limit} | +${overBy} |`);
     }
     
-    lines.push('\n> Consider moving content to `references/` subdirectories.');
+    lines.push("\n> Consider moving content to `references/` subdirectories.");
   } else {
-    lines.push('### ✅ All files within token limits');
+    lines.push("### ✅ All files within token limits");
   }
   
-  return lines.join('\n');
+  return lines.join("\n");
 }
 
 function printConsoleReport(report: ValidationReport): void {
-  console.log('\n📊 Token Limit Check');
-  console.log('═'.repeat(60));
+  console.log("\n📊 Token Limit Check");
+  console.log("═".repeat(60));
   console.log(`Files Checked: ${report.totalFiles}`);
   console.log(`Files Exceeded: ${report.exceededCount}`);
-  console.log('');
+  console.log("");
   
   if (report.exceededCount > 0) {
-    console.log('⚠️  Files exceeding limits:');
-    console.log('─'.repeat(60));
+    console.log("⚠️  Files exceeding limits:");
+    console.log("─".repeat(60));
     
     for (const result of report.results.filter(r => r.exceeded)) {
       const overBy = result.tokens - result.limit;
@@ -106,20 +106,20 @@ function printConsoleReport(report: ValidationReport): void {
       console.log(`     ${result.tokens} tokens (limit: ${result.limit}, over by ${overBy})`);
     }
     
-    console.log('\n💡 Tip: Move detailed content to references/ subdirectories');
+    console.log("\n💡 Tip: Move detailed content to references/ subdirectories");
   } else {
-    console.log('✅ All files within token limits!');
+    console.log("✅ All files within token limits!");
   }
   
-  console.log('');
+  console.log("");
 }
 
 export function check(rootDir: string, args: string[]): void {
   const { values, positionals } = parseArgs({
     args,
     options: {
-      markdown: { type: 'boolean', default: false },
-      json: { type: 'boolean', default: false }
+      markdown: { type: "boolean", default: false },
+      json: { type: "boolean", default: false }
     },
     strict: false,
     allowPositionals: true

--- a/scripts/src/tokens/commands/compare.ts
+++ b/scripts/src/tokens/commands/compare.ts
@@ -2,26 +2,26 @@
  * Compare command - Git-based token comparison
  */
 
-import { parseArgs } from 'node:util';
-import { readFileSync, readdirSync, Dirent } from 'node:fs';
-import { join, relative } from 'node:path';
-import { execSync } from 'node:child_process';
-import type { 
-  FileTokens, 
-  FileComparison, 
+import { parseArgs } from "node:util";
+import { readFileSync, readdirSync, Dirent } from "node:fs";
+import { join, relative } from "node:path";
+import { execSync } from "node:child_process";
+import type {
+  FileTokens,
+  FileComparison,
   ComparisonReport
-} from './types.js';
+} from "./types.js";
 import {
-  estimateTokens, 
-  EXCLUDED_DIRS, 
-  isMarkdownFile, 
+  estimateTokens,
+  EXCLUDED_DIRS,
+  isMarkdownFile,
   normalizePath,
   DEFAULT_SCAN_DIRS,
   MAX_GIT_BUFFER_SIZE,
   GIT_OPERATION_TIMEOUT
-} from './types.js';
+} from "./types.js";
 
-const GIT_REF_PATTERN = /^[a-zA-Z0-9._\-\/~^]+$/;
+const GIT_REF_PATTERN = /^[a-zA-Z0-9._\-/~^]+$/;
 const MAX_REF_LENGTH = 256;
 
 /**
@@ -31,20 +31,20 @@ const MAX_REF_LENGTH = 256;
  * @throws Error if ref is invalid or dangerous
  */
 function validateGitRef(ref: string): void {
-  if (!ref || typeof ref !== 'string') {
-    throw new Error('Git ref must be a non-empty string');
+  if (!ref || typeof ref !== "string") {
+    throw new Error("Git ref must be a non-empty string");
   }
-  
+
   if (ref.length === 0 || ref.length >= MAX_REF_LENGTH) {
     throw new Error(`Git ref length must be between 1 and ${MAX_REF_LENGTH} characters`);
   }
-  
+
   if (!GIT_REF_PATTERN.test(ref)) {
     throw new Error(`Invalid git ref format: ${ref}`);
   }
-  
+
   // Prevent command injection attempts
-  const dangerousPatterns = [';', '&&', '||', '|', '`', '$', '(', ')', '{', '}', '<', '>', '\n', '\r'];
+  const dangerousPatterns = [";", "&&", "||", "|", "`", "$", "(", ")", "{", "}", "<", ">", "\n", "\r"];
   for (const pattern of dangerousPatterns) {
     if (ref.includes(pattern)) {
       throw new Error(`Git ref contains dangerous characters: ${ref}`);
@@ -59,7 +59,7 @@ function validateGitRef(ref: string): void {
  * @throws Error if path contains dangerous characters
  */
 function validatePath(path: string): void {
-  const dangerousChars = [';', '&&', '||', '|', '`', '$', '(', ')', '{', '}', '<', '>', '\n', '\r', '"', "'"];
+  const dangerousChars = [";", "&&", "||", "|", "`", "$", "(", ")", "{", "}", "<", ">", "\n", "\r", '"', "'"];
   for (const char of dangerousChars) {
     if (path.includes(char)) {
       throw new Error(`Path contains dangerous characters: ${path}`);
@@ -80,22 +80,22 @@ function validatePath(path: string): void {
  */
 function getFileTokensAtRef(filePath: string, ref: string, rootDir: string): FileTokens | null {
   validateGitRef(ref);
-  
+
   try {
     const relativePath = normalizePath(relative(rootDir, filePath));
     validatePath(relativePath);
     const content = execSync(`git show "${ref}:${relativePath}"`, {
       cwd: rootDir,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'inherit'],
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "inherit"],
       maxBuffer: MAX_GIT_BUFFER_SIZE,
       timeout: GIT_OPERATION_TIMEOUT
     });
-    
+
     return {
       tokens: estimateTokens(content),
       characters: content.length,
-      lines: content.split('\n').length
+      lines: content.split("\n").length
     };
   } catch (error) {
     // Log specific error for debugging but return null for flow control
@@ -113,11 +113,11 @@ function getFileTokensAtRef(filePath: string, ref: string, rootDir: string): Fil
  */
 function getCurrentFileTokens(filePath: string): FileTokens | null {
   try {
-    const content = readFileSync(filePath, 'utf-8');
+    const content = readFileSync(filePath, "utf-8");
     return {
       tokens: estimateTokens(content),
       characters: content.length,
-      lines: content.split('\n').length
+      lines: content.split("\n").length
     };
   } catch {
     return null;
@@ -127,16 +127,16 @@ function getCurrentFileTokens(filePath: string): FileTokens | null {
 function getChangedFiles(baseRef: string, headRef: string, rootDir: string): string[] {
   validateGitRef(baseRef);
   validateGitRef(headRef);
-  
+
   try {
     const output = execSync(`git diff --name-only "${baseRef}"..."${headRef}" -- "*.md" "*.mdx"`, {
       cwd: rootDir,
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'inherit'],
+      encoding: "utf-8",
+      stdio: ["pipe", "pipe", "inherit"],
       maxBuffer: MAX_GIT_BUFFER_SIZE,
       timeout: GIT_OPERATION_TIMEOUT
     });
-    return output.trim().split('\n').filter(Boolean);
+    return output.trim().split("\n").filter(Boolean);
   } catch (error) {
     if (process.env.DEBUG) {
       console.error(`Failed to get changed files: ${error}`);
@@ -147,7 +147,7 @@ function getChangedFiles(baseRef: string, headRef: string, rootDir: string): str
 
 function getAllMarkdownFiles(dir: string, files: string[] = [], rootDir: string = dir): string[] {
   const entries: Dirent[] = readdirSync(dir, { withFileTypes: true });
-  
+
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
     if (entry.isDirectory()) {
@@ -160,7 +160,7 @@ function getAllMarkdownFiles(dir: string, files: string[] = [], rootDir: string 
       files.push(normalizePath(relative(rootDir, fullPath)));
     }
   }
-  
+
   return files;
 }
 
@@ -178,50 +178,50 @@ function getDefaultMarkdownFiles(rootDir: string): string[] {
 }
 
 function compareTokens(baseRef: string, headRef: string, rootDir: string, onlyChanged: boolean): ComparisonReport {
-  const files = onlyChanged 
+  const files = onlyChanged
     ? getChangedFiles(baseRef, headRef, rootDir)
     : getDefaultMarkdownFiles(rootDir);
-  
+
   const comparisons: FileComparison[] = [];
   let totalBefore = 0, totalAfter = 0;
   let filesAdded = 0, filesRemoved = 0, filesModified = 0, filesIncreased = 0, filesDecreased = 0;
-  
+
   for (const file of files) {
     const fullPath = join(rootDir, file);
     const before = getFileTokensAtRef(fullPath, baseRef, rootDir);
-    const after = headRef === 'HEAD' || headRef === 'WORKING' 
+    const after = headRef === "HEAD" || headRef === "WORKING"
       ? getCurrentFileTokens(fullPath)
       : getFileTokensAtRef(fullPath, headRef, rootDir);
-    
+
     const beforeTokens = before?.tokens ?? 0;
     const afterTokens = after?.tokens ?? 0;
     const diff = afterTokens - beforeTokens;
-    const percentChange = beforeTokens > 0 
-      ? Math.round((diff / beforeTokens) * 100) 
+    const percentChange = beforeTokens > 0
+      ? Math.round((diff / beforeTokens) * 100)
       : (afterTokens > 0 ? 100 : 0);
-    
-    let status: FileComparison['status'];
-    if (!before && after) { status = 'added'; filesAdded++; }
-    else if (before && !after) { status = 'removed'; filesRemoved++; }
-    else if (diff !== 0) { 
-      status = 'modified'; 
+
+    let status: FileComparison["status"];
+    if (!before && after) { status = "added"; filesAdded++; }
+    else if (before && !after) { status = "removed"; filesRemoved++; }
+    else if (diff !== 0) {
+      status = "modified";
       filesModified++;
       if (diff > 0) filesIncreased++;
       if (diff < 0) filesDecreased++;
-    } else { 
-      status = 'unchanged'; 
+    } else {
+      status = "unchanged";
     }
-    
+
     totalBefore += beforeTokens;
     totalAfter += afterTokens;
     comparisons.push({ file, before, after, diff, percentChange, status });
   }
-  
+
   comparisons.sort((a, b) => Math.abs(b.diff) - Math.abs(a.diff));
-  
+
   const totalDiff = totalAfter - totalBefore;
   const totalPercentChange = totalBefore > 0 ? Math.round((totalDiff / totalBefore) * 100) : 0;
-  
+
   return {
     baseRef,
     headRef,
@@ -232,110 +232,110 @@ function compareTokens(baseRef: string, headRef: string, rootDir: string, onlyCh
 }
 
 function formatDiff(diff: number): string {
-  return diff > 0 ? `+${diff.toLocaleString()}` : diff < 0 ? diff.toLocaleString() : '0';
+  return diff > 0 ? `+${diff.toLocaleString()}` : diff < 0 ? diff.toLocaleString() : "0";
 }
 
 function formatPercent(percent: number): string {
-  return percent > 0 ? `+${percent}%` : percent < 0 ? `${percent}%` : '0%';
+  return percent > 0 ? `+${percent}%` : percent < 0 ? `${percent}%` : "0%";
 }
 
 function getChangeEmoji(diff: number, percent: number): string {
-  if (diff === 0) return '➖';
-  if (diff < 0) return '📉';
-  if (percent > 50) return '🔴';
-  if (percent > 20) return '🟠';
-  return '📈';
+  if (diff === 0) return "➖";
+  if (diff < 0) return "📉";
+  if (percent > 50) return "🔴";
+  if (percent > 20) return "🟠";
+  return "📈";
 }
 
 function formatMarkdownReport(report: ComparisonReport): string {
   const lines: string[] = [];
   const s = report.summary;
-  
-  lines.push('## 📊 Token Change Report\n');
+
+  lines.push("## 📊 Token Change Report\n");
   lines.push(`Comparing \`${report.baseRef}\` → \`${report.headRef}\`\n`);
-  
-  const emoji = s.totalDiff > 0 ? '📈' : s.totalDiff < 0 ? '📉' : '➖';
-  lines.push('### Summary\n');
-  lines.push('| Metric | Value |', '|--------|-------|');
+
+  const emoji = s.totalDiff > 0 ? "📈" : s.totalDiff < 0 ? "📉" : "➖";
+  lines.push("### Summary\n");
+  lines.push("| Metric | Value |", "|--------|-------|");
   lines.push(`| ${emoji} **Total Change** | **${formatDiff(s.totalDiff)} tokens (${formatPercent(s.percentChange)})** |`);
   lines.push(`| Before | ${s.totalBefore.toLocaleString()} tokens |`);
   lines.push(`| After | ${s.totalAfter.toLocaleString()} tokens |`);
   lines.push(`| Files Changed | ${s.filesModified + s.filesAdded + s.filesRemoved} |`);
-  lines.push('');
-  
-  const changedFiles = report.files.filter(f => f.status !== 'unchanged');
+  lines.push("");
+
+  const changedFiles = report.files.filter(f => f.status !== "unchanged");
   if (changedFiles.length > 0) {
-    lines.push('### Changed Files\n');
-    lines.push('| File | Before | After | Change |', '|------|--------|-------|--------|');
-    
+    lines.push("### Changed Files\n");
+    lines.push("| File | Before | After | Change |", "|------|--------|-------|--------|");
+
     for (const file of changedFiles) {
-      const before = file.before?.tokens.toLocaleString() ?? '-';
-      const after = file.after?.tokens.toLocaleString() ?? '-';
-      const change = file.status === 'added' ? `+${file.after?.tokens}` :
-                    file.status === 'removed' ? `-${file.before?.tokens}` :
-                    `${formatDiff(file.diff)} (${formatPercent(file.percentChange)})`;
+      const before = file.before?.tokens.toLocaleString() ?? "-";
+      const after = file.after?.tokens.toLocaleString() ?? "-";
+      const change = file.status === "added" ? `+${file.after?.tokens}` :
+        file.status === "removed" ? `-${file.before?.tokens}` :
+          `${formatDiff(file.diff)} (${formatPercent(file.percentChange)})`;
       lines.push(`| \`${file.file}\` | ${before} | ${after} | ${change} |`);
     }
   }
-  
-  return lines.join('\n');
+
+  return lines.join("\n");
 }
 
 function formatConsoleReport(report: ComparisonReport): void {
   const s = report.summary;
-  
-  console.log('\n' + '═'.repeat(60));
-  console.log('📊 TOKEN CHANGE REPORT');
-  console.log('═'.repeat(60));
+
+  console.log("\n" + "═".repeat(60));
+  console.log("📊 TOKEN CHANGE REPORT");
+  console.log("═".repeat(60));
   console.log(`Comparing: ${report.baseRef} → ${report.headRef}`);
-  console.log('─'.repeat(60));
-  
-  const emoji = s.totalDiff > 0 ? '📈' : s.totalDiff < 0 ? '📉' : '➖';
+  console.log("─".repeat(60));
+
+  const emoji = s.totalDiff > 0 ? "📈" : s.totalDiff < 0 ? "📉" : "➖";
   console.log(`\n${emoji} Total Change: ${formatDiff(s.totalDiff)} tokens (${formatPercent(s.percentChange)})`);
   console.log(`   Before: ${s.totalBefore.toLocaleString()} tokens`);
   console.log(`   After:  ${s.totalAfter.toLocaleString()} tokens`);
   console.log(`   Files:  ${s.filesModified} modified, ${s.filesAdded} added, ${s.filesRemoved} removed`);
-  
-  const changedFiles = report.files.filter(f => f.status !== 'unchanged');
+
+  const changedFiles = report.files.filter(f => f.status !== "unchanged");
   if (changedFiles.length > 0) {
-    console.log('\n' + '─'.repeat(60));
-    console.log('Changed Files:');
-    
+    console.log("\n" + "─".repeat(60));
+    console.log("Changed Files:");
+
     for (const file of changedFiles.slice(0, 15)) {
       const emoji = getChangeEmoji(file.diff, file.percentChange);
       console.log(`${emoji} ${file.file}: ${file.before?.tokens ?? 0} → ${file.after?.tokens ?? 0} [${formatDiff(file.diff)}]`);
     }
-    
+
     if (changedFiles.length > 15) {
       console.log(`   ... and ${changedFiles.length - 15} more files`);
     }
   }
-  
-  console.log('\n' + '═'.repeat(60) + '\n');
+
+  console.log("\n" + "═".repeat(60) + "\n");
 }
 
 export function compare(rootDir: string, args: string[]): void {
   const { values } = parseArgs({
     args,
     options: {
-      base: { type: 'string', default: 'main' },
-      head: { type: 'string', default: 'HEAD' },
-      markdown: { type: 'boolean', default: false },
-      json: { type: 'boolean', default: false },
-      all: { type: 'boolean', default: false }
+      base: { type: "string", default: "main" },
+      head: { type: "string", default: "HEAD" },
+      markdown: { type: "boolean", default: false },
+      json: { type: "boolean", default: false },
+      all: { type: "boolean", default: false }
     },
     strict: false,
     allowPositionals: true
   });
 
-  const baseRef = (values.base ?? 'main') as string;
-  const headRef = (values.head ?? 'HEAD') as string;
+  const baseRef = (values.base ?? "main") as string;
+  const headRef = (values.head ?? "HEAD") as string;
   const markdown = values.markdown ?? false;
   const json = values.json ?? false;
   const allFiles = values.all ?? false;
-  
+
   const report = compareTokens(baseRef, headRef, rootDir, !allFiles);
-  
+
   if (json) console.log(JSON.stringify(report, null, 2));
   else if (markdown) console.log(formatMarkdownReport(report));
   else formatConsoleReport(report);

--- a/scripts/src/tokens/commands/count.ts
+++ b/scripts/src/tokens/commands/count.ts
@@ -2,19 +2,19 @@
  * Count command - Token counting for markdown files
  */
 
-import { parseArgs } from 'node:util';
-import { readFileSync, writeFileSync } from 'node:fs';
-import { join, relative, resolve, isAbsolute } from 'node:path';
+import { parseArgs } from "node:util";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join, relative, resolve, isAbsolute } from "node:path";
 import type { 
   TokenMetadata, 
   TokenCount
-} from './types.js';
+} from "./types.js";
 import { 
   estimateTokens,
   DEFAULT_SCAN_DIRS,
   getErrorMessage
-} from './types.js';
-import { findMarkdownFiles } from './utils.js';
+} from "./types.js";
+import { findMarkdownFiles } from "./utils.js";
 
 /**
  * Counts tokens, characters, and lines in a file.
@@ -24,8 +24,8 @@ import { findMarkdownFiles } from './utils.js';
  */
 function countFileTokens(filePath: string): TokenCount {
   try {
-    const content = readFileSync(filePath, 'utf-8');
-    const lines = content.split('\n').length;
+    const content = readFileSync(filePath, "utf-8");
+    const lines = content.split("\n").length;
     
     return {
       tokens: estimateTokens(content),
@@ -58,7 +58,7 @@ function generateMetadata(rootDir: string, scanDirs: string[]): TokenMetadata {
   
   for (const file of allFiles) {
     try {
-      const relativePath = relative(rootDir, file).replace(/[\\/]/g, '/');
+      const relativePath = relative(rootDir, file).replace(/[\\/]/g, "/");
       const tokenCount = countFileTokens(file);
       fileTokens[relativePath] = tokenCount;
       totalTokens += tokenCount.tokens;
@@ -81,25 +81,25 @@ function generateMetadata(rootDir: string, scanDirs: string[]): TokenMetadata {
 }
 
 function printSummary(metadata: TokenMetadata): void {
-  console.log('\n📊 Token Count Summary');
-  console.log('═'.repeat(60));
+  console.log("\n📊 Token Count Summary");
+  console.log("═".repeat(60));
   console.log(`Total Files: ${metadata.totalFiles.toLocaleString()}`);
   console.log(`Total Tokens: ${metadata.totalTokens.toLocaleString()}`);
   console.log(`Generated: ${metadata.generatedAt}`);
-  console.log('');
+  console.log("");
   
   const sorted = Object.entries(metadata.files)
     .sort(([, a], [, b]) => b.tokens - a.tokens);
   
-  console.log('Top 10 Files by Token Count:');
-  console.log('─'.repeat(60));
+  console.log("Top 10 Files by Token Count:");
+  console.log("─".repeat(60));
   
   for (const [file, count] of sorted.slice(0, 10)) {
     const tokens = count.tokens.toLocaleString().padStart(6);
     console.log(`  ${tokens} tokens │ ${file}`);
   }
   
-  console.log('');
+  console.log("");
 }
 
 /**
@@ -114,11 +114,11 @@ function isPathWithinRoot(targetPath: string, rootDir: string): boolean {
   const resolvedRoot = resolve(rootDir);
   
   // Normalize paths to prevent traversal attacks (unify separators)
-  const normalizedTarget = resolvedTarget.replace(/[\\/]+/g, '/');
-  const normalizedRoot = resolvedRoot.replace(/[\\/]+/g, '/');
-  const rootWithSep = normalizedRoot.endsWith('/') ? normalizedRoot : normalizedRoot + '/';
+  const normalizedTarget = resolvedTarget.replace(/[\\/]+/g, "/");
+  const normalizedRoot = resolvedRoot.replace(/[\\/]+/g, "/");
+  const rootWithSep = normalizedRoot.endsWith("/") ? normalizedRoot : normalizedRoot + "/";
 
-  if (process.platform === 'win32') {
+  if (process.platform === "win32") {
     // Windows file systems are typically case-insensitive
     const targetLower = normalizedTarget.toLowerCase();
     const rootLowerWithSep = rootWithSep.toLowerCase();
@@ -134,8 +134,8 @@ export function count(rootDir: string, args: string[]): void {
   const { values } = parseArgs({
     args,
     options: {
-      output: { type: 'string' },
-      json: { type: 'boolean', default: false }
+      output: { type: "string" },
+      json: { type: "boolean", default: false }
     },
     strict: false,
     allowPositionals: true
@@ -146,13 +146,13 @@ export function count(rootDir: string, args: string[]): void {
 
   const metadata = generateMetadata(rootDir, [...DEFAULT_SCAN_DIRS]);
   
-  if (outputPath && typeof outputPath === 'string') {
+  if (outputPath && typeof outputPath === "string") {
     const fullOutputPath = isAbsolute(outputPath) 
       ? outputPath 
       : join(rootDir, outputPath);
     
     if (!isPathWithinRoot(fullOutputPath, rootDir)) {
-      console.error(`❌ Error: Output path must be within the repository root`);
+      console.error("❌ Error: Output path must be within the repository root");
       console.error(`   Attempted path: ${fullOutputPath}`);
       console.error(`   Repository root: ${rootDir}`);
       process.exitCode = 1;

--- a/scripts/src/tokens/commands/types.ts
+++ b/scripts/src/tokens/commands/types.ts
@@ -2,7 +2,7 @@
  * Shared types and utilities for token management
  */
 
-import { extname } from 'node:path';
+import { extname } from "node:path";
 import * as micromatch from "micromatch";
 
 export interface TokenCount {
@@ -59,7 +59,7 @@ export interface FileComparison {
   readonly after: FileTokens | null;
   readonly diff: number;
   readonly percentChange: number;
-  readonly status: 'added' | 'removed' | 'modified' | 'unchanged';
+  readonly status: "added" | "removed" | "modified" | "unchanged";
 }
 
 export interface ComparisonSummary {
@@ -119,27 +119,27 @@ export const TOKENS_PER_CODE_LINE = 16;
 export const TOKENS_PER_TABLE_ROW = 12;
 
 /** Common directories to exclude from scanning */
-export const EXCLUDED_DIRS = ['node_modules', '.git', 'dist', 'coverage'] as const;
+export const EXCLUDED_DIRS = ["node_modules", ".git", "dist", "coverage"] as const;
 
 /** Default directories to scan for skills/agents */
-export const DEFAULT_SCAN_DIRS = ['.github/skills', 'plugin/skills', '.github/agents'] as const;
+export const DEFAULT_SCAN_DIRS = [".github/skills", "plugin/skills", ".github/agents"] as const;
 
 /** Supported markdown extensions */
-export const MARKDOWN_EXTENSIONS = ['.md', '.mdx'] as const;
+export const MARKDOWN_EXTENSIONS = [".md", ".mdx"] as const;
 
 /** Default token limits configuration */
 export const DEFAULT_LIMITS: TokenLimitsConfig = {
   defaults: {
-    'SKILL.md': 500,
-    'references/**/*.md': 1000,
-    'docs/**/*.md': 1500,
-    '**/*.md': 2000,
-    '*.md': 2000
+    "SKILL.md": 500,
+    "references/**/*.md": 1000,
+    "docs/**/*.md": 1500,
+    "**/*.md": 2000,
+    "*.md": 2000
   },
   overrides: {
-    'README.md': 3000,
-    'CONTRIBUTING.md': 2500,
-    'plugin/README.md': 3000
+    "README.md": 3000,
+    "CONTRIBUTING.md": 2500,
+    "plugin/README.md": 3000
   }
 };
 
@@ -156,15 +156,15 @@ export function isMarkdownFile(filename: string): boolean {
 
 /** Normalizes path separators to forward slashes */
 export function normalizePath(filePath: string): string {
-  return filePath.replace(/\\/g, '/');
+  return filePath.replace(/\\/g, "/");
 }
 
 /** Checks if file path matches a glob pattern */
 export function matchesPattern(filePath: string, pattern: string): boolean {
   const normalizedPath = normalizePath(filePath);
 
-  if (!pattern.includes('/') && !pattern.includes('*')) {
-    return normalizedPath.endsWith('/' + pattern) || normalizedPath === pattern;
+  if (!pattern.includes("/") && !pattern.includes("*")) {
+    return normalizedPath.endsWith("/" + pattern) || normalizedPath === pattern;
   }
 
   return micromatch.isMatch(normalizedPath, pattern);

--- a/scripts/src/tokens/commands/utils.ts
+++ b/scripts/src/tokens/commands/utils.ts
@@ -2,11 +2,11 @@
  * Shared utility functions for token commands
  */
 
-import { readFileSync, readdirSync, existsSync, Dirent } from 'node:fs';
-import { join } from 'node:path';
-import type { 
+import { readFileSync, readdirSync, existsSync, Dirent } from "node:fs";
+import { join } from "node:path";
+import type {
   TokenLimitsConfig
-} from './types.js';
+} from "./types.js";
 import {
   DEFAULT_LIMITS,
   EXCLUDED_DIRS,
@@ -14,7 +14,7 @@ import {
   normalizePath,
   matchesPattern,
   getErrorMessage
-} from './types.js';
+} from "./types.js";
 
 /**
  * Loads token limits configuration from .token-limits.json or returns defaults.
@@ -22,25 +22,25 @@ import {
  * @returns Token limits configuration
  */
 export function loadConfig(rootDir: string): TokenLimitsConfig {
-  const configPath = join(rootDir, '.token-limits.json');
-  
+  const configPath = join(rootDir, ".token-limits.json");
+
   if (existsSync(configPath)) {
     try {
-      const content = readFileSync(configPath, 'utf-8');
+      const content = readFileSync(configPath, "utf-8");
       const parsed = JSON.parse(content);
-      
+
       // Validate structure
-      if (!parsed.defaults || typeof parsed.defaults !== 'object') {
+      if (!parsed.defaults || typeof parsed.defaults !== "object") {
         throw new Error('Missing or invalid "defaults" field');
       }
-      
+
       return parsed as TokenLimitsConfig;
     } catch (error) {
       console.error(`⚠️  Warning: Invalid .token-limits.json (${getErrorMessage(error)}), using defaults`);
       return DEFAULT_LIMITS;
     }
   }
-  
+
   return DEFAULT_LIMITS;
 }
 
@@ -52,24 +52,24 @@ export function loadConfig(rootDir: string): TokenLimitsConfig {
  */
 function getPatternSpecificity(pattern: string): number {
   let score = 0;
-  
+
   // No wildcards = most specific (exact match)
-  if (!pattern.includes('*')) {
+  if (!pattern.includes("*")) {
     score += 10000;
   }
-  
+
   // More path segments = more specific
-  score += (pattern.split('/').length - 1) * 100;
-  
+  score += (pattern.split("/").length - 1) * 100;
+
   // Single wildcard * is more specific than globstar **
   const starCount = (pattern.match(/(?<!\*)\*(?!\*)/g) || []).length;
   const globstarCount = (pattern.match(/\*\*/g) || []).length;
   score += starCount * 10;
   score -= globstarCount * 50;
-  
+
   // Longer patterns are slightly more specific
   score += pattern.length;
-  
+
   return score;
 }
 
@@ -80,28 +80,28 @@ function getPatternSpecificity(pattern: string): number {
  * @param rootDir - Root directory for relative path resolution
  * @returns Object containing limit and matching pattern
  */
-export function getLimitForFile(filePath: string, config: TokenLimitsConfig, rootDir: string): { limit: number; pattern: string } {
+export function getLimitForFile(filePath: string, config: TokenLimitsConfig, _rootDir: string): { limit: number; pattern: string } {
   const normalizedPath = normalizePath(filePath);
-  
+
   // Check overrides first (exact matches)
   for (const [overridePath, limit] of Object.entries(config.overrides)) {
-    if (normalizedPath === overridePath || normalizedPath.endsWith('/' + overridePath)) {
+    if (normalizedPath === overridePath || normalizedPath.endsWith("/" + overridePath)) {
       return { limit, pattern: overridePath };
     }
   }
-  
+
   // Check defaults (sorted by specificity, most specific first)
   const sortedDefaults = Object.entries(config.defaults)
     .sort(([a], [b]) => getPatternSpecificity(b) - getPatternSpecificity(a));
-  
+
   for (const [pattern, limit] of sortedDefaults) {
     if (matchesPattern(normalizedPath, pattern)) {
       return { limit, pattern };
     }
   }
-  
+
   // Fallback to default markdown limit
-  return { limit: config.defaults['*.md'] ?? 2000, pattern: '*.md' };
+  return { limit: config.defaults["*.md"] ?? 2000, pattern: "*.md" };
 }
 
 /**
@@ -113,7 +113,7 @@ export function getLimitForFile(filePath: string, config: TokenLimitsConfig, roo
  */
 export function findMarkdownFiles(dir: string, files: string[] = []): string[] {
   let entries: Dirent[];
-  
+
   try {
     entries = readdirSync(dir, { withFileTypes: true });
   } catch (error) {
@@ -122,10 +122,10 @@ export function findMarkdownFiles(dir: string, files: string[] = []): string[] {
     }
     return files;
   }
-  
+
   for (const entry of entries) {
     const fullPath = join(dir, entry.name);
-    
+
     if (entry.isDirectory()) {
       const dirName = entry.name;
       const isExcluded = EXCLUDED_DIRS.some(excluded => excluded === dirName);
@@ -136,6 +136,6 @@ export function findMarkdownFiles(dir: string, files: string[] = []): string[] {
       files.push(fullPath);
     }
   }
-  
+
   return files;
 }

--- a/scripts/src/verify-local.ts
+++ b/scripts/src/verify-local.ts
@@ -8,18 +8,18 @@
  * Usage: npm run verify-local
  */
 
-import { existsSync, realpathSync } from 'node:fs';
-import { resolve, join, dirname } from 'node:path';
-import { homedir } from 'node:os';
-import { fileURLToPath } from 'node:url';
+import { existsSync, realpathSync } from "node:fs";
+import { resolve, join, dirname } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
 
 function getRepoRoot(): string {
   const scriptDir = dirname(fileURLToPath(import.meta.url));
-  return resolve(scriptDir, '../..');
+  return resolve(scriptDir, "../..");
 }
 
 function getInstalledPluginPath(): string {
-  return join(homedir(), '.copilot', 'installed-plugins', 'github-copilot-for-azure');
+  return join(homedir(), ".copilot", "installed-plugins", "github-copilot-for-azure");
 }
 
 function resolveSymlinkTarget(linkPath: string): string | null {
@@ -33,21 +33,21 @@ function resolveSymlinkTarget(linkPath: string): string | null {
 function main(): void {
   const repoRoot = getRepoRoot();
   const installedPath = getInstalledPluginPath();
-  const localPath = resolve(repoRoot, 'plugin');
+  const localPath = resolve(repoRoot, "plugin");
 
-  console.log('\n🔍 Verifying Local Skills Setup\n');
-  console.log('────────────────────────────────────────────────────────────');
+  console.log("\n🔍 Verifying Local Skills Setup\n");
+  console.log("────────────────────────────────────────────────────────────");
 
-  console.log(`\n📁 Local plugin path:`);
+  console.log("\n📁 Local plugin path:");
   console.log(`   ${localPath}`);
-  console.log(`   ${existsSync(localPath) ? '✅ Exists' : '❌ Not found'}`);
+  console.log(`   ${existsSync(localPath) ? "✅ Exists" : "❌ Not found"}`);
 
-  console.log(`\n📁 Installed plugin path:`);
+  console.log("\n📁 Installed plugin path:");
   console.log(`   ${installedPath}`);
 
   if (!existsSync(installedPath)) {
-    console.log('   ❌ Not found\n');
-    console.log('⚠️  No plugin installed. Run the symlink setup from CONTRIBUTING.md\n');
+    console.log("   ❌ Not found\n");
+    console.log("⚠️  No plugin installed. Run the symlink setup from CONTRIBUTING.md\n");
     process.exitCode = 1;
     return;
   }
@@ -57,28 +57,28 @@ function main(): void {
     console.log(`   → Points to: ${target}`);
   }
 
-  console.log('\n────────────────────────────────────────────────────────────');
+  console.log("\n────────────────────────────────────────────────────────────");
 
   // Compare normalized paths
-  const normalizedTarget = target?.toLowerCase().replace(/\\/g, '/');
-  const normalizedLocal = realpathSync(localPath).toLowerCase().replace(/\\/g, '/');
+  const normalizedTarget = target?.toLowerCase().replace(/\\/g, "/");
+  const normalizedLocal = realpathSync(localPath).toLowerCase().replace(/\\/g, "/");
   const isLinkedToLocal = normalizedTarget === normalizedLocal;
 
   if (isLinkedToLocal) {
-    console.log('\n✅ SUCCESS: Using local skills from this repository\n');
-    console.log('   Your changes to skills will be picked up by Copilot CLI');
-    console.log('   (restart CLI after making changes)\n');
+    console.log("\n✅ SUCCESS: Using local skills from this repository\n");
+    console.log("   Your changes to skills will be picked up by Copilot CLI");
+    console.log("   (restart CLI after making changes)\n");
   } else if (target) {
-    console.log('\n⚠️  WARNING: Plugin is linked to a DIFFERENT location\n');
+    console.log("\n⚠️  WARNING: Plugin is linked to a DIFFERENT location\n");
     console.log(`   Expected: ${localPath}`);
     console.log(`   Actual:   ${target}\n`);
-    console.log('   To fix, remove the existing link and create a new one.');
-    console.log('   See CONTRIBUTING.md for instructions.\n');
+    console.log("   To fix, remove the existing link and create a new one.");
+    console.log("   See CONTRIBUTING.md for instructions.\n");
     process.exitCode = 1;
   } else {
-    console.log('\n❌ ERROR: Plugin exists but is not a symlink\n');
-    console.log('   The installed plugin may be a regular copy, not linked to your repo.');
-    console.log('   Remove it and create a symlink per CONTRIBUTING.md\n');
+    console.log("\n❌ ERROR: Plugin exists but is not a symlink\n");
+    console.log("   The installed plugin may be a regular copy, not linked to your repo.");
+    console.log("   Remove it and create a symlink per CONTRIBUTING.md\n");
     process.exitCode = 1;
   }
 }

--- a/scripts/tsconfig.eslint.json
+++ b/scripts/tsconfig.eslint.json
@@ -1,0 +1,10 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true
+    },
+    "include": [
+        "src/**/*",
+        "vitest.config.ts"
+    ]
+}

--- a/scripts/vitest.config.ts
+++ b/scripts/vitest.config.ts
@@ -1,15 +1,15 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
     fileParallelism: false,  // Run test files sequentially to avoid race conditions on Windows
     coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      include: ['src/**/*.ts'],
+      provider: "v8",
+      reporter: ["text", "json", "html"],
+      include: ["src/**/*.ts"],
       exclude: [
-        'src/**/*.test.ts',
-        'src/**/__tests__/**'
+        "src/**/*.test.ts",
+        "src/**/__tests__/**"
       ],
       thresholds: {
         statements: 80,

--- a/tests/eslint.config.mjs
+++ b/tests/eslint.config.mjs
@@ -1,4 +1,5 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
 import tseslint from "typescript-eslint";
 import jest from "eslint-plugin-jest";
 import integrationTestNameRule from "./eslint-rules/integration-test-name.mjs";
@@ -37,7 +38,7 @@ const sharedRules = {
     "quotes": ["error", "double", { "avoidEscape": true }],
 };
 
-export default tseslint.config(
+export default defineConfig(
     // Global ignores
     {
         ignores: [


### PR DESCRIPTION
- Add eslint rules to scripts project
- Fix violations in the scripts project:
  - Use double quotes
  - No unused error object for catch blocks
  - No empty blocks
  - Unused variables
 - Add a step in pr.yml to lint the scripts project