### PR TITLE
Fix broken auto-create evaluators step in deploy/observe loop

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
@@ -229,11 +229,46 @@ After a successful deployment, persist the following to a `.env` or config file 
 
 If a `.env` file already exists, read it first and merge — do not overwrite existing values without confirmation.
 
-## After Deployment
+## After Deployment — Auto-Create Evaluators & Dataset
 
-After a successful deployment, ask the user: *"Would you like to set up evaluation and monitoring for this agent?"*
+> ⚠️ **This step is automatic.** After a successful deployment, immediately prepare for evaluation without waiting for the user to request it. This matches the eval-driven optimization loop.
 
-- **Evaluation & optimization** → follow the [observe skill](../observe/observe.md) to configure evaluators, run batch evaluations, and optimize the agent.
+### 1. Read Agent Instructions
+
+Use **`agent_get`** (or local `agent.yaml`) to understand the agent's purpose and capabilities.
+
+### 2. Select Default Evaluators
+
+| Category | Evaluators |
+|----------|-----------|
+| **Quality (built-in)** | intent_resolution, task_adherence, coherence |
+| **Safety (include ≥2)** | violence, self_harm, hate_unfairness |
+
+### 3. Identify LLM-Judge Deployment
+
+Use **`model_deployment_get`** to find a suitable model (e.g., `gpt-4o`) for quality evaluators.
+
+### 4. Compose Generation Prompt
+
+Build a `generationPrompt` from the agent's instructions describing purpose, capabilities, and tools so generated queries are realistic.
+
+### 5. Persist Artifacts
+
+Save evaluator definitions to `evaluators/<name>.yaml` and any locally generated test datasets to `datasets/*.jsonl`:
+
+```
+evaluators/        # custom evaluator definitions
+  <name>.yaml      # prompt text, scoring type, thresholds
+datasets/          # locally generated input datasets
+  *.jsonl          # test queries
+```
+
+### 6. Prompt User
+
+*"Your agent is deployed and running. Evaluators and a test dataset have been auto-configured. Would you like to run an evaluation to identify optimization opportunities?"*
+
+- **Yes** → follow the [observe skill](../observe/observe.md) starting at **Step 2 (Evaluate)** — evaluators and dataset are already prepared.
+- **No** → stop. The user can return later.
 - **Production trace analysis** → follow the [trace skill](../trace/trace.md) to search conversations, diagnose failures, and analyze latency using App Insights.
 
 ## Agent Definition Schemas

--- a/plugin/skills/microsoft-foundry/foundry-agent/observe/observe.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/observe/observe.md
@@ -20,12 +20,15 @@ USE FOR: evaluate my agent, run an eval, test my agent, check agent quality, run
 
 | User Intent | Start At |
 |-------------|----------|
-| "Deploy and evaluate my agent" | [Step 1: Deploy & Setup](references/deploy-and-setup.md) |
-| "Evaluate my agent" / "Run an eval" | [Step 2: Evaluate](references/evaluate-step.md) |
+| "Deploy and evaluate my agent" | [Step 1: Auto-Setup Evaluators](references/deploy-and-setup.md) (deploy first via [deploy skill](../deploy/deploy.md)) |
+| "Agent just deployed" / "Set up evaluation" | [Step 1: Auto-Setup Evaluators](references/deploy-and-setup.md) (skip deploy, run auto-create) |
+| "Evaluate my agent" / "Run an eval" | [Step 1: Auto-Setup Evaluators](references/deploy-and-setup.md) first if `evaluators/` is empty, then [Step 2: Evaluate](references/evaluate-step.md) |
 | "Why did my eval fail?" / "Analyze results" | [Step 3: Analyze](references/analyze-results.md) |
 | "Improve my agent" / "Optimize prompt" | [Step 4: Optimize](references/optimize-deploy.md) |
 | "Compare agent versions" | [Step 5: Compare](references/compare-iterate.md) |
 | "Set up CI/CD evals" | [Step 6: CI/CD](references/cicd-monitoring.md) |
+
+> ⚠️ **Important:** Before running any evaluation (Step 2), always check if evaluators and test datasets exist in `evaluators/` and `datasets/`. If they don't, route through [Step 1: Auto-Setup](references/deploy-and-setup.md) first — even if the user only asked to "evaluate."
 
 ## Before Starting — Detect Current State
 
@@ -33,6 +36,22 @@ USE FOR: evaluate my agent, run an eval, test my agent, check agent quality, run
 2. Use `agent_get` and `agent_container_status_get` to verify the agent exists and is running
 3. Use `evaluation_get` to check for existing eval runs
 4. Jump to the appropriate entry point
+
+## Loop Overview
+
+```
+1. Auto-setup evaluators & synthetic dataset
+   → ask: "Run an evaluation to identify optimization opportunities?"
+2. Evaluate (batch eval run)
+3. Download & cluster failures
+4. Pick a category to optimize
+5. Optimize prompt
+6. Deploy new version (after user sign-off)
+7. Re-evaluate (same eval group)
+8. Compare versions → decide which to keep
+9. Loop to next category or finish
+10. Prompt: enable CI/CD evals & continuous production monitoring
+```
 
 ## Behavioral Rules
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/observe/references/deploy-and-setup.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/observe/references/deploy-and-setup.md
@@ -1,17 +1,8 @@
-# Step 1 — Deploy Agent & Setup Evaluators
+# Step 1 — Auto-Setup Evaluators & Dataset
 
-## Deploy
-
-For deployment, follow the [deploy skill](../../deploy/deploy.md). It handles project detection, Dockerfile generation, ACR build, agent creation, and container startup.
-
-After deployment completes, persist these variables to `.env` for future conversations:
-
-| Variable | Purpose |
-|----------|---------|
-| `AZURE_AI_PROJECT_ENDPOINT` | Foundry project endpoint |
-| `AZURE_AI_AGENT_NAME` | Deployed agent name |
-| `AZURE_AI_AGENT_VERSION` | Current agent version |
-| `AZURE_CONTAINER_REGISTRY` | ACR resource (hosted agents) |
+> **This step runs automatically after deployment.** If the agent was deployed via the [deploy skill](../../deploy/deploy.md), evaluators and a test dataset may already be configured. Check `evaluators/` and `datasets/` for existing artifacts before re-creating.
+>
+> If the agent is **not yet deployed**, follow the [deploy skill](../../deploy/deploy.md) first. It handles project detection, Dockerfile generation, ACR build, agent creation, container startup, **and** auto-creates evaluators & dataset after a successful deployment.
 
 ## Auto-Create Evaluators & Dataset
 


### PR DESCRIPTION
The 'Auto-create evaluators & evaluation dataset' step was being skipped when the monolithic agent-observability-loop skill was split into separate deploy and observe skills. Neither skill owned the auto-create step, causing post-deploy users to jump directly to evaluation.

Changes:
- deploy.md: Replace generic 'set up evaluation?' prompt with automatic 6-step evaluator & dataset creation matching the reference behavior
- observe.md: Add Loop Overview, fix entry points to route post-deploy users through auto-setup, add evaluator existence check
- deploy-and-setup.md: Make auto-create primary content, demote deploy section to prerequisites