### PR TITLE
Early terminate skill-invocation tests of azure-prepare

### DIFF
--- a/tests/_template/integration.test.ts
+++ b/tests/_template/integration.test.ts
@@ -15,11 +15,11 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import {
   useAgentRunner,
-  isSkillInvoked,
   areToolCallsSuccess,
   doesAssistantMessageIncludeKeyword,
   shouldSkipIntegrationTests
 } from "../utils/agent-runner";
+import { isSkillInvoked } from "../utils/evaluate";
 
 // Replace with your skill name
 const SKILL_NAME = "your-skill-name";

--- a/tests/azure-hosted-copilot-sdk/util.ts
+++ b/tests/azure-hosted-copilot-sdk/util.ts
@@ -9,12 +9,12 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   type AgentMetadata,
 } from "../utils/agent-runner";
 import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
+import { isSkillInvoked } from "../utils/evaluate";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/tests/azure-messaging/integration.test.ts
+++ b/tests/azure-messaging/integration.test.ts
@@ -10,12 +10,12 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   doesAssistantMessageIncludeKeyword,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason
 } from "../utils/agent-runner";
 import { softCheckSkill } from "../utils/evaluate";
+import { isSkillInvoked } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-messaging";
 const RUNS_PER_PROMPT = 3;

--- a/tests/azure-prepare/integration.test.ts
+++ b/tests/azure-prepare/integration.test.ts
@@ -11,15 +11,14 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
-  getToolCalls
 } from "../utils/agent-runner";
 import { hasValidationCommand } from "../azure-validate/utils";
 import { hasPlanReadyForValidation, getDockerContext, hasServicesSection, getServiceProject } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
-import { expectFiles, softCheckSkill } from "../utils/evaluate";
+import { expectFiles, getToolCalls, softCheckSkill } from "../utils/evaluate";
+import { isSkillInvoked } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-prepare";
 const RUNS_PER_PROMPT = 5;
@@ -40,11 +39,13 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   const agent = useAgentRunner();
 
   describe("skill-invocation", () => {
+    const maxToolCallBeforeTerminate = 3;
     test("invokes azure-prepare skill for new Azure application preparation prompt", async () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Prepare my application for Azure deployment and set up the infrastructure"
+            prompt: "Prepare my application for Azure deployment and set up the infrastructure",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -62,7 +63,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Modernize my existing application for Azure hosting and generate the required infrastructure files"
+            prompt: "Modernize my existing application for Azure hosting and generate the required infrastructure files",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -80,7 +82,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Prepare my Azure application to use Key Vault for storing secrets and credentials"
+            prompt: "Prepare my Azure application to use Key Vault for storing secrets and credentials",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -98,7 +101,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Set up my Azure application with managed identity authentication for accessing Azure services"
+            prompt: "Set up my Azure application with managed identity authentication for accessing Azure services",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -115,7 +119,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a simple social media application with likes and comments and deploy to Azure using Terraform infrastructure code"
+            prompt: "Create a simple social media application with likes and comments and deploy to Azure using Terraform infrastructure code",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -133,7 +138,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure"
+            prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -151,7 +157,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create an event-driven function app to process messages and deploy to Azure Functions"
+            prompt: "Create an event-driven function app to process messages and deploy to Azure Functions",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -169,7 +176,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create an Azure Functions app with a timer trigger"
+            prompt: "Create an Azure Functions app with a timer trigger",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -188,7 +196,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a static whiteboard web app and deploy to Azure using my current subscription in eastus2 region."
+            prompt: "Create a static whiteboard web app and deploy to Azure using my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -206,7 +215,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a static portfolio website and deploy to Azure using my current subscription in eastus2 region."
+            prompt: "Create a static portfolio website and deploy to Azure using my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -225,7 +235,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a discussion board application and deploy to Azure App Service using my current subscription in eastus2 region."
+            prompt: "Create a discussion board application and deploy to Azure App Service using my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -243,7 +254,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a todo list with frontend and API and deploy to Azure App Service using my current subscription in eastus2 region."
+            prompt: "Create a todo list with frontend and API and deploy to Azure App Service using my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -262,7 +274,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure using my current subscription in eastus2 region."
+            prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure using my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -280,7 +293,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create an event-driven function app to process messages and deploy to Azure Functions using my current subscription in eastus2 region."
+            prompt: "Create an event-driven function app to process messages and deploy to Azure Functions using my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -298,7 +312,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create an azure python function app that takes input from a service bus trigger and does message processing and deploy to Azure using my current subscription in eastus2 region."
+            prompt: "Create an azure python function app that takes input from a service bus trigger and does message processing and deploy to Azure using my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -317,7 +332,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a containerized web application and deploy to Azure Container Apps using my current subscription in eastus2 region."
+            prompt: "Create a containerized web application and deploy to Azure Container Apps using my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -335,7 +351,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a simple containerized Node.js hello world app and deploy to Azure Container Apps using my current subscription in eastus2 region."
+            prompt: "Create a simple containerized Node.js hello world app and deploy to Azure Container Apps using my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -354,7 +371,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a static whiteboard web app and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create a static whiteboard web app and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -372,7 +390,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a static portfolio website and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create a static portfolio website and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -391,7 +410,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a discussion board application and deploy to Azure App Service using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create a discussion board application and deploy to Azure App Service using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -409,7 +429,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a todo list with frontend and API and deploy to Azure App Service using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create a todo list with frontend and API and deploy to Azure App Service using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -428,7 +449,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -446,7 +468,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create an event-driven function app to process messages and deploy to Azure Functions using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create an event-driven function app to process messages and deploy to Azure Functions using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -464,7 +487,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a URL shortener service using Azure Functions that creates short links and redirects users to the original URL and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create a URL shortener service using Azure Functions that creates short links and redirects users to the original URL and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -483,7 +507,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a containerized web application and deploy to Azure Container Apps using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create a containerized web application and deploy to Azure Container Apps using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -501,7 +526,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a simple containerized Node.js hello world app and deploy to Azure Container Apps using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create a simple containerized Node.js hello world app and deploy to Azure Container Apps using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -519,7 +545,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a simple social media application with likes and comments and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region."
+            prompt: "Create a simple social media application with likes and comments and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
+            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -658,7 +685,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
       expect(workspacePath).toBeDefined();
       expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
-      
+
       // Verify azure.yaml exists
       expectFiles(workspacePath!, [/azure\.yaml$/], []);
 

--- a/tests/azure-prepare/utils.ts
+++ b/tests/azure-prepare/utils.ts
@@ -1,6 +1,6 @@
-import { type AgentMetadata, getToolCalls } from "../utils/agent-runner";
+import { type AgentMetadata } from "../utils/agent-runner";
 import * as fs from "fs";
-import { listFilesRecursive } from "../utils/evaluate";
+import { getToolCalls, listFilesRecursive } from "../utils/evaluate";
 
 /**
  * Check if the agent has set the plan status to "Ready for Validation"

--- a/tests/azure-rbac/integration.test.ts
+++ b/tests/azure-rbac/integration.test.ts
@@ -11,13 +11,13 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   areToolCallsSuccess,
   doesAssistantMessageIncludeKeyword,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason
 } from "../utils/agent-runner";
 import { softCheckSkill } from "../utils/evaluate";
+import { isSkillInvoked } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-rbac";
 const RUNS_PER_PROMPT = 5;

--- a/tests/azure-resource-lookup/integration.test.ts
+++ b/tests/azure-resource-lookup/integration.test.ts
@@ -13,10 +13,10 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   doesAssistantMessageIncludeKeyword,
   shouldSkipIntegrationTests
 } from "../utils/agent-runner";
+import { isSkillInvoked } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-resource-lookup";
 

--- a/tests/azure-resource-visualizer/integration.test.ts
+++ b/tests/azure-resource-visualizer/integration.test.ts
@@ -13,13 +13,13 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
-  getToolCalls,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason
 } from "../utils/agent-runner";
 import type { AgentMetadata } from "../utils/agent-runner";
 import { softCheckSkill } from "../utils/evaluate";
+import { isSkillInvoked } from "../utils/evaluate";
+import { getToolCalls } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-resource-visualizer";
 const RUNS_PER_PROMPT = 5;

--- a/tests/azure-validate/integration.test.ts
+++ b/tests/azure-validate/integration.test.ts
@@ -11,7 +11,6 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason
 } from "../utils/agent-runner";
@@ -21,7 +20,7 @@ import {
 } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
 import { matchesCommand, softCheckSkill } from "../utils/evaluate";
-
+import { isSkillInvoked } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-validate";
 const RUNS_PER_PROMPT = 5;

--- a/tests/azure-validate/utils.ts
+++ b/tests/azure-validate/utils.ts
@@ -1,4 +1,5 @@
-import { type AgentMetadata, getToolCalls } from "../utils/agent-runner";
+import { type AgentMetadata } from "../utils/agent-runner";
+import { getToolCalls } from "../utils/evaluate";
 
 /**
  * Validation command patterns that indicate the agent is performing

--- a/tests/microsoft-foundry/foundry-agent/create/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/create/integration.test.ts
@@ -12,11 +12,11 @@
 import {
   useAgentRunner,
   AgentMetadata,
-  getToolCalls,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../../../utils/agent-runner";
 import { softCheckSkill } from "../../../utils/evaluate";
+import { getToolCalls } from "../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 const RUNS_PER_PROMPT = 5;

--- a/tests/microsoft-foundry/foundry-agent/deploy/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/deploy/integration.test.ts
@@ -7,11 +7,11 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   doesAssistantMessageIncludeKeyword,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../../../utils/agent-runner";
+import { isSkillInvoked } from "../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 

--- a/tests/microsoft-foundry/foundry-agent/invoke/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/invoke/integration.test.ts
@@ -7,11 +7,11 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   doesAssistantMessageIncludeKeyword,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../../../utils/agent-runner";
+import { isSkillInvoked } from "../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 

--- a/tests/microsoft-foundry/foundry-agent/observe/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/observe/integration.test.ts
@@ -7,9 +7,9 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   shouldSkipIntegrationTests
 } from "../../../utils/agent-runner";
+import { isSkillInvoked } from "../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 

--- a/tests/microsoft-foundry/foundry-agent/trace/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/trace/integration.test.ts
@@ -7,9 +7,9 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   shouldSkipIntegrationTests
 } from "../../../utils/agent-runner";
+import { isSkillInvoked } from "../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 

--- a/tests/microsoft-foundry/foundry-agent/troubleshoot/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/troubleshoot/integration.test.ts
@@ -7,11 +7,11 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   doesAssistantMessageIncludeKeyword,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../../../utils/agent-runner";
+import { isSkillInvoked } from "../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 

--- a/tests/microsoft-foundry/integration.test.ts
+++ b/tests/microsoft-foundry/integration.test.ts
@@ -11,11 +11,11 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../utils/agent-runner";
 import { softCheckSkill } from "../utils/evaluate";
+import { isSkillInvoked } from "../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 const RUNS_PER_PROMPT = 5;

--- a/tests/microsoft-foundry/quota/integration.test.ts
+++ b/tests/microsoft-foundry/quota/integration.test.ts
@@ -14,10 +14,10 @@
 
 import {
   useAgentRunner,
-  isSkillInvoked,
   doesAssistantMessageIncludeKeyword,
   shouldSkipIntegrationTests
 } from "../../utils/agent-runner";
+import { isSkillInvoked } from "../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -464,19 +464,6 @@ export function useAgentRunner() {
 }
 
 /**
- * Check if a skill was invoked during the session
- */
-export function isSkillInvoked(agentMetadata: AgentMetadata, skillName: string): boolean {
-  return agentMetadata.events
-    .filter(event => event.type === "tool.execution_start")
-    .filter(event => event.data.toolName === "skill")
-    .some(event => {
-      const args = event.data.arguments;
-      return JSON.stringify(args).includes(skillName);
-    });
-}
-
-/**
  * Check if all tool calls for a given tool were successful
  */
 export function areToolCallsSuccess(agentMetadata: AgentMetadata, toolName?: string): boolean {
@@ -529,19 +516,6 @@ export function doesAssistantMessageIncludeKeyword(
     }
     return message.toLowerCase().includes(keyword.toLowerCase());
   });
-}
-
-/**
- * Get all tool calls made during the session
- */
-export function getToolCalls(agentMetadata: AgentMetadata, toolName?: string): SessionEvent[] {
-  let calls = agentMetadata.events.filter(event => event.type === "tool.execution_start");
-
-  if (toolName) {
-    calls = calls.filter(event => event.data.toolName === toolName);
-  }
-
-  return calls;
 }
 
 // Track skip reason for reporting


### PR DESCRIPTION
Early terminate skill-invcation tests of azure-prepare when either of these events happen:
- The azure-prepare skill is invoked
- 3 tools have been invoked but azure-prepare skill hasn't been invoked

This aims at reducing the amount of time spent on running these test cases.

