### PR TITLE
Collapse token analysis comment

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -162,7 +162,7 @@ jobs:
             );
             
             const footer = '\n\n---\n*Automated token analysis. See [skill authoring guidelines](.github/skills/skill-authoring/SKILL.md) for best practices.*';
-            const body = report + footer;
+            const body = '<details>' + report + '</details>' + footer;
             
             if (botComment) {
               await github.rest.issues.updateComment({


### PR DESCRIPTION
Collapse the token analysis report so it doesn't occupy substantial space making code review hard.