### PR TITLE
fix: use >- folded scalar for all SKILL.md descriptions

### DIFF
--- a/plugin/skills/azure-observability/SKILL.md
+++ b/plugin/skills/azure-observability/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: azure-observability
-description: Azure Observability Services including Azure Monitor, Application Insights, Log Analytics, Alerts, and Workbooks. Provides metrics, APM, distributed tracing, KQL queries, and interactive reports.
+description: >-
+  Azure Observability Services including Azure Monitor, Application Insights, Log Analytics, Alerts, and Workbooks. Provides metrics, APM, distributed tracing, KQL queries, and interactive reports.
+  USE FOR: Azure Monitor, Application Insights, Log Analytics, Alerts, Workbooks, metrics, APM, distributed tracing, KQL queries, interactive reports, observability, monitoring dashboards.
+  DO NOT USE FOR: instrumenting apps with App Insights SDK (use appinsights-instrumentation), querying Kusto/ADX clusters (use azure-kusto), cost analysis (use azure-cost-optimization).
 ---
 
 # Azure Observability Services

--- a/plugin/skills/azure-postgres/SKILL.md
+++ b/plugin/skills/azure-postgres/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: azure-postgres
-description: Create new Azure Database for PostgreSQL Flexible Server instances and configure passwordless authentication with Microsoft Entra ID. Set up developer access, managed identities for apps, group-based permissions, and migrate from password-based to Entra ID authentication. Trigger phrases include "passwordless for postgres", "entra id postgres", "azure ad postgres authentication", "postgres managed identity", "migrate postgres to passwordless".
+description: >-
+  Create new Azure Database for PostgreSQL Flexible Server instances and configure passwordless authentication with Microsoft Entra ID. Set up developer access, managed identities for apps, group-based permissions, and migrate from password-based to Entra ID authentication.
+  USE FOR: passwordless for postgres, entra id postgres, azure ad postgres authentication, postgres managed identity, migrate postgres to passwordless, create postgres server, configure postgres auth.
+  DO NOT USE FOR: MySQL databases (use azure-prepare), Cosmos DB (use azure-prepare), general Azure resource creation (use azure-prepare).
 ---
 
 # Azure Database for PostgreSQL

--- a/plugin/skills/azure-storage/SKILL.md
+++ b/plugin/skills/azure-storage/SKILL.md
@@ -1,6 +1,9 @@
 ---
 name: azure-storage
-description: Azure Storage Services including Blob Storage, File Shares, Queue Storage, Table Storage, and Data Lake. Provides object storage, SMB file shares, async messaging, NoSQL key-value, and big data analytics capabilities. Includes access tiers (hot, cool, archive) and lifecycle management.
+description: >-
+  Azure Storage Services including Blob Storage, File Shares, Queue Storage, Table Storage, and Data Lake. Provides object storage, SMB file shares, async messaging, NoSQL key-value, and big data analytics capabilities. Includes access tiers (hot, cool, archive) and lifecycle management.
+  USE FOR: blob storage, file shares, queue storage, table storage, data lake, upload files, download blobs, storage accounts, access tiers, lifecycle management.
+  DO NOT USE FOR: SQL databases (use azure-postgres), Cosmos DB (use azure-prepare), messaging with Event Hubs or Service Bus (use azure-messaging).
 ---
 
 # Azure Storage Services


### PR DESCRIPTION
## Problem

When skills are installed, SKILL.md files with plain unquoted \description\ values containing \: \ (colon-space) patterns fail to parse:

\\\
Nested mappings are not allowed in compact mappings at line 2, column 14
\\\

YAML interprets \USE FOR:\, \DO NOT USE FOR:\, and similar patterns as nested mapping keys instead of literal text.

## Changes

### 1. Convert 3 plain descriptions to \>-\ folded scalar

- \zure-observability/SKILL.md\ — added \USE FOR:\ and \DO NOT USE FOR:\ triggers
- \zure-storage/SKILL.md\ — added \USE FOR:\ and \DO NOT USE FOR:\ triggers
- \zure-postgres/SKILL.md\ — added \USE FOR:\ and \DO NOT USE FOR:\ triggers

These were the only 3 skills still using plain unquoted descriptions. All other 19 skills already use \>-\ folded scalar format per the repo convention.

### 2. Add YAML safety check to sensei scoring

Added Rule 8 (YAML Description Safety) to \.github/skills/sensei/references/SCORING.md\:
- Flags plain descriptions containing \: \ as **Invalid** (will fail to parse)
- Flags descriptions over 200 chars not using \>-\ as a **Warning**
- Updated scoring algorithm and \collectSuggestions()\ to include the new check

## Validation

All 23 SKILL.md files parse correctly with \gray-matter\ (js-yaml). No description exceeds the 1024-char limit.