### PR TITLE
Enable SKILLS_INSTRUCTIONS feature flag

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -513,6 +513,7 @@ export function useAgentRunner() {
             tools: ["*"]
           }
         },
+        systemMessage: config.systemPrompt
       });
       entry.session = session;
 


### PR DESCRIPTION
Was told by someone from Copilot SDK to use this env var to turn on the feature flag for adding skills instructions.