### PR TITLE
fix: convert SKILL.md descriptions from YAML folded scalars to inline

### DIFF
--- a/plugin/skills/appinsights-instrumentation/SKILL.md
+++ b/plugin/skills/appinsights-instrumentation/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: appinsights-instrumentation
-description: >-
-  Guidance for instrumenting webapps with Azure Application Insights. Provides telemetry patterns, SDK setup, and configuration references.
-  USE FOR: how to instrument app, App Insights SDK, telemetry patterns, what is App Insights, Application Insights guidance, instrumentation examples, APM best practices.
-  DO NOT USE FOR: adding App Insights to my app (use azure-prepare), add telemetry to my project (use azure-prepare), add monitoring (use azure-prepare). This skill provides guidance—azure-prepare orchestrates component changes.
+description: "Guidance for instrumenting webapps with Azure Application Insights. Provides telemetry patterns, SDK setup, and configuration references. USE FOR: how to instrument app, App Insights SDK, telemetry patterns, what is App Insights, Application Insights guidance, instrumentation examples, APM best practices. DO NOT USE FOR: adding App Insights to my app (use azure-prepare), add telemetry to my project (use azure-prepare), add monitoring (use azure-prepare). This skill provides guidance—azure-prepare orchestrates component changes."
 ---
 
 # AppInsights Instrumentation Guide

--- a/plugin/skills/azure-aigateway/SKILL.md
+++ b/plugin/skills/azure-aigateway/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: azure-aigateway
-description: >-
-  Configure Azure API Management (APIM) as AI Gateway to secure, observe, control AI models, MCP servers, agents. Helps with rate limiting, semantic caching, content safety, load balancing.
-  USE FOR: AI Gateway, APIM, setup gateway, configure gateway, add gateway, model gateway, MCP server, rate limit, token limit, semantic cache, content safety, load balance, OpenAPI import, convert API to MCP.
-  DO NOT USE FOR: deploy models (use microsoft-foundry), Azure Functions (use azure-functions), databases.
+description: "Configure Azure API Management (APIM) as AI Gateway to secure, observe, control AI models, MCP servers, agents. Helps with rate limiting, semantic caching, content safety, load balancing. USE FOR: AI Gateway, APIM, setup gateway, configure gateway, add gateway, model gateway, MCP server, rate limit, token limit, semantic cache, content safety, load balance, OpenAPI import, convert API to MCP. DO NOT USE FOR: deploy models (use microsoft-foundry), Azure Functions (use azure-functions), databases."
 ---
 
 # Azure AI Gateway

--- a/plugin/skills/azure-compliance/SKILL.md
+++ b/plugin/skills/azure-compliance/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: azure-compliance
-description: >-
-  Comprehensive Azure compliance and security auditing capabilities including best practices assessment,
-  Key Vault expiration monitoring, and resource configuration validation.
-  USE FOR: compliance scan, security audit, azqr, Azure best practices, Key Vault expiration check,
-  compliance assessment, resource review, configuration validation, expired certificates, expiring secrets,
-  orphaned resources, policy compliance, security posture evaluation.
-  DO NOT USE FOR: deploying resources (use azure-deploy), cost analysis alone (use azure-cost-optimization),
-  active security hardening (use azure-security-hardening), general Azure Advisor queries (use azure-observability).
+description: "Comprehensive Azure compliance and security auditing capabilities including best practices assessment, Key Vault expiration monitoring, and resource configuration validation. USE FOR: compliance scan, security audit, azqr, Azure best practices, Key Vault expiration check, compliance assessment, resource review, configuration validation, expired certificates, expiring secrets, orphaned resources, policy compliance, security posture evaluation. DO NOT USE FOR: deploying resources (use azure-deploy), cost analysis alone (use azure-cost-optimization), active security hardening (use azure-security-hardening), general Azure Advisor queries (use azure-observability)."
 ---
 
 # Azure Compliance & Security Auditing

--- a/plugin/skills/azure-cost-optimization/SKILL.md
+++ b/plugin/skills/azure-cost-optimization/SKILL.md
@@ -1,13 +1,6 @@
 ---
 name: azure-cost-optimization
-description: >-
-  Identify and quantify cost savings across Azure subscriptions by analyzing actual costs,
-  utilization metrics, and generating actionable optimization recommendations. USE FOR:
-  optimize Azure costs, reduce Azure spending, reduce Azure expenses, analyze Azure costs,
-  find cost savings, generate cost optimization report, find orphaned resources, rightsize VMs,
-  cost analysis, reduce waste, Azure spending analysis, find unused resources, optimize Redis
-  costs. DO NOT USE FOR: deploying resources (use azure-deploy), general Azure diagnostics
-  (use azure-diagnostics), security issues (use azure-security)
+description: "Identify and quantify cost savings across Azure subscriptions by analyzing actual costs, utilization metrics, and generating actionable optimization recommendations. USE FOR: optimize Azure costs, reduce Azure spending, reduce Azure expenses, analyze Azure costs, find cost savings, generate cost optimization report, find orphaned resources, rightsize VMs, cost analysis, reduce waste, Azure spending analysis, find unused resources, optimize Redis costs. DO NOT USE FOR: deploying resources (use azure-deploy), general Azure diagnostics (use azure-diagnostics), security issues (use azure-security)"
 ---
 
 # Azure Cost Optimization Skill

--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: azure-deploy
-description: >-
-  Execute deployment to Azure. Final step after preparation and validation. Runs azd up, azd deploy, or infrastructure provisioning commands.
-  USE FOR: run azd up, run azd deploy, execute deployment, provision infrastructure, push to production, go live, ship it, deploy web app, deploy container app, deploy static site, deploy Azure Functions, deploy function app, deploy serverless function, deploy Azure Functions to cloud, bicep deploy, terraform apply.
-  DO NOT USE FOR: creating or building apps (use azure-prepare), validating before deploy (use azure-validate).
+description: "Execute deployment to Azure. Final step after preparation and validation. Runs azd up, azd deploy, or infrastructure provisioning commands. USE FOR: run azd up, run azd deploy, execute deployment, provision infrastructure, push to production, go live, ship it, deploy web app, deploy container app, deploy static site, deploy Azure Functions, deploy function app, deploy serverless function, deploy Azure Functions to cloud, bicep deploy, terraform apply. DO NOT USE FOR: creating or building apps (use azure-prepare), validating before deploy (use azure-validate)."
 ---
 
 # Azure Deploy

--- a/plugin/skills/azure-diagnostics/SKILL.md
+++ b/plugin/skills/azure-diagnostics/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: azure-diagnostics
-description: >-
-  Debug and troubleshoot production issues on Azure. Covers Container Apps diagnostics, log analysis with KQL, health checks, and common issue resolution for image pulls, cold starts, and health probes.
-  USE FOR: debug production issues, troubleshoot container apps, analyze logs with KQL, fix image pull failures, resolve cold start issues, investigate health probe failures, check resource health, view application logs, find root cause of errors
-  DO NOT USE FOR: deploying applications (use azure-deploy), creating new resources (use azure-prepare), setting up monitoring (use azure-observability), cost optimization (use azure-cost-optimization)
+description: "Debug and troubleshoot production issues on Azure. Covers Container Apps diagnostics, log analysis with KQL, health checks, and common issue resolution for image pulls, cold starts, and health probes. USE FOR: debug production issues, troubleshoot container apps, analyze logs with KQL, fix image pull failures, resolve cold start issues, investigate health probe failures, check resource health, view application logs, find root cause of errors DO NOT USE FOR: deploying applications (use azure-deploy), creating new resources (use azure-prepare), setting up monitoring (use azure-observability), cost optimization (use azure-cost-optimization)"
 ---
 
 # Azure Diagnostics

--- a/plugin/skills/azure-kusto/SKILL.md
+++ b/plugin/skills/azure-kusto/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: azure-kusto
-description: >-
-  Query and analyze data in Azure Data Explorer (Kusto/ADX) using KQL for log analytics, telemetry, and time series analysis.
-  USE FOR: KQL queries, Kusto database queries, Azure Data Explorer, ADX clusters, log analytics, time series data, IoT telemetry, anomaly detection
-  DO NOT USE FOR: SQL databases, NoSQL queries (use azure-storage), Elasticsearch, AWS analytics tools
+description: "Query and analyze data in Azure Data Explorer (Kusto/ADX) using KQL for log analytics, telemetry, and time series analysis. USE FOR: KQL queries, Kusto database queries, Azure Data Explorer, ADX clusters, log analytics, time series data, IoT telemetry, anomaly detection DO NOT USE FOR: SQL databases, NoSQL queries (use azure-storage), Elasticsearch, AWS analytics tools"
 ---
 
 # Azure Data Explorer (Kusto) Query & Analytics

--- a/plugin/skills/azure-messaging/SKILL.md
+++ b/plugin/skills/azure-messaging/SKILL.md
@@ -1,15 +1,6 @@
 ---
 name: azure-messaging
-description: >-
-  Troubleshoot and resolve issues with Azure Messaging SDKs for Event Hubs and Service Bus.
-  Covers connection failures, authentication errors, message processing issues, and SDK configuration problems.
-  USE FOR: event hub SDK error, service bus SDK issue, messaging connection failure, AMQP error,
-  event processor host issue, message lock lost, send timeout, receiver disconnected, SDK troubleshooting,
-  azure messaging SDK, event hub consumer, service bus queue issue, topic subscription error,
-  enable logging event hub, service bus logging, eventhub python, servicebus java, eventhub javascript,
-  servicebus dotnet, event hub checkpoint, event hub not receiving messages, service bus dead letter
-  DO NOT USE FOR: creating Event Hub or Service Bus resources (use azure-prepare), monitoring metrics
-  (use azure-observability), cost analysis (use azure-cost-optimization)
+description: "Troubleshoot and resolve issues with Azure Messaging SDKs for Event Hubs and Service Bus. Covers connection failures, authentication errors, message processing issues, and SDK configuration problems. USE FOR: event hub SDK error, service bus SDK issue, messaging connection failure, AMQP error, event processor host issue, message lock lost, send timeout, receiver disconnected, SDK troubleshooting, azure messaging SDK, event hub consumer, service bus queue issue, topic subscription error, enable logging event hub, service bus logging, eventhub python, servicebus java, eventhub javascript, servicebus dotnet, event hub checkpoint, event hub not receiving messages, service bus dead letter DO NOT USE FOR: creating Event Hub or Service Bus resources (use azure-prepare), monitoring metrics (use azure-observability), cost analysis (use azure-cost-optimization)"
 ---
 
 # Azure Messaging SDK Troubleshooting

--- a/plugin/skills/azure-observability/SKILL.md
+++ b/plugin/skills/azure-observability/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: azure-observability
-description: >-
-  Azure Observability Services including Azure Monitor, Application Insights, Log Analytics, Alerts, and Workbooks. Provides metrics, APM, distributed tracing, KQL queries, and interactive reports.
-  USE FOR: Azure Monitor, Application Insights, Log Analytics, Alerts, Workbooks, metrics, APM, distributed tracing, KQL queries, interactive reports, observability, monitoring dashboards.
-  DO NOT USE FOR: instrumenting apps with App Insights SDK (use appinsights-instrumentation), querying Kusto/ADX clusters (use azure-kusto), cost analysis (use azure-cost-optimization).
+description: "Azure Observability Services including Azure Monitor, Application Insights, Log Analytics, Alerts, and Workbooks. Provides metrics, APM, distributed tracing, KQL queries, and interactive reports. USE FOR: Azure Monitor, Application Insights, Log Analytics, Alerts, Workbooks, metrics, APM, distributed tracing, KQL queries, interactive reports, observability, monitoring dashboards. DO NOT USE FOR: instrumenting apps with App Insights SDK (use appinsights-instrumentation), querying Kusto/ADX clusters (use azure-kusto), cost analysis (use azure-cost-optimization)."
 ---
 
 # Azure Observability Services

--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: azure-prepare
-description: >-
-  Default entry point for Azure application development. Invoke for ANY app work related to Azure: creating, building, updating, migrating, or modernizing apps. Analyzes your project and prepares it for Azure deployment by generating infrastructure code (Bicep/Terraform), azure.yaml, and Dockerfiles.
-  USE FOR: create an app, build a web app, create API, create frontend, create backend, add a feature, build a service, develop a project, migrate my app, modernize my code, update my application, add database, add authentication, add caching, deploy to Azure, host on Azure, Azure with Terraform, Azure with azd, generate azure.yaml, generate Bicep or Terraform, prepare Azure Functions, create Azure Functions app, create serverless HTTP API, create function app, create event-driven function.
-  DO NOT USE FOR: only validating an already-prepared app (use azure-validate), only running azd up/deploy (use azure-deploy), pure Terraform without azd (prefer azd+Terraform).
+description: "Default entry point for Azure application development. Invoke for ANY app work related to Azure: creating, building, updating, migrating, or modernizing apps. Analyzes your project and prepares it for Azure deployment by generating infrastructure code (Bicep/Terraform), azure.yaml, and Dockerfiles. USE FOR: create an app, build a web app, create API, create frontend, create backend, add a feature, build a service, develop a project, migrate my app, modernize my code, update my application, add database, add authentication, add caching, deploy to Azure, host on Azure, Azure with Terraform, Azure with azd, generate azure.yaml, generate Bicep or Terraform, prepare Azure Functions, create Azure Functions app, create serverless HTTP API, create function app, create event-driven function. DO NOT USE FOR: only validating an already-prepared app (use azure-validate), only running azd up/deploy (use azure-deploy), pure Terraform without azd (prefer azd+Terraform)."
 ---
 
 # Azure Prepare

--- a/plugin/skills/azure-rbac/SKILL.md
+++ b/plugin/skills/azure-rbac/SKILL.md
@@ -1,8 +1,5 @@
 ---
 name: azure-rbac
-description: >-
-  Helps users find the right Azure RBAC role for an identity with least privilege access, then generate CLI commands and Bicep code to assign it.
-  USE FOR: "what role should I assign", "least privilege role", "RBAC role for", "role to read blobs", "role for managed identity", "custom role definition", "assign role to identity".
-  DO NOT USE FOR: creating or configuring managed identities, or general Azure security hardening; those are out of scope for this role-selection skill.
+description: "Helps users find the right Azure RBAC role for an identity with least privilege access, then generate CLI commands and Bicep code to assign it. USE FOR: \"what role should I assign\", \"least privilege role\", \"RBAC role for\", \"role to read blobs\", \"role for managed identity\", \"custom role definition\", \"assign role to identity\". DO NOT USE FOR: creating or configuring managed identities, or general Azure security hardening; those are out of scope for this role-selection skill."
 ---
 Use the 'azure__documentation' tool to find the minimal role definition that matches the desired permissions the user wants to assign to an identity. If no built-in role matches the desired permissions, use the 'azure__extension_cli_generate' tool to create a custom role definition with the desired permissions. Then use the 'azure__extension_cli_generate' tool to generate the CLI commands needed to assign that role to the identity. Finally, use the 'azure__bicepschema' and 'azure__get_azure_bestpractices' tools to provide a Bicep code snippet for adding the role assignment.

--- a/plugin/skills/azure-resource-lookup/SKILL.md
+++ b/plugin/skills/azure-resource-lookup/SKILL.md
@@ -1,16 +1,6 @@
 ---
 name: azure-resource-lookup
-description: >-
-  List, find, and show Azure resources. Answers "list my VMs", "show my storage accounts", "list websites",
-  "find container apps", "what resources do I have", and similar queries for any Azure resource type.
-  USE FOR: list resources, list virtual machines, list VMs, list storage accounts, list websites, list web apps,
-  list container apps, show resources, find resources, what resources do I have, list resources in resource group,
-  list resources in subscription, find resources by tag, find orphaned resources, resource inventory,
-  count resources by type, cross-subscription resource query, Azure Resource Graph, resource discovery,
-  list container registries, list SQL servers, list Key Vaults, show resource groups, list app services,
-  find resources across subscriptions, find unattached disks, tag analysis.
-  DO NOT USE FOR: deploying resources (use azure-deploy), creating or modifying resources,
-  cost optimization (use azure-cost-optimization), writing application code, non-Azure clouds.
+description: "List, find, and show Azure resources. Answers \"list my VMs\", \"show my storage accounts\", \"list websites\", \"find container apps\", \"what resources do I have\", and similar queries for any Azure resource type. USE FOR: list resources, list virtual machines, list VMs, list storage accounts, list websites, list web apps, list container apps, show resources, find resources, what resources do I have, list resources in resource group, list resources in subscription, find resources by tag, find orphaned resources, resource inventory, count resources by type, cross-subscription resource query, Azure Resource Graph, resource discovery, list container registries, list SQL servers, list Key Vaults, show resource groups, list app services, find resources across subscriptions, find unattached disks, tag analysis. DO NOT USE FOR: deploying resources (use azure-deploy), creating or modifying resources, cost optimization (use azure-cost-optimization), writing application code, non-Azure clouds."
 ---
 
 # Azure Resource Lookup

--- a/plugin/skills/azure-resource-visualizer/SKILL.md
+++ b/plugin/skills/azure-resource-visualizer/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: azure-resource-visualizer
-description: >-
-  Analyze Azure resource groups and generate detailed Mermaid architecture diagrams showing the relationships between individual resources.
-  USE FOR: create architecture diagram, visualize Azure resources, show resource relationships, generate Mermaid diagram, analyze resource group, diagram my resources, architecture visualization, resource topology, map Azure infrastructure
-  DO NOT USE FOR: creating/modifying resources (use azure-deploy), security scanning (use azure-security), performance troubleshooting (use azure-diagnostics), code generation (use relevant service skill)
+description: "Analyze Azure resource groups and generate detailed Mermaid architecture diagrams showing the relationships between individual resources. USE FOR: create architecture diagram, visualize Azure resources, show resource relationships, generate Mermaid diagram, analyze resource group, diagram my resources, architecture visualization, resource topology, map Azure infrastructure DO NOT USE FOR: creating/modifying resources (use azure-deploy), security scanning (use azure-security), performance troubleshooting (use azure-diagnostics), code generation (use relevant service skill)"
 ---
 
 # Azure Resource Visualizer - Architecture Diagram Generator

--- a/plugin/skills/azure-storage/SKILL.md
+++ b/plugin/skills/azure-storage/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: azure-storage
-description: >-
-  Azure Storage Services including Blob Storage, File Shares, Queue Storage, Table Storage, and Data Lake. Provides object storage, SMB file shares, async messaging, NoSQL key-value, and big data analytics capabilities. Includes access tiers (hot, cool, archive) and lifecycle management.
-  USE FOR: blob storage, file shares, queue storage, table storage, data lake, upload files, download blobs, storage accounts, access tiers, lifecycle management.
-  DO NOT USE FOR: SQL databases, Cosmos DB (use azure-prepare), messaging with Event Hubs or Service Bus (use azure-messaging).
+description: "Azure Storage Services including Blob Storage, File Shares, Queue Storage, Table Storage, and Data Lake. Provides object storage, SMB file shares, async messaging, NoSQL key-value, and big data analytics capabilities. Includes access tiers (hot, cool, archive) and lifecycle management. USE FOR: blob storage, file shares, queue storage, table storage, data lake, upload files, download blobs, storage accounts, access tiers, lifecycle management. DO NOT USE FOR: SQL databases, Cosmos DB (use azure-prepare), messaging with Event Hubs or Service Bus (use azure-messaging)."
 ---
 
 # Azure Storage Services

--- a/plugin/skills/azure-validate/SKILL.md
+++ b/plugin/skills/azure-validate/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: azure-validate
-description: >-
-  Pre-deployment validation checkpoint. Run deep checks to ensure your application is ready for Azure deployment. Validates configuration, infrastructure, permissions, and prerequisites.
-  USE FOR: validate my app, check deployment readiness, run preflight checks, verify configuration, check if ready to deploy, validate azure.yaml, validate Bicep, test before deploying, troubleshoot deployment errors, validate Azure Functions, validate function app, validate serverless deployment.
-  DO NOT USE FOR: creating or building apps (use azure-prepare), executing deployments (use azure-deploy).
+description: "Pre-deployment validation checkpoint. Run deep checks to ensure your application is ready for Azure deployment. Validates configuration, infrastructure, permissions, and prerequisites. USE FOR: validate my app, check deployment readiness, run preflight checks, verify configuration, check if ready to deploy, validate azure.yaml, validate Bicep, test before deploying, troubleshoot deployment errors, validate Azure Functions, validate function app, validate serverless deployment. DO NOT USE FOR: creating or building apps (use azure-prepare), executing deployments (use azure-deploy)."
 ---
 
 # Azure Validate

--- a/plugin/skills/entra-app-registration/SKILL.md
+++ b/plugin/skills/entra-app-registration/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: entra-app-registration
-description: >-
-  Guides Microsoft Entra ID app registration, OAuth 2.0 authentication, and MSAL integration.
-  USE FOR: create app registration, register Azure AD app, configure OAuth, set up authentication, add API permissions, generate service principal, MSAL example, console app auth, Entra ID setup, Azure AD authentication.
-  DO NOT USE FOR: Azure RBAC or role assignments (use azure-rbac), Key Vault secrets (use azure-keyvault-expiration-audit), Azure resource security (use azure-security).
+description: "Guides Microsoft Entra ID app registration, OAuth 2.0 authentication, and MSAL integration. USE FOR: create app registration, register Azure AD app, configure OAuth, set up authentication, add API permissions, generate service principal, MSAL example, console app auth, Entra ID setup, Azure AD authentication. DO NOT USE FOR: Azure RBAC or role assignments (use azure-rbac), Key Vault secrets (use azure-keyvault-expiration-audit), Azure resource security (use azure-security)."
 ---
 
 ## Overview

--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: microsoft-foundry
-description: >-
-  Use this skill to work with Microsoft Foundry (Azure AI Foundry) and tools from Foundry MCP server: deploy AI models, manage hosted agent and prompt agent (create, deploy, invoke, run, troubleshoot Foundry Agents), manage RBAC permissions and role assignments, manage quotas and capacity, create Foundry resources.
-  USE FOR: Microsoft Foundry, AI Foundry, hosted agent, create agent, deploy agent, debug agent, invoke agent, run agent, agent chat, evaluate agent, agent monitoring, deploy model, model catalog, knowledge index, create Foundry project, new Foundry project, set up Foundry, onboard to Foundry, create Foundry resource, create AI Services, AIServices kind, register resource provider, enable Cognitive Services, setup AI Services account, create resource group for Foundry, RBAC, role assignment, quota, capacity, TPM, deployment failure, QuotaExceeded.
-  DO NOT USE FOR: Azure Functions (use azure-functions), App Service (use azure-create-app), generic Azure resource creation (use azure-create-app).
+description: "Use this skill to work with Microsoft Foundry (Azure AI Foundry) and tools from Foundry MCP server: deploy AI models, manage hosted agent and prompt agent (create, deploy, invoke, run, troubleshoot Foundry Agents), manage RBAC permissions and role assignments, manage quotas and capacity, create Foundry resources. USE FOR: Microsoft Foundry, AI Foundry, hosted agent, create agent, deploy agent, debug agent, invoke agent, run agent, agent chat, evaluate agent, agent monitoring, deploy model, model catalog, knowledge index, create Foundry project, new Foundry project, set up Foundry, onboard to Foundry, create Foundry resource, create AI Services, AIServices kind, register resource provider, enable Cognitive Services, setup AI Services account, create resource group for Foundry, RBAC, role assignment, quota, capacity, TPM, deployment failure, QuotaExceeded. DO NOT USE FOR: Azure Functions (use azure-functions), App Service (use azure-create-app), generic Azure resource creation (use azure-create-app)."
 ---
 
 # Microsoft Foundry Skill

--- a/plugin/skills/microsoft-foundry/models/deploy-model/SKILL.md
+++ b/plugin/skills/microsoft-foundry/models/deploy-model/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: deploy-model
-description: >-
-  Unified Azure OpenAI model deployment skill with intelligent intent-based routing. Handles quick preset deployments, fully customized deployments (version/SKU/capacity/RAI policy), and capacity discovery across regions and projects.
-  USE FOR: deploy model, deploy gpt, create deployment, model deployment, deploy openai model, set up model, provision model, find capacity, check model availability, where can I deploy, best region for model, capacity analysis.
-  DO NOT USE FOR: listing existing deployments (use foundry_models_deployments_list MCP tool), deleting deployments, agent creation (use agent/create), project creation (use project/create).
+description: "Unified Azure OpenAI model deployment skill with intelligent intent-based routing. Handles quick preset deployments, fully customized deployments (version/SKU/capacity/RAI policy), and capacity discovery across regions and projects. USE FOR: deploy model, deploy gpt, create deployment, model deployment, deploy openai model, set up model, provision model, find capacity, check model availability, where can I deploy, best region for model, capacity analysis. DO NOT USE FOR: listing existing deployments (use foundry_models_deployments_list MCP tool), deleting deployments, agent creation (use agent/create), project creation (use project/create)."
 ---
 
 # Deploy Model

--- a/plugin/skills/microsoft-foundry/models/deploy-model/capacity/SKILL.md
+++ b/plugin/skills/microsoft-foundry/models/deploy-model/capacity/SKILL.md
@@ -1,9 +1,6 @@
 ---
 name: capacity
-description: >-
-  Discovers available Azure OpenAI model capacity across regions and projects. Analyzes quota limits, compares availability, and recommends optimal deployment locations based on capacity requirements.
-  USE FOR: find capacity, check quota, where can I deploy, capacity discovery, best region for capacity, multi-project capacity search, quota analysis, model availability, region comparison, check TPM availability.
-  DO NOT USE FOR: actual deployment (hand off to preset or customize after discovery), quota increase requests (direct user to Azure Portal), listing existing deployments.
+description: "Discovers available Azure OpenAI model capacity across regions and projects. Analyzes quota limits, compares availability, and recommends optimal deployment locations based on capacity requirements. USE FOR: find capacity, check quota, where can I deploy, capacity discovery, best region for capacity, multi-project capacity search, quota analysis, model availability, region comparison, check TPM availability. DO NOT USE FOR: actual deployment (hand off to preset or customize after discovery), quota increase requests (direct user to Azure Portal), listing existing deployments."
 ---
 
 # Capacity Discovery

--- a/plugin/skills/microsoft-foundry/models/deploy-model/customize/SKILL.md
+++ b/plugin/skills/microsoft-foundry/models/deploy-model/customize/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: customize
-description: >-
-  Interactive guided deployment flow for Azure OpenAI models with full customization control. Step-by-step selection of model version, SKU (GlobalStandard/Standard/ProvisionedManaged), capacity, RAI policy (content filter), and advanced options (dynamic quota, priority processing, spillover). USE FOR: custom deployment, customize model deployment, choose version, select SKU, set capacity, configure content filter, RAI policy, deployment options, detailed deployment, advanced deployment, PTU deployment, provisioned throughput. DO NOT USE FOR: quick deployment to optimal region (use preset).
+description: "Interactive guided deployment flow for Azure OpenAI models with full customization control. Step-by-step selection of model version, SKU (GlobalStandard/Standard/ProvisionedManaged), capacity, RAI policy (content filter), and advanced options (dynamic quota, priority processing, spillover). USE FOR: custom deployment, customize model deployment, choose version, select SKU, set capacity, configure content filter, RAI policy, deployment options, detailed deployment, advanced deployment, PTU deployment, provisioned throughput. DO NOT USE FOR: quick deployment to optimal region (use preset)."
 ---
 
 # Customize Model Deployment

--- a/plugin/skills/microsoft-foundry/models/deploy-model/preset/SKILL.md
+++ b/plugin/skills/microsoft-foundry/models/deploy-model/preset/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: preset
-description: >-
-  Intelligently deploys Azure OpenAI models to optimal regions by analyzing capacity across all available regions. Automatically checks current region first and shows alternatives if needed. USE FOR: quick deployment, optimal region, best region, automatic region selection, fast setup, multi-region capacity check, high availability deployment, deploy to best location. DO NOT USE FOR: custom SKU selection (use customize), specific version selection (use customize), custom capacity configuration (use customize), PTU deployments (use customize).
+description: "Intelligently deploys Azure OpenAI models to optimal regions by analyzing capacity across all available regions. Automatically checks current region first and shows alternatives if needed. USE FOR: quick deployment, optimal region, best region, automatic region selection, fast setup, multi-region capacity check, high availability deployment, deploy to best location. DO NOT USE FOR: custom SKU selection (use customize), specific version selection (use customize), custom capacity configuration (use customize), PTU deployments (use customize)."
 ---
 
 # Deploy Model to Optimal Region


### PR DESCRIPTION
skills.sh cannot parse YAML multi-line scalar syntax (>-) in frontmatter description fields, causing descriptions to render as literal '>-' instead of the actual description text. 

This PR converts all 21 affected SKILL.md files in plugin/skills/ from >- folded scalars to inline double-quoted strings, preserving the exact description content.

<img width="1057" height="642" alt="image" src="https://github.com/user-attachments/assets/987fb8ef-082e-4a43-a089-2faf57124bbb" />

[Link to skills.sh page](https://skills.sh/microsoft/github-copilot-for-azure)