### PR TITLE
Use the MI service connection to query for key vaults

### DIFF
--- a/pipelines/azure-benchmarks.yml
+++ b/pipelines/azure-benchmarks.yml
@@ -17,7 +17,7 @@ stages:
     - task: AzureCLI@2
       displayName: 'Run Copilot Benchmarks script'
       inputs:
-        connectedServiceNameARM: 'azure-sdk_to_ghcp4a-testing'
+        connectedServiceNameARM: 'azure_msbench_eval'
         addSpnToEnvironment: true
         scriptType: 'pscore'
         scriptLocation: 'scriptPath'

--- a/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
@@ -2,5 +2,11 @@ param(
     [string]$BuildId
 )
 
+
+
+# Install MSBench CLI
+Write-Host "Installing keyring"
+pip install keyring artifacts-keyring
+
 Write-Host "Listing key vaults in the resource group"
 az keyvault list --resource-group rg-msbench-eval-kv-azure-mcp --query "[].name" -o tsv


### PR DESCRIPTION
Prove agent-to-azure access by using the new `azure_msbench_eval` service connection to list the vaults in our test resource group.