### PR TITLE
Remove Playwright MCP server until skills require it

### DIFF
--- a/docs/spec/azure-hosted-copilot-sdk.md
+++ b/docs/spec/azure-hosted-copilot-sdk.md
@@ -74,7 +74,7 @@ The `azure-hosted-copilot-sdk` skill enables users to build, deploy, and configu
 - Test suite: triggers, unit, and integration tests
 - Test infrastructure: `evaluate.ts` shared helpers, `regression-detectors.ts`
 - Local dev tooling: `setup`, `verify`, `test` commands
-- MCP server entries for Context7 and Playwright
+- MCP server entry for Context7
 - Specialized routing in `azure-prepare` to delegate to `azure-hosted-copilot-sdk`
 
 **Not included:**

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -11,10 +11,6 @@
     "context7": {
       "command": "npx",
       "args": ["-y", "@upstash/context7-mcp@latest"]
-    },
-    "playwright": {
-      "command": "npx",
-      "args": ["-y", "@playwright/mcp@latest"]
     }
   }
 }

--- a/scripts/src/local/commands/test.ts
+++ b/scripts/src/local/commands/test.ts
@@ -244,12 +244,6 @@ const MCP_TOOL_PROBES: McpToolProbe[] = [
     invokedPattern: /context7-resolve-library-id/i,
   },
   {
-    server: "playwright",
-    prompt: "Call the playwright-browser_tabs tool with action set to list. If it returns data or an error response, say PLAYWRIGHT_OK. If the tool is not found, say PLAYWRIGHT_FAIL.",
-    successPattern: /PLAYWRIGHT_OK/i,
-    invokedPattern: /playwright-browser_tabs/i,
-  },
-  {
     server: "azure",
     prompt: "Call the azure-documentation tool with intent set to azure functions overview and learn set to true. If it returns data, say AZURE_OK. If it fails, say AZURE_FAIL.",
     successPattern: /AZURE_OK/i,


### PR DESCRIPTION
Removes Playwright MCP server references since no current skills depend on it.

**Changes:**
- Removed playwright entry from plugin/.mcp.json`n- Removed Playwright tool probe from scripts/src/local/commands/test.ts`n- Updated spec doc to reflect only Context7 MCP server