### PR TITLE
fix: switch skill descriptions from YAML literal block to folded (>-)

### DIFF
--- a/.github/skills/sensei/README.md
+++ b/.github/skills/sensei/README.md
@@ -300,7 +300,7 @@ description: 'Instrument a webapp to send useful telemetry data to Azure App Ins
 ```yaml
 ---
 name: appinsights-instrumentation
-description: |
+description: >-
   Instrument web apps to send telemetry to Azure Application Insights.
   USE FOR: "add App Insights", "instrument my app", "set up monitoring",
   "add telemetry", "track requests", "ASP.NET Core telemetry", "Node.js monitoring".

--- a/.github/skills/sensei/SKILL.md
+++ b/.github/skills/sensei/SKILL.md
@@ -117,14 +117,14 @@ For each skill, execute this loop until score >= Medium-High AND tests pass:
 ```yaml
 ---
 name: skill-name
-description: |
+description: >-
   [1-2 sentence description of what the skill does]
   USE FOR: [trigger phrase 1], [trigger phrase 2], [trigger phrase 3]
   DO NOT USE FOR: [scenario] (use other-skill), [scenario] (use another-skill)
 ---
 ```
 
-> **IMPORTANT:** Always use multi-line YAML format (`|`) for descriptions over 200 characters. Single-line descriptions become difficult to read, review, and maintain. See [azure-ai](../../plugin/skills/azure-ai/SKILL.md), [azure-functions](../../plugin/skills/azure-functions/SKILL.md) for examples.
+> **IMPORTANT:** Always use folded YAML format (`>-`) for descriptions over 200 characters. Single-line descriptions become difficult to read, review, and maintain. The `>-` format keeps descriptions readable in source while parsing to a flat string compatible with skills.sh and other registries.
 
 > Keep total description under 1024 characters.
 

--- a/.github/skills/sensei/references/EXAMPLES.md
+++ b/.github/skills/sensei/references/EXAMPLES.md
@@ -44,7 +44,7 @@ const shouldNotTriggerPrompts = [
 ```yaml
 ---
 name: appinsights-instrumentation
-description: |
+description: >-
   Instrument web applications to send telemetry data to Azure Application Insights
   for monitoring and diagnostics. USE FOR: "add App Insights", "instrument my app",
   "set up application monitoring", "add telemetry", "track requests and dependencies",
@@ -114,7 +114,7 @@ description: 'Azure Security Services including Key Vault, Managed Identity, RBA
 ```yaml
 ---
 name: azure-security
-description: |
+description: >-
   Overview of Azure security services and concepts including Key Vault, Managed Identity,
   RBAC, Entra ID, and Defender for Cloud. USE FOR: "Azure security overview", "what
   security services are available", "explain managed identity", "RBAC basics", "Key Vault
@@ -139,7 +139,7 @@ description: |
 ```yaml
 ---
 name: azure-deploy
-description: |
+description: >-
   Deploy applications to Azure App Service, Azure Functions, and Static Web Apps.
   USE THIS SKILL when users want to deploy, publish, host, or run their application
   on Azure. This skill detects application type and recommends optimal Azure service.
@@ -157,7 +157,7 @@ description: |
 ```yaml
 ---
 name: azure-deploy
-description: |
+description: >-
   Deploy applications to Azure App Service, Azure Functions, and Static Web Apps.
   USE FOR: "deploy to Azure", "host on Azure", "publish to Azure", "run on Azure",
   "azd up", "deploy my app", "push to Azure", "get this running in the cloud".
@@ -243,10 +243,10 @@ sensei: improve appinsights-instrumentation frontmatter
 description: Identify and quantify cost savings across Azure subscriptions by analyzing actual costs, utilization metrics, and generating actionable optimization recommendations. USE FOR: optimize Azure costs, reduce Azure spending, analyze Azure costs, find cost savings. DO NOT USE FOR: cost estimation for new resources (use azure-cost-estimation).
 ```
 
-**Problem:** Single-line descriptions over 200 characters are hard to read, review, and maintain. Use multi-line YAML format (`|`) instead:
+**Problem:** Single-line descriptions over 200 characters are hard to read, review, and maintain. Use folded YAML format (`>-`) instead:
 
 ```yaml
-description: |
+description: >-
   Identify and quantify cost savings across Azure subscriptions by analyzing actual costs,
   utilization metrics, and generating actionable optimization recommendations. USE FOR:
   optimize Azure costs, reduce Azure spending, analyze Azure costs, find cost savings.
@@ -256,7 +256,7 @@ description: |
 ### ❌ Don't Do This: Overly Long Description
 
 ```yaml
-description: |
+description: >-
   This skill helps you instrument your web applications to send telemetry data
   to Azure Application Insights which is a feature of Azure Monitor that provides
   extensible application performance management (APM) and monitoring for live
@@ -275,7 +275,7 @@ description: |
 ### ❌ Don't Do This: Vague Anti-Triggers
 
 ```yaml
-description: |
+description: >-
   Deploy apps to Azure. USE FOR: deployment.
   DO NOT USE FOR: other stuff.
 ```

--- a/.github/skills/sensei/references/LOOP.md
+++ b/.github/skills/sensei/references/LOOP.md
@@ -166,7 +166,7 @@ const SKILL_NAME = '{skill-name}';  // Replace placeholder
 ```yaml
 ---
 name: {skill-name}
-description: |
+description: >-
   [What the skill does - 1-2 sentences]
   USE FOR: [phrase1], [phrase2], [phrase3], [phrase4], [phrase5]
   DO NOT USE FOR: [scenario1] (use other-skill), [scenario2] (use another-skill)

--- a/.github/skills/sensei/references/SCORING.md
+++ b/.github/skills/sensei/references/SCORING.md
@@ -59,7 +59,7 @@ A skill is **Medium** if:
 
 **Examples of Medium-adherence descriptions:**
 ```yaml
-description: |
+description: >-
   Deploy applications to Azure using Azure Developer CLI (azd). USE THIS SKILL 
   when users want to deploy, publish, host, or run their application on Azure. 
   Trigger phrases include "deploy to Azure", "host on Azure", "publish to Azure".
@@ -75,7 +75,7 @@ A skill is **Medium-High** if:
 
 **Example of Medium-High adherence:**
 ```yaml
-description: |
+description: >-
   Instrument web apps to send telemetry to Azure Application Insights.
   USE FOR: "add App Insights", "instrument my app", "set up monitoring".
   DO NOT USE FOR: querying logs (use azure-observability), creating alerts.
@@ -90,7 +90,7 @@ A skill is **High** if:
 
 **Example of High adherence:**
 ```yaml
-description: |
+description: >-
   Instrument web apps to send telemetry to Azure Application Insights.
   USE FOR: "add App Insights", "instrument my app", "set up monitoring".
   DO NOT USE FOR: querying logs (use azure-observability), creating alerts.
@@ -120,7 +120,7 @@ compatibility: Supports ASP.NET Core (.NET 6+), Node.js. Requires App Insights r
 | Ideal | 300-600 chars |
 | Max | 1024 chars |
 
-**Format Rule:** Descriptions over 200 characters MUST use multi-line YAML format (`|`) for maintainability.
+**Format Rule:** Descriptions over 200 characters MUST use folded YAML format (`>-`) for maintainability. The `>-` format keeps descriptions readable in source while parsing to a flat string compatible with skills.sh and other registries. Do NOT use `|` (literal block) as it preserves newlines.
 
 ### 3. Trigger Phrase Detection
 

--- a/plugin/skills/appinsights-instrumentation/SKILL.md
+++ b/plugin/skills/appinsights-instrumentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: appinsights-instrumentation
-description: |
+description: >-
   Guidance for instrumenting webapps with Azure Application Insights. Provides telemetry patterns, SDK setup, and configuration references.
   USE FOR: how to instrument app, App Insights SDK, telemetry patterns, what is App Insights, Application Insights guidance, instrumentation examples, APM best practices.
   DO NOT USE FOR: adding App Insights to my app (use azure-prepare), add telemetry to my project (use azure-prepare), add monitoring (use azure-prepare). This skill provides guidance—azure-prepare orchestrates component changes.

--- a/plugin/skills/azure-aigateway/SKILL.md
+++ b/plugin/skills/azure-aigateway/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-aigateway
-description: |
+description: >-
   Configure Azure API Management (APIM) as AI Gateway to secure, observe, control AI models, MCP servers, agents. Helps with rate limiting, semantic caching, content safety, load balancing.
   USE FOR: AI Gateway, APIM, setup gateway, configure gateway, add gateway, model gateway, MCP server, rate limit, token limit, semantic cache, content safety, load balance, OpenAPI import, convert API to MCP.
   DO NOT USE FOR: deploy models (use microsoft-foundry), Azure Functions (use azure-functions), databases (use azure-postgres).

--- a/plugin/skills/azure-compliance/SKILL.md
+++ b/plugin/skills/azure-compliance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-compliance
-description: |
+description: >-
   Comprehensive Azure compliance and security auditing capabilities including best practices assessment,
   Key Vault expiration monitoring, and resource configuration validation.
   USE FOR: compliance scan, security audit, azqr, Azure best practices, Key Vault expiration check,

--- a/plugin/skills/azure-cost-optimization/SKILL.md
+++ b/plugin/skills/azure-cost-optimization/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-cost-optimization
-description: |
+description: >-
   Identify and quantify cost savings across Azure subscriptions by analyzing actual costs,
   utilization metrics, and generating actionable optimization recommendations. USE FOR:
   optimize Azure costs, reduce Azure spending, reduce Azure expenses, analyze Azure costs,

--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-deploy
-description: |
+description: >-
   Execute deployment to Azure. Final step after preparation and validation. Runs azd up, azd deploy, or infrastructure provisioning commands.
   USE FOR: run azd up, run azd deploy, execute deployment, provision infrastructure, push to production, go live, ship it, deploy web app, deploy container app, deploy static site, deploy Azure Functions, bicep deploy, terraform apply.
   DO NOT USE FOR: creating or building apps (use azure-prepare), validating before deploy (use azure-validate).

--- a/plugin/skills/azure-diagnostics/SKILL.md
+++ b/plugin/skills/azure-diagnostics/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-diagnostics
-description: |
+description: >-
   Debug and troubleshoot production issues on Azure. Covers Container Apps diagnostics, log analysis with KQL, health checks, and common issue resolution for image pulls, cold starts, and health probes.
   USE FOR: debug production issues, troubleshoot container apps, analyze logs with KQL, fix image pull failures, resolve cold start issues, investigate health probe failures, check resource health, view application logs, find root cause of errors
   DO NOT USE FOR: deploying applications (use azure-deploy), creating new resources (use azure-prepare), setting up monitoring (use azure-observability), cost optimization (use azure-cost-optimization)

--- a/plugin/skills/azure-kusto/SKILL.md
+++ b/plugin/skills/azure-kusto/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-kusto
-description: |
+description: >-
   Query and analyze data in Azure Data Explorer (Kusto/ADX) using KQL for log analytics, telemetry, and time series analysis.
   USE FOR: KQL queries, Kusto database queries, Azure Data Explorer, ADX clusters, log analytics, time series data, IoT telemetry, anomaly detection
   DO NOT USE FOR: SQL databases (use azure-postgres), NoSQL queries (use azure-storage), Elasticsearch, AWS analytics tools

--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-prepare
-description: |
+description: >-
   Default entry point for Azure application development. Invoke this skill for ANY application work related to Azure: creating apps, building features, adding components, updating code, migrating, or modernizing. Analyzes your project and prepares it for Azure deployment by generating infrastructure code (Bicep/Terraform), azure.yaml configuration, and Dockerfiles.
   USE FOR: create an app, build a web app, create API, create frontend, create backend, add a feature, build a service, make an application, develop a project, migrate my app, modernize my code, update my application, add database, add authentication, add caching, deploy to Azure, host on Azure, Azure with Terraform (defaults to azd+Terraform), Azure with azd, generate azure.yaml, generate Bicep or Terraform, prepare Azure Functions.
   DO NOT USE FOR: only validating an already-prepared app (use azure-validate), only running azd up/deploy (use azure-deploy), pure Terraform without azd (prefer azd+Terraform).

--- a/plugin/skills/azure-rbac/SKILL.md
+++ b/plugin/skills/azure-rbac/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-rbac
-description: |
+description: >-
   Helps users find the right Azure RBAC role for an identity with least privilege access, then generate CLI commands and Bicep code to assign it.
   USE FOR: "what role should I assign", "least privilege role", "RBAC role for", "role to read blobs", "role for managed identity", "custom role definition", "assign role to identity".
   DO NOT USE FOR: creating or configuring managed identities, or general Azure security hardening; those are out of scope for this role-selection skill.

--- a/plugin/skills/azure-resource-lookup/SKILL.md
+++ b/plugin/skills/azure-resource-lookup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-resource-lookup
-description: |
+description: >-
   List, find, and show Azure resources. Answers "list my VMs", "show my storage accounts", "list websites",
   "find container apps", "what resources do I have", and similar queries for any Azure resource type.
   USE FOR: list resources, list virtual machines, list VMs, list storage accounts, list websites, list web apps,

--- a/plugin/skills/azure-resource-visualizer/SKILL.md
+++ b/plugin/skills/azure-resource-visualizer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-resource-visualizer
-description: |
+description: >-
   Analyze Azure resource groups and generate detailed Mermaid architecture diagrams showing the relationships between individual resources.
   USE FOR: create architecture diagram, visualize Azure resources, show resource relationships, generate Mermaid diagram, analyze resource group, diagram my resources, architecture visualization, resource topology, map Azure infrastructure
   DO NOT USE FOR: creating/modifying resources (use azure-deploy), security scanning (use azure-security), performance troubleshooting (use azure-diagnostics), code generation (use relevant service skill)

--- a/plugin/skills/azure-validate/SKILL.md
+++ b/plugin/skills/azure-validate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-validate
-description: |
+description: >-
   Pre-deployment validation checkpoint. Run deep checks to ensure your application is ready for Azure deployment. Validates configuration, infrastructure, permissions, and prerequisites.
   USE FOR: validate my app, check deployment readiness, run preflight checks, verify configuration, check if ready to deploy, validate azure.yaml, validate Bicep, test before deploying, troubleshoot deployment errors.
   DO NOT USE FOR: creating or building apps (use azure-prepare), executing deployments (use azure-deploy).

--- a/plugin/skills/entra-app-registration/SKILL.md
+++ b/plugin/skills/entra-app-registration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: entra-app-registration
-description: |
+description: >-
   Guides Microsoft Entra ID app registration, OAuth 2.0 authentication, and MSAL integration.
   USE FOR: create app registration, register Azure AD app, configure OAuth, set up authentication, add API permissions, generate service principal, MSAL example, console app auth, Entra ID setup, Azure AD authentication.
   DO NOT USE FOR: Azure RBAC or role assignments (use azure-rbac), Key Vault secrets (use azure-keyvault-expiration-audit), Azure resource security (use azure-security).

--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: microsoft-foundry
-description: |
+description: >-
   Use this skill to work with Microsoft Foundry (Azure AI Foundry) and tools from Foundry MCP server: deploy AI models, manage AI agents (create, deploy, invoke, run, troubleshoot Foundry Agents), manage RBAC permissions and role assignments, manage quotas and capacity, create Foundry resources.
   USE FOR: Microsoft Foundry, AI Foundry, create agent, deploy agent, debug agent, invoke agent, run agent, agent chat, evaluate agent, agent monitoring, deploy model, model catalog, knowledge index, create Foundry project, new Foundry project, set up Foundry, onboard to Foundry, create Foundry resource, create AI Services, AIServices kind, register resource provider, enable Cognitive Services, setup AI Services account, create resource group for Foundry, RBAC, role assignment, quota, capacity, TPM, deployment failure, QuotaExceeded.
   DO NOT USE FOR: Azure Functions (use azure-functions), App Service (use azure-create-app), generic Azure resource creation (use azure-create-app).

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/agent-framework/SKILL.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/agent-framework/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agent-framework
-description: |
+description: >-
   Create AI agents and workflows using Microsoft Agent Framework SDK. Supports single-agent and multi-agent workflow patterns.
   USE FOR: create agent, build agent, scaffold agent, new agent, agent framework, workflow pattern, multi-agent, MCP tools, create workflow.
   DO NOT USE FOR: deploying agents (use deploy), evaluating agents (use agent/evaluate), Azure AI Foundry agents without Agent Framework SDK.

--- a/plugin/skills/microsoft-foundry/models/deploy-model/SKILL.md
+++ b/plugin/skills/microsoft-foundry/models/deploy-model/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: deploy-model
-description: |
+description: >-
   Unified Azure OpenAI model deployment skill with intelligent intent-based routing. Handles quick preset deployments, fully customized deployments (version/SKU/capacity/RAI policy), and capacity discovery across regions and projects.
   USE FOR: deploy model, deploy gpt, create deployment, model deployment, deploy openai model, set up model, provision model, find capacity, check model availability, where can I deploy, best region for model, capacity analysis.
   DO NOT USE FOR: listing existing deployments (use foundry_models_deployments_list MCP tool), deleting deployments, agent creation (use agent/create), project creation (use project/create).

--- a/plugin/skills/microsoft-foundry/models/deploy-model/capacity/SKILL.md
+++ b/plugin/skills/microsoft-foundry/models/deploy-model/capacity/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: capacity
-description: |
+description: >-
   Discovers available Azure OpenAI model capacity across regions and projects. Analyzes quota limits, compares availability, and recommends optimal deployment locations based on capacity requirements.
   USE FOR: find capacity, check quota, where can I deploy, capacity discovery, best region for capacity, multi-project capacity search, quota analysis, model availability, region comparison, check TPM availability.
   DO NOT USE FOR: actual deployment (hand off to preset or customize after discovery), quota increase requests (direct user to Azure Portal), listing existing deployments.

--- a/plugin/skills/microsoft-foundry/models/deploy-model/customize/SKILL.md
+++ b/plugin/skills/microsoft-foundry/models/deploy-model/customize/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: customize
-description: |
+description: >-
   Interactive guided deployment flow for Azure OpenAI models with full customization control. Step-by-step selection of model version, SKU (GlobalStandard/Standard/ProvisionedManaged), capacity, RAI policy (content filter), and advanced options (dynamic quota, priority processing, spillover). USE FOR: custom deployment, customize model deployment, choose version, select SKU, set capacity, configure content filter, RAI policy, deployment options, detailed deployment, advanced deployment, PTU deployment, provisioned throughput. DO NOT USE FOR: quick deployment to optimal region (use preset).
 ---
 

--- a/plugin/skills/microsoft-foundry/models/deploy-model/preset/SKILL.md
+++ b/plugin/skills/microsoft-foundry/models/deploy-model/preset/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: preset
-description: |
+description: >-
   Intelligently deploys Azure OpenAI models to optimal regions by analyzing capacity across all available regions. Automatically checks current region first and shows alternatives if needed. USE FOR: quick deployment, optimal region, best region, automatic region selection, fast setup, multi-region capacity check, high availability deployment, deploy to best location. DO NOT USE FOR: custom SKU selection (use customize), specific version selection (use customize), custom capacity configuration (use customize), PTU deployments (use customize).
 ---
 

--- a/plugin/skills/microsoft-foundry/project/create/create-foundry-project.md
+++ b/plugin/skills/microsoft-foundry/project/create/create-foundry-project.md
@@ -1,6 +1,6 @@
 ---
 name: foundry-create-project
-description: |
+description: >-
   Create a new Azure AI Foundry project using Azure Developer CLI (azd) to provision infrastructure for hosting AI agents and models.
   USE FOR: create Foundry project, new AI Foundry project, set up Foundry, azd init Foundry, provision Foundry infrastructure, onboard to Foundry, create Azure AI project, set up AI project.
   DO NOT USE FOR: deploying agents to existing projects (use deploy), creating agent code (use agent/create), deploying AI models from catalog (use microsoft-foundry main skill), Azure Functions (use azure-functions).

--- a/plugin/skills/microsoft-foundry/resource/create/create-foundry-resource.md
+++ b/plugin/skills/microsoft-foundry/resource/create/create-foundry-resource.md
@@ -1,6 +1,6 @@
 ---
 name: microsoft-foundry:resource/create
-description: |
+description: >-
   Create Azure AI Services multi-service resource (Foundry resource) using Azure CLI.
   USE FOR: create Foundry resource, new AI Services resource, create multi-service resource, provision Azure AI Services, AIServices kind resource, register resource provider, enable Cognitive Services, setup AI Services account, create resource group for Foundry.
   DO NOT USE FOR: creating ML workspace hubs (use microsoft-foundry:project/create), deploying models (use microsoft-foundry:models/deploy), managing permissions (use microsoft-foundry:rbac), monitoring resource usage (use microsoft-foundry:quota).

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -24,7 +24,7 @@ Load the file at `plugin/skills/{skill-name}/SKILL.md` to understand:
 - `references/services/` - Multiple Azure services the skill supports
 - References load only when explicitly linked, so understand what paths SKILL.md links to
 
-> **Frontmatter Format Rule:** Descriptions over 200 characters MUST use multi-line YAML format (`|`) for maintainability. See [azure-ai](../plugin/skills/azure-ai/SKILL.md), [azure-functions](../plugin/skills/azure-functions/SKILL.md) for examples.
+> **Frontmatter Format Rule:** Descriptions over 200 characters MUST use folded YAML format (`>-`) for maintainability. The `>-` format keeps descriptions readable in source while parsing to a flat string compatible with skills.sh and other registries. Do NOT use `|` (literal block) as it preserves newlines.
 
 ### Step 3: Update test files
 In each test file (`unit.test.ts`, `triggers.test.ts`), change:


### PR DESCRIPTION
## Problem

Skills were not rendering correctly on [skills.sh/microsoft/github-copilot-for-azure](https://skills.sh/microsoft/github-copilot-for-azure) because 21 skill files used the YAML literal block scalar for their description field. The literal format preserves newlines in the parsed string value, but skills.sh expects a flat single-line string.

## Root Cause

The YAML literal block scalar preserves newlines, producing parsed values like "Line one.\nUSE FOR: deploy.\n". The folded block scalar (>-) folds newlines into spaces, producing "Line one. USE FOR: deploy." which is what skills.sh expects.

## Solution

Switched from literal to folded block scalar (>-). This gives the best of both worlds:
- **In the file**: multi-line, readable, maintainable
- **When parsed**: single-line string with spaces (compatible with skills.sh)

## Changes

**21 skill files** (14 top-level + 7 microsoft-foundry sub-skills):
- Changed description format from literal to folded block scalar

**6 sensei/test documentation files**:
- Updated format rules, templates, and code examples to recommend >- instead of literal format
- .github/skills/sensei/SKILL.md, README.md, references/SCORING.md, references/EXAMPLES.md, references/LOOP.md
- tests/AGENTS.md

## Scoring Impact

**None.** Sensei scoring checks parsed string content (USE FOR, DO NOT USE FOR, description length, compatibility field). These substring checks work identically regardless of YAML scalar style -- the parsed value contains the same keywords.

## Validation

- Verified all 23 SKILL.md files parse to flat strings with no embedded newlines
- 27 files changed, 38 insertions, 38 deletions (clean 1:1 substitution)
