### PR TITLE
Redact possible secrets in LLM generated report

### DIFF
--- a/tests/scripts/generate-test-reports.ts
+++ b/tests/scripts/generate-test-reports.ts
@@ -15,6 +15,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { useAgentRunner, type AgentRunConfig } from "../utils/agent-runner";
+import { redactSecrets } from "../utils/redact";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -64,7 +65,7 @@ function filterSubdirectoriesBySkill(subdirectories: string[], skill: string): s
     // See tests/eslint-rules/integration-test-name.mjs for details.
     const terminatorIndex = subdirName.indexOf("_");
     const skillName = subdirName.substring(0, terminatorIndex);
-    
+
     return skillName === skill;
   });
 }
@@ -117,6 +118,8 @@ async function processSubdirectory(subdirPath: string, reportTemplate: string): 
 
     consolidatedContent += `\n## ${fileName}\n\n${content}\n`;
   }
+
+  consolidatedContent = redactSecrets(consolidatedContent);
 
   console.log("    Generating report...");
 

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -18,28 +18,13 @@ import * as path from "path";
 import { fileURLToPath } from "url";
 import { type CopilotSession, CopilotClient, type SessionEvent } from "@github/copilot-sdk";
 import { getAllAssistantMessages } from "./evaluate";
+import { redactSecrets } from "./redact";
+
 // Re-export for backward compatibility (consumers still import from agent-runner)
 export { getAllAssistantMessages } from "./evaluate";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-
-/** Redact token-like values from report text to prevent secret leakage */
-const SECRET_PATTERNS = [
-  /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, // JWT
-  /Bearer\s+[A-Za-z0-9_\-.~+/]{20,}/gi, // Bearer tokens
-  /gh[pousr]_[A-Za-z0-9_]{36,}/g, // GitHub tokens
-  /(?:password|passwd|secret|token|api[_-]?key|connection[_-]?string)\s*[:=]\s*["']?[^\s"',]{8,}/gi, // key=value secrets
-];
-
-function redactSecrets(text: string): string {
-  let result = text;
-  for (const pattern of SECRET_PATTERNS) {
-    pattern.lastIndex = 0;
-    result = result.replace(pattern, "[REDACTED]");
-  }
-  return result;
-}
 
 export interface AgentMetadata {
   /**

--- a/tests/utils/redact.ts
+++ b/tests/utils/redact.ts
@@ -1,0 +1,16 @@
+/** Redact token-like values from report text to prevent secret leakage */
+const SECRET_PATTERNS = [
+    /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g, // JWT
+    /Bearer\s+[A-Za-z0-9_\-.~+/]{20,}/gi, // Bearer tokens
+    /gh[pousr]_[A-Za-z0-9_]{36,}/g, // GitHub tokens
+    /(?:password|passwd|secret|token|api[_-]?key|connection[_-]?string)\s*[:=]\s*["']?[^\s"',]{8,}/gi, // key=value secrets
+];
+
+export function redactSecrets(text: string): string {
+    let result = text;
+    for (const pattern of SECRET_PATTERNS) {
+        pattern.lastIndex = 0;
+        result = result.replace(pattern, "[REDACTED]");
+    }
+    return result;
+}


### PR DESCRIPTION
Prevent the LLM from accidentally including secrets in the generated report by redacting potential secret values in its input.