### PR TITLE
feat: cross-model description compatibility for skill frontmatter

### DIFF
--- a/.github/skills/sensei/SKILL.md
+++ b/.github/skills/sensei/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sensei
-description: "Iteratively improve skill frontmatter compliance using the Ralph loop pattern. USE FOR: run sensei, sensei help, improve skill, fix frontmatter, skill compliance, frontmatter audit, improve triggers, add anti-triggers, batch skill improvement, check skill tokens. DO NOT USE FOR: creating new skills (use skill-authoring), writing skill content, token optimization only (use markdown-token-optimizer), or non-frontmatter changes."
+description: "**WORKFLOW SKILL** — Iteratively improve skill frontmatter compliance using the Ralph loop pattern. WHEN: \"run sensei\", \"sensei help\", \"improve skill\", \"fix frontmatter\", \"skill compliance\", \"frontmatter audit\", \"score skill\", \"check skill tokens\". INVOKES: token counting tools, test runners, git commands. FOR SINGLE OPERATIONS: use token CLI directly for counts/checks."
 ---
 
 # Sensei
@@ -35,7 +35,7 @@ When user says "sensei help" or asks how to use sensei, show this:
 ║    1. READ      - Load skill's SKILL.md, tests, and token count  ║
 ║    2. SCORE     - Check compliance (Low/Medium/Medium-High/High) ║
 ║    3. SCAFFOLD  - Create tests from template if missing          ║
-║    4. IMPROVE   - Add USE FOR triggers + DO NOT USE FOR          ║
+║    4. IMPROVE   - Add WHEN: triggers (cross-model optimized)     ║
 ║    5. TEST      - Run tests, fix if needed                       ║
 ║    6. REFERENCES- Validate markdown links                        ║
 ║    7. TOKENS    - Check token budget, gather suggestions         ║
@@ -44,9 +44,9 @@ When user says "sensei help" or asks how to use sensei, show this:
 ║   10. REPEAT    - Until Medium-High score + tests pass           ║
 ║                                                                  ║
 ║  TARGET SCORE: Medium-High                                       ║
-║    ✓ Description > 150 chars                                     ║
-║    ✓ Has "USE FOR:" trigger phrases                              ║
-║    ✓ Has "DO NOT USE FOR:" anti-triggers                         ║
+║    ✓ Description > 150 chars, ≤ 60 words                         ║
+║    ✓ Has "WHEN:" trigger phrases (preferred)                     ║
+║    ✓ No "DO NOT USE FOR:" (cross-model compat)                   ║
 ║    ✓ SKILL.md < 500 tokens (soft limit)                          ║
 ║                                                                  ║
 ║  MORE INFO:                                                      ║
@@ -91,11 +91,13 @@ For each skill, execute this loop until score >= Medium-High AND tests pass:
 1. **READ** - Load `plugin/skills/{skill-name}/SKILL.md`, tests, and token count
 2. **SCORE** - Run spec-based compliance check (see [SCORING.md](references/SCORING.md)):
    - Validate `name` per [agentskills.io spec](https://agentskills.io/specification) (no `--`, no start/end `-`, lowercase alphanumeric)
-   - Check description length, triggers, anti-triggers
+   - Check description length and word count (≤60 words)
+   - Check triggers (WHEN: preferred, USE FOR: accepted)
+   - Warn on "DO NOT USE FOR:" (cross-model contamination)
    - Preserve optional spec fields (`license`, `metadata`, `allowed-tools`) if present
 3. **CHECK** - If score >= Medium-High AND tests pass → go to TOKENS step
 4. **SCAFFOLD** - If `tests/{skill-name}/` doesn't exist, create from `tests/_template/`
-5. **IMPROVE FRONTMATTER** - Add triggers, anti-triggers, compatibility (stay under 1024 chars)
+5. **IMPROVE FRONTMATTER** - Add WHEN: triggers (stay under 60 words and 1024 chars)
 6. **IMPROVE TESTS** - Update `shouldTriggerPrompts` and `shouldNotTriggerPrompts` to match
 7. **VERIFY** - Run `cd tests && npm test -- --testPathPattern={skill-name}`
 8. **VALIDATE REFERENCES** - Run `cd scripts && npm run references {skill-name}` to check markdown links
@@ -111,12 +113,14 @@ Sensei validates skills against the [agentskills.io specification](https://agent
 | Score | Requirements |
 |-------|--------------|
 | **Invalid** | Name fails spec validation (consecutive hyphens, start/end hyphen, uppercase, etc.) |
-| **Low** | Basic description, no explicit triggers, no anti-triggers |
-| **Medium** | Has trigger keywords/phrases, description > 150 chars |
-| **Medium-High** | Has "USE FOR:" triggers AND "DO NOT USE FOR:" anti-triggers |
-| **High** | Triggers + anti-triggers + compatibility field |
+| **Low** | Basic description, no explicit triggers |
+| **Medium** | Has trigger keywords/phrases, description > 150 chars, >60 words |
+| **Medium-High** | Has "WHEN:" (preferred) or "USE FOR:" triggers, ≤60 words |
+| **High** | Medium-High + compatibility field |
 
-**Target: Medium-High** (triggers + anti-triggers present)
+**Target: Medium-High** (distinctive triggers, concise description)
+
+> ⚠️ "DO NOT USE FOR:" is **actively discouraged** — causes keyword contamination on Claude Sonnet and similar models. Use positive routing with `WHEN:` instead.
 
 **Strongly recommended** (reported as suggestions if missing):
 - `license` — identifies the license applied to the skill
@@ -129,10 +133,7 @@ Per the [agentskills.io spec](https://agentskills.io/specification), required an
 ```yaml
 ---
 name: skill-name
-description: >-
-  [1-2 sentence description of what the skill does]
-  USE FOR: [trigger phrase 1], [trigger phrase 2], [trigger phrase 3]
-  DO NOT USE FOR: [scenario] (use other-skill), [scenario] (use another-skill)
+description: "[ACTION VERB] [UNIQUE_DOMAIN]. [One clarifying sentence]. WHEN: \"trigger 1\", \"trigger 2\", \"trigger 3\"."
 license: MIT
 metadata:
   version: "1.0"
@@ -142,9 +143,9 @@ metadata:
 ---
 ```
 
-> **IMPORTANT:** Always use folded YAML format (`>-`) for descriptions over 200 characters. Single-line descriptions become difficult to read, review, and maintain. The `>-` format keeps descriptions readable in source while parsing to a flat string compatible with skills.sh and other registries.
+> **IMPORTANT:** Use inline double-quoted strings for descriptions. Do NOT use `>-` folded scalars (incompatible with skills.sh). Do NOT use `|` literal blocks (preserves newlines). Keep total description under 1024 characters and ≤60 words.
 
-> Keep total description under 1024 characters.
+> ⚠️ **Do NOT add "DO NOT USE FOR:" clauses.** Anti-trigger clauses cause keyword contamination on Claude Sonnet and similar models — they introduce the very keywords that trigger wrong-skill activation. Use positive routing with distinctive `WHEN:` phrases instead.
 
 ## Test Scaffolding
 

--- a/.github/skills/sensei/references/EXAMPLES.md
+++ b/.github/skills/sensei/references/EXAMPLES.md
@@ -44,27 +44,20 @@ const shouldNotTriggerPrompts = [
 ```yaml
 ---
 name: appinsights-instrumentation
-description: >-
-  Instrument web applications to send telemetry data to Azure Application Insights
-  for monitoring and diagnostics. USE FOR: "add App Insights", "instrument my app",
-  "set up application monitoring", "add telemetry", "track requests and dependencies",
-  "ASP.NET Core telemetry", "Node.js Application Insights". DO NOT USE FOR: querying
-  existing logs (use azure-observability), creating alerts or dashboards, analyzing
-  costs, or Azure Monitor metrics queries.
+description: "Instrument web applications to send telemetry to Azure Application Insights for monitoring and diagnostics. WHEN: \"add App Insights\", \"instrument my app\", \"set up application monitoring\", \"add telemetry\", \"track requests and dependencies\", \"ASP.NET Core telemetry\", \"Node.js Application Insights\"."
 ---
 ```
 
 **Metrics:**
 - Score: Medium-High ✅
 - Tokens: ~385 (under 500 budget ✅)
-- Triggers: 7
-- Anti-triggers: 4
+- Triggers: 7 (WHEN: format)
 
 **Improvements:**
-- ✅ 385 characters - informative but under 1024 limit
-- ✅ Clear description of purpose
-- ✅ Explicit "USE FOR:" trigger phrases
-- ✅ "DO NOT USE FOR:" anti-triggers prevent collision
+- ✅ Informative but concise (under 60 words)
+- ✅ Uses inline double-quoted string (skills.sh compatible)
+- ✅ Explicit "WHEN:" trigger phrases with quoted keywords
+- ✅ No "DO NOT USE FOR:" (avoids keyword contamination)
 
 **triggers.test.ts:**
 ```javascript
@@ -114,20 +107,14 @@ description: 'Azure Security Services including Key Vault, Managed Identity, RBA
 ```yaml
 ---
 name: azure-security
-description: >-
-  Overview of Azure security services and concepts including Key Vault, Managed Identity,
-  RBAC, Entra ID, and Defender for Cloud. USE FOR: "Azure security overview", "what
-  security services are available", "explain managed identity", "RBAC basics", "Key Vault
-  concepts", "Entra ID overview", "Defender for Cloud features". DO NOT USE FOR: hardening
-  existing resources (use azure-security-hardening), Entra app registration setup (use
-  entra-app-registration), or role assignment guidance (use azure-rbac).
+description: "Overview of Azure security services and concepts including Key Vault, Managed Identity, RBAC, Entra ID, and Defender for Cloud. WHEN: \"Azure security overview\", \"what security services are available\", \"explain managed identity\", \"RBAC basics\", \"Key Vault concepts\", \"Entra ID overview\", \"Defender for Cloud features\"."
 ---
 ```
 
 **Improvements:**
 - ✅ Reframed as "overview/concepts" skill
-- ✅ Explicit triggers for educational queries
-- ✅ Clear anti-triggers pointing to specialized skills
+- ✅ Explicit WHEN: triggers for educational queries
+- ✅ No "DO NOT USE FOR:" (avoids keyword contamination with azure-security-hardening, entra-app-registration)
 
 ---
 
@@ -157,20 +144,14 @@ description: >-
 ```yaml
 ---
 name: azure-deploy
-description: >-
-  Deploy applications to Azure App Service, Azure Functions, and Static Web Apps.
-  USE FOR: "deploy to Azure", "host on Azure", "publish to Azure", "run on Azure",
-  "azd up", "deploy my app", "push to Azure", "get this running in the cloud".
-  DO NOT USE FOR: initial project setup (use azure-create-app), validating Bicep
-  before deployment (use azure-deployment-preflight), or troubleshooting failed
-  deployments (use azure-diagnostics).
+description: "Deploy applications to Azure App Service, Azure Functions, and Static Web Apps. WHEN: \"deploy to Azure\", \"host on Azure\", \"publish to Azure\", \"run on Azure\", \"azd up\", \"deploy my app\", \"push to Azure\", \"get this running in the cloud\"."
 ---
 ```
 
 **Improvements:**
-- ✅ Added "DO NOT USE FOR:" section
-- ✅ Clear handoff to related skills
-- ✅ Prevents deployment vs. setup confusion
+- ✅ Uses WHEN: with distinctive quoted trigger phrases
+- ✅ No "DO NOT USE FOR:" — previously mentioned "azure-create-app" and "azure-deployment-preflight" which caused keyword contamination
+- ✅ Concise and cross-model optimized
 
 ---
 
@@ -237,21 +218,31 @@ sensei: improve appinsights-instrumentation frontmatter
 
 ## Anti-Pattern Examples
 
-### ❌ Don't Do This: Single-Line Long Description
+### ❌ Don't Do This: Anti-Trigger Keyword Contamination
 
 ```yaml
-description: Identify and quantify cost savings across Azure subscriptions by analyzing actual costs, utilization metrics, and generating actionable optimization recommendations. USE FOR: optimize Azure costs, reduce Azure spending, analyze Azure costs, find cost savings. DO NOT USE FOR: cost estimation for new resources (use azure-cost-estimation).
+description: "Deploy to Azure. USE FOR: \"deploy app\", \"push to production\". DO NOT USE FOR: Function apps (use azure-functions), storage accounts (use azure-storage), Kubernetes (use azure-aks)."
 ```
 
-**Problem:** Single-line descriptions over 200 characters are hard to read, review, and maintain. Use folded YAML format (`>-`) instead:
+**Problem:** The "DO NOT USE FOR" clause introduces "Function apps", "storage", "Kubernetes" — on Claude Sonnet these keywords cause this skill to activate for Functions, Storage, and AKS tasks. Remove anti-triggers and use positive routing with distinctive `WHEN:` phrases instead.
+
+### ❌ Don't Do This: Description Too Dense (>60 words)
+
+```yaml
+description: "This skill orchestrates the complete Azure deployment workflow including preparation, validation, and execution phases for web applications, APIs, Function apps, container apps, and static web apps. It generates Bicep templates, Terraform configurations, azure.yaml files, and Dockerfiles. USE FOR: deploy, create app, build, migrate, modernize, prepare, validate, provision, configure, set up, initialize..."
+```
+
+**Problem:** At 60+ words, Sonnet's attention is diluted across all 24+ skill descriptions. Cap at ≤60 words and front-load the unique signal.
+
+### ❌ Don't Do This: Using >- Folded Scalars
 
 ```yaml
 description: >-
-  Identify and quantify cost savings across Azure subscriptions by analyzing actual costs,
-  utilization metrics, and generating actionable optimization recommendations. USE FOR:
-  optimize Azure costs, reduce Azure spending, analyze Azure costs, find cost savings.
-  DO NOT USE FOR: cost estimation for new resources (use azure-cost-estimation).
+  Deploy applications to Azure App Service, Azure Functions, and Static Web Apps.
+  USE FOR: "deploy to Azure", "host on Azure", "publish to Azure".
 ```
+
+**Problem:** The `>-` folded scalar syntax is incompatible with skills.sh and other registries. Use inline double-quoted strings instead.
 
 ### ❌ Don't Do This: Overly Long Description
 

--- a/.github/skills/sensei/references/LOOP.md
+++ b/.github/skills/sensei/references/LOOP.md
@@ -161,25 +161,24 @@ const SKILL_NAME = '{skill-name}';  // Replace placeholder
 **Action:** Enhance the SKILL.md frontmatter
 
 **Goals:**
-1. Add "USE FOR:" section with trigger phrases
-2. Add "DO NOT USE FOR:" section with anti-triggers
-3. Keep description under 1024 characters
-4. Maintain clarity and usefulness
+1. Add "WHEN:" section with distinctive quoted trigger phrases (preferred over "USE FOR:")
+2. Remove any "DO NOT USE FOR:" clauses (keyword contamination risk)
+3. Keep description under 60 words and 1024 characters
+4. Lead with unique action verb + domain
+
+> ⚠️ **Do NOT add "DO NOT USE FOR:" clauses.** They cause keyword contamination on Claude Sonnet — anti-triggers introduce the very keywords that trigger wrong-skill activation. Use positive routing with distinctive `WHEN:` phrases instead.
 
 **Strategy:**
 - Read skill content to understand purpose
-- Identify related skills for anti-triggers
-- Extract keywords that should trigger this skill
-- Identify scenarios that should NOT trigger this skill
+- Identify distinctive action verbs and domain for lead sentence
+- Extract 3-5 quoted phrases unique to this skill for WHEN: triggers
+- Keep total description ≤60 words for cross-model reliability
 
 **Template:**
 ```yaml
 ---
 name: {skill-name}
-description: >-
-  [What the skill does - 1-2 sentences]
-  USE FOR: [phrase1], [phrase2], [phrase3], [phrase4], [phrase5]
-  DO NOT USE FOR: [scenario1] (use other-skill), [scenario2] (use another-skill)
+description: "[ACTION VERB] [UNIQUE_DOMAIN]. [One clarifying sentence]. WHEN: \"[phrase1]\", \"[phrase2]\", \"[phrase3]\", \"[phrase4]\", \"[phrase5]\"."
 ---
 ```
 
@@ -193,12 +192,11 @@ description: >-
 **Updates needed:**
 
 1. **shouldTriggerPrompts** (minimum 5):
-   - Match the "USE FOR:" phrases
+   - Match the "WHEN:" or "USE FOR:" phrases
    - Include variations and natural language
    - Cover the skill's primary use cases
 
 2. **shouldNotTriggerPrompts** (minimum 5):
-   - Match the "DO NOT USE FOR:" scenarios
    - Include unrelated topics (weather, poetry)
    - Include other cloud providers (AWS, GCP)
    - Include related but different Azure services

--- a/.github/skills/skill-authoring/SKILL.md
+++ b/.github/skills/skill-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-authoring
-description: "Guidelines for writing Agent Skills. TRIGGERS: create a skill, new skill, write a skill, skill template, skill structure, review skill, skill PR, skill compliance, agentskills spec, SKILL.md format, skill frontmatter, skill best practices"
+description: "Guidelines for writing Agent Skills that comply with the agentskills.io specification. WHEN: \"create a skill\", \"new skill\", \"write a skill\", \"skill template\", \"skill structure\", \"review skill\", \"skill PR\", \"skill compliance\", \"SKILL.md format\", \"skill frontmatter\", \"skill best practices\"."
 ---
 
 # Skill Authoring Guide
@@ -17,7 +17,10 @@ This skill provides guidance for writing Agent Skills that comply with the [agen
 ## Constraints
 
 - `name`: 1-64 chars, lowercase + hyphens, match directory
-- `description`: 1-1024 chars, explain WHAT and WHEN
+- `description`: 1-1024 chars, ≤60 words, explain WHAT and WHEN
+- Use `WHEN:` with quoted trigger phrases (preferred over `USE FOR:`)
+- Do NOT use `DO NOT USE FOR:` (keyword contamination on Sonnet)
+- Use inline double-quoted strings (not `>-` folded scalars)
 - SKILL.md: <500 tokens (soft), <5000 (hard)
 - references/*.md: <1000 tokens each
 

--- a/.github/skills/skill-authoring/references/CHECKLIST.md
+++ b/.github/skills/skill-authoring/references/CHECKLIST.md
@@ -10,7 +10,10 @@ Use this checklist before submitting a new skill or updating an existing one.
 - [ ] `name` matches the parent directory name
 - [ ] `description` field is present and 1-1024 characters
 - [ ] `description` explains WHAT the skill does
-- [ ] `description` explains WHEN to use it (activation triggers)
+- [ ] `description` explains WHEN to use it (use `WHEN:` with quoted trigger phrases)
+- [ ] `description` does NOT contain `DO NOT USE FOR:` (keyword contamination risk)
+- [ ] `description` is ≤ 60 words (cross-model density)
+- [ ] `description` uses inline double-quoted string (not `>-` folded scalar)
 
 ## Token Budget
 

--- a/.github/skills/skill-authoring/references/guidelines/frontmatter.md
+++ b/.github/skills/skill-authoring/references/guidelines/frontmatter.md
@@ -37,13 +37,21 @@ metadata:
 
 ## Activation Triggers
 
+Use `WHEN:` with distinctive quoted trigger phrases (preferred for cross-model compatibility):
+
 ```yaml
-# Good - specific keywords and scenarios
-description: Performs Azure compliance assessments using azqr. Use when users 
-  ask to check compliance, assess Azure resources, run azqr, or review security posture.
+# Good - WHEN: with quoted phrases (preferred)
+description: "Perform Azure compliance assessments using azqr. WHEN: \"check compliance\", \"assess Azure resources\", \"run azqr\", \"review security posture\"."
+```
+
+```yaml
+# Accepted - USE FOR: still works
+description: "Perform Azure compliance assessments using azqr. USE FOR: \"check compliance\", \"assess Azure resources\", \"run azqr\"."
 ```
 
 ```yaml
 # Bad - too vague
-description: Helps with Azure stuff.
+description: "Helps with Azure stuff."
 ```
+
+> ⚠️ **Do NOT add "DO NOT USE FOR:" clauses.** They cause keyword contamination on Claude Sonnet and similar models. Use positive routing with distinctive `WHEN:` phrases instead.


### PR DESCRIPTION
## Summary

Backport cross-model description compatibility changes from the [sensei repo](https://github.com/shboyer/sensei). Based on [cross-model analysis](https://gist.github.com/kvenkatrajan/52e6e77f5560ca30640490b4cc65d109) of skill invocation reliability across Claude Sonnet, GPT-4, and Gemini.

### Problem

Skill descriptions invoke unreliably on Claude Sonnet (vs Opus) due to:
1. **Description length overload** — 60-100 word descriptions dilute attention
2. **Keyword contamination** — \\DO NOT USE FOR:\\ clauses introduce competing keywords that trigger wrong skills
3. **Inconsistent format** — multiple description patterns across skills
4. **Missing density constraints** — no word count limits

### Changes

| Change | Before | After |
|--------|--------|-------|
| Trigger format | \\USE FOR:\\ (loose keywords) | \\WHEN:\\ (quoted phrases, preferred) |
| Anti-triggers | \\DO NOT USE FOR:\\ required | **Actively warned against** (keyword contamination) |
| Word count | No limit | ≤60 words |
| YAML format | \\>-\\ folded scalar | Inline double-quoted string |
| Scoring | Medium-High requires anti-triggers | Medium-High requires distinctive triggers + density |

### Files Changed

**sensei skill** (\\.github/skills/sensei/\\):
- \\SKILL.md\\ — Updated description, help box, scoring table, frontmatter template
- \\eferences/SCORING.md\\ — Updated adherence levels, trigger/anti-trigger detection, scoring algorithm
- \\eferences/EXAMPLES.md\\ — Updated before/after examples, added anti-pattern examples
- \\eferences/LOOP.md\\ — Updated improve frontmatter step and test guidance

**skill-authoring skill** (\\.github/skills/skill-authoring/\\):
- \\SKILL.md\\ — Updated description to use WHEN:, added constraints for density/format
- \\eferences/CHECKLIST.md\\ — Added word count, anti-trigger, and format checks
- \\eferences/guidelines/frontmatter.md\\ — Updated activation triggers guidance

### Dependencies

Depends on #1038 (\\>-\\ to inline description conversion for plugin skills)

### Core Principle

> Sonnet selects skills by fast pattern matching on the first ~20 words, not by deep reasoning over 100-word descriptions. Front-load the signal, eliminate noise, and make each skill's identity unmistakable in its opening phrase.