### PR TITLE
Add AVM (Azure Verified Modules) integration tests

### DIFF
--- a/tests/azure-deploy/avm/integration.test.ts
+++ b/tests/azure-deploy/avm/integration.test.ts
@@ -130,7 +130,7 @@ describeIntegration(`${SKILL_NAME}_avm-flow - Integration Tests`, () => {
           // Verify the response discusses AVM fallback within AVM ecosystem
           expectKeywordsPresent(
             output,
-            ["avm", "resource", "utility", "fallback", "module"],
+            ["avm", "resource", "utility", "fallback", "fall back", "fall-back", "module"],
             5,
             "avm-fallback-behavior",
           );
@@ -157,7 +157,11 @@ describeIntegration(`${SKILL_NAME}_avm-flow - Integration Tests`, () => {
             while ((match = pattern.exec(output)) !== null) {
               const start = Math.max(0, match.index - 40);
               const preceding = output.substring(start, match.index);
-              const isNegated = negationPrefixes.some((neg) => preceding.includes(neg));
+              const end = Math.min(output.length, match.index + match[0].length + 40);
+              const following = output.substring(match.index + match[0].length, end);
+              const isNegated =
+                negationPrefixes.some((neg) => preceding.includes(neg)) ||
+                negationPrefixes.some((neg) => following.includes(neg));
               if (!isNegated) {
                 suggestsNonAvm = true;
                 break;
@@ -213,8 +217,10 @@ describeIntegration(`${SKILL_NAME}_avm-flow - Integration Tests`, () => {
           );
           // Verify AZD pattern modules are discussed before resource modules
           const normalizedOutput = output.toLowerCase();
-          const patModIdx = normalizedOutput.indexOf("pattern module");
-          const resModIdx = normalizedOutput.indexOf("resource module");
+          const patModMatch = normalizedOutput.match(/(?:avm\s+|azd\s+)?pattern modules?/);
+          const resModMatch = normalizedOutput.match(/(?:avm\s+)?resource modules?/);
+          const patModIdx = patModMatch?.index ?? -1;
+          const resModIdx = resModMatch?.index ?? -1;
           if (patModIdx !== -1 && resModIdx !== -1) {
             expect(patModIdx).toBeLessThan(resModIdx);
           }


### PR DESCRIPTION
## Summary

Adds integration tests for the Azure Verified Modules (AVM) flow, validating that the `azure-deploy` skill enforces the mandatory AVM module selection hierarchy for Bicep infrastructure generation.

## Test Cases

| Test | What it validates |
|------|-------------------|
| `avm-module-priority` | AVM modules are prioritized over non-AVM alternatives |
| `avm-fallback-behavior` | Fallback stays within the AVM ecosystem (resource -> utility), never to non-AVM |
| `avm-azd-pattern-preference` | AZD pattern modules are preferred over plain resource modules |

## AVM Selection Hierarchy

The tests validate the mandatory ordering defined in `iac-rules.md`:

1. **AVM + AZD Pattern Modules** (highest priority)
2. **AVM Resource Modules**
3. **AVM Utility Modules**
4. **Never** fall back to non-AVM

## Quality Gates

- TypeScript: clean (`tsc --noEmit`)
- ESLint: clean (includes `integration-test-name` rule compliance)
- Tests: 3/3 passing (~101s)
- MQ: all gates passed