### PR TITLE
Don't run integration tests during weekends

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -98,13 +98,13 @@ jobs:
             
             # Set deploy-test-pattern and debug based on the schedule slot
             case "$CRON" in
-              "0 5 * * *")
+              "0 5 * * 2-6")
                 echo "debug=${{ env.SCHEDULED_DEBUG_21 }}" >> "$GITHUB_OUTPUT"
                 ;;
-              "0 8 * * *")
+              "0 8 * * 2-6")
                 echo "debug=${{ env.SCHEDULED_DEBUG_00 }}" >> "$GITHUB_OUTPUT"
                 ;;
-              "0 12 * * *")
+              "0 12 * * 2-6")
                 echo "debug=${{ env.SCHEDULED_DEBUG_04 }}" >> "$GITHUB_OUTPUT"
                 ;;
               *)

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -23,8 +23,8 @@
         "microsoft-foundry"
     ],
     "integrationTestSchedule": {
-        "0 5 * * *": "microsoft-foundry",
-        "0 8 * * *": "azure-deploy",
-        "0 12 * * *": "appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost-optimization,azure-diagnostics,azure-hosted-copilot-sdk,azure-kusto,azure-messaging,azure-observability,azure-prepare,azure-rbac,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-validate,entra-app-registration"
+        "0 5 * * 2-6": "microsoft-foundry",
+        "0 8 * * 2-6": "azure-deploy",
+        "0 12 * * 2-6": "appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost-optimization,azure-diagnostics,azure-hosted-copilot-sdk,azure-kusto,azure-messaging,azure-observability,azure-prepare,azure-rbac,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-validate,entra-app-registration"
     }
 }


### PR DESCRIPTION
Instead of running the tests everyday, run them with the following schedule around weekends since we usually don't make changes over the weekends.

- Friday 9:00 PM
- Saturday 12:00 AM
- Saturday 4:00 AM
- Saturday 9:00 PM (skip)
- Sunday 12:00 AM (skip)
- Sunday 4:00 AM (skip)
- Sunday 9:00 PM (skip)
- Monday 12:00 AM (skip)
- Monday 4:00 AM (skip)
- Monday 9:00 PM

in PST