### PR TITLE
Improve microsoft-foundry skill's create/debug part

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
@@ -44,7 +44,7 @@ If the user hasn't already specified, use `ask_user` to collect:
 
 > ⚠️ **Warning:** LangGraph is Python-only. For C# + LangGraph, suggest Agent Framework or Custom instead.
 
-If user has no specific preference, suggest Microsoft Agent Framework + Python as defaults. When using Agent Framework, read the [Agent Framework best practices](references/agentframework.md) for hosting adapter setup, credential patterns, and debugging guidance.
+If user has no specific preference, suggest Microsoft Agent Framework + Python as defaults.
 
 ### Step 3: Browse and Select Sample
 
@@ -228,6 +228,8 @@ Apply these to both greenfield and brownfield projects:
 1. **Logging** — Implement proper logging using the language's standard logging framework (Python `logging` module, .NET `ILogger`). Hosted agents stream container stdout/stderr logs to Foundry, so all log output is visible via the troubleshoot workflow. Use structured log levels (INFO, WARNING, ERROR) and include context like request IDs and agent names.
 
 2. **SSL Certificate Verification** — Applicable only For vNext Experience. Disable SSL certificate verification globally in the agent process. The hosted agent runtime environment uses internal certificates that may not be in the default trust store. For Python, set the environment variable `REQUESTS_CA_BUNDLE=""` and `SSL_CERT_FILE=""`, or configure `httpx`/`aiohttp` clients with `verify=False`. For .NET, configure `HttpClientHandler.ServerCertificateCustomValidationCallback` to always return true.
+
+3. **Framework-specific best practices** — When using Agent Framework, read the [Agent Framework best practices](references/agentframework.md) for hosting adapter setup, credential patterns, and debugging guidance.
 
 ## Error Handling
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
@@ -74,13 +74,13 @@ For workflow samples and advanced patterns, search the [Agent Framework GitHub r
 
 ## Debugging
 
-Use AI Toolkit for VS Code with the `agentdev` CLI tool for interactive debugging:
+Use [AI Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) with the `agentdev` CLI tool for interactive debugging:
 
 1. Install `debugpy` for VS Code Python Debugger support
 2. Install `agent-dev-cli` (pre-release) for the `agentdev` command
-3. Launch with: `python -m debugpy --listen 127.0.0.1:5679 -m agentdev run <entrypoint>.py --verbose --port 8087`
+3. Key debug tasks: `agentdev run <entrypoint>.py --port 8087` starts the agent HTTP server, `debugpy --listen 127.0.0.1:5679` attaches the debugger, and the `ai-mlstudio.openTestTool` VS Code command opens the Agent Inspector UI
 
-For VS Code `launch.json` and `tasks.json` configuration templates, see the [Agent Framework Getting Started samples](https://github.com/microsoft/agent-framework/tree/main/python/samples/01-get-started).
+For VS Code `launch.json` and `tasks.json` configuration templates, see [AI Toolkit Agent Inspector — Configure debugging manually](https://github.com/microsoft/vscode-ai-toolkit/blob/main/doc/agent-test-tool.md#configure-debugging-manually).
 
 ## Common Errors
 


### PR DESCRIPTION
- Apply agent-framework best practice for both greenfield and brownfield
- Optimize debugging part and correct template link

(Tested scenarios like "*/azure:microsoft-foundry Create a Python agent-framework based hosted agent... with local debug support*", "*/azure:microsoft-foundry Convert to host agent and add local debug support*")