### PR TITLE
Approve all permission requests

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -16,7 +16,7 @@ import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
 import { fileURLToPath } from "url";
-import { type CopilotSession, CopilotClient, type SessionEvent } from "@github/copilot-sdk";
+import { type CopilotSession, CopilotClient, type SessionEvent, approveAll } from "@github/copilot-sdk";
 import { getAllAssistantMessages } from "./evaluate";
 import { redactSecrets } from "./redact";
 
@@ -391,6 +391,7 @@ export function useAgentRunner() {
 
       const session = await client.createSession({
         model: "claude-sonnet-4.5",
+        onPermissionRequest: approveAll,
         skillDirectories: [skillDirectory],
         mcpServers: {
           azure: {
@@ -735,6 +736,7 @@ export async function runConversation(config: ConversationConfig): Promise<Conve
 
     session = await client.createSession({
       model: "claude-sonnet-4.5",
+      onPermissionRequest: approveAll,
       skillDirectories: [skillDirectory],
       mcpServers: {
         azure: {


### PR DESCRIPTION
PR #1028 updated the Copilot SDK package we use for testing to at least version 0.1.25. This brought along a [breaking change](https://github.com/github/copilot-sdk/pull/509) where all tool operations are denied by default.

Since our integration tests needs to run in a fully automated manner, this commit adds `onPermissionRequest: approveAll` to restore the previous behavior.