### PR TITLE
Early terminate azure-deploy, azure-validate skill-invocation tests

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../utils/agent-runner";
 import { hasDeployLinks, softCheckDeploySkills, softCheckContainerDeployEnvVars } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
-import { expectFiles, softCheckSkill, doesWorkspaceFileIncludePattern } from "../utils/evaluate";
+import { expectFiles, softCheckSkill, doesWorkspaceFileIncludePattern, shouldEarlyTerminateForSkillInvocation } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-deploy";
 const RUNS_PER_PROMPT = 1;
@@ -46,6 +46,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Run azd up to deploy my already-prepared app to Azure",
             nonInteractive: true,
             followUp,
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -66,6 +67,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "My app already has azure.yaml and infra/ configured. Publish it to Azure now.",
             nonInteractive: true,
             followUp,
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -86,6 +88,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Deploy my existing Azure Functions project to the cloud. The infrastructure and azure.yaml are already set up.",
             nonInteractive: true,
             followUp,
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);

--- a/tests/azure-prepare/integration.test.ts
+++ b/tests/azure-prepare/integration.test.ts
@@ -17,7 +17,7 @@ import {
 import { hasValidationCommand } from "../azure-validate/utils";
 import { hasPlanReadyForValidation, getDockerContext, hasServicesSection, getServiceProject } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
-import { expectFiles, getToolCalls, softCheckSkill, isSkillInvoked } from "../utils/evaluate";
+import { expectFiles, getToolCalls, softCheckSkill, isSkillInvoked, shouldEarlyTerminateForSkillInvocation } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-prepare";
 const RUNS_PER_PROMPT = 1;
@@ -38,7 +38,6 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   const agent = useAgentRunner();
 
   describe("skill-invocation", () => {
-    const maxToolCallBeforeTerminate = 3;
     const followUp = ["Go with recommended options."];
     test("invokes azure-prepare skill for new Azure application preparation prompt", async () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
@@ -47,7 +46,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Prepare my application for Azure deployment and set up the infrastructure",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -68,7 +67,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Modernize my existing application for Azure hosting and generate the required infrastructure files",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -89,7 +88,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Prepare my Azure application to use Key Vault for storing secrets and credentials",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -110,7 +109,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Set up my Azure application with managed identity authentication for accessing Azure services",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -130,7 +129,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a simple social media application with likes and comments and deploy to Azure using Terraform infrastructure code",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -151,7 +150,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -172,7 +171,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create an event-driven function app to process messages and deploy to Azure Functions",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -193,7 +192,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create an Azure Functions app with a timer trigger",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -215,7 +214,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a static whiteboard web app and deploy to Azure using my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -236,7 +235,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a static portfolio website and deploy to Azure using my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -258,7 +257,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a discussion board application and deploy to Azure App Service using my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -279,7 +278,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a todo list with frontend and API and deploy to Azure App Service using my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -301,7 +300,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure using my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -322,7 +321,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create an event-driven function app to process messages and deploy to Azure Functions using my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -343,7 +342,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create an azure python function app that takes input from a service bus trigger and does message processing and deploy to Azure using my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -365,7 +364,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a containerized web application and deploy to Azure Container Apps using my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -386,7 +385,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a simple containerized Node.js hello world app and deploy to Azure Container Apps using my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -408,7 +407,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a static whiteboard web app and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -429,7 +428,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a static portfolio website and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -451,7 +450,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a discussion board application and deploy to Azure App Service using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -472,7 +471,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a todo list with frontend and API and deploy to Azure App Service using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -494,7 +493,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -515,7 +514,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create an event-driven function app to process messages and deploy to Azure Functions using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -536,7 +535,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a URL shortener service using Azure Functions that creates short links and redirects users to the original URL and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -558,7 +557,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a containerized web application and deploy to Azure Container Apps using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -579,7 +578,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a simple containerized Node.js hello world app and deploy to Azure Container Apps using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -600,7 +599,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             prompt: "Create a simple social media application with likes and comments and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
             nonInteractive: true,
             followUp,
-            shouldEarlyTerminate: (agentMetadata) => isSkillInvoked(agentMetadata, SKILL_NAME) || getToolCalls(agentMetadata).length > maxToolCallBeforeTerminate
+            shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);

--- a/tests/azure-validate/integration.test.ts
+++ b/tests/azure-validate/integration.test.ts
@@ -19,10 +19,10 @@ import {
   matchesFileEdit,
 } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
-import { matchesCommand, softCheckSkill, isSkillInvoked } from "../utils/evaluate";
+import { matchesCommand, softCheckSkill, isSkillInvoked, shouldEarlyTerminateForSkillInvocation } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-validate";
-const RUNS_PER_PROMPT = 5;
+const RUNS_PER_PROMPT = 1;
 const aspireEnvVarTestTimeoutMs = 2700000; // 45 minutes
 
 // Check if integration tests should be skipped at module level
@@ -44,7 +44,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Check if my app is ready to deploy to Azure"
+            prompt: "Check if my app is ready to deploy to Azure",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -62,7 +63,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Validate my azure.yaml configuration before deploying"
+            prompt: "Validate my azure.yaml configuration before deploying",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -81,7 +83,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Validate my Bicep template before deploying to Azure"
+            prompt: "Validate my Bicep template before deploying to Azure",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -99,7 +102,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Run a what-if analysis to preview changes before deploying my infrastructure"
+            prompt: "Run a what-if analysis to preview changes before deploying my infrastructure",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -189,3 +189,30 @@ export function getAllToolText(metadata: AgentMetadata): string {
   }
   return parts.join("\n");
 }
+
+/**
+ * Maximum number of tool calls allowed before invoking the expected skill.
+ * If more than this number of tool calls are made before invoking the expected skill,
+ * we consider the agent failed to invoke the skill.
+ */
+const maxToolCallBeforeSkillInvocationTerminate = 3;
+
+export function shouldEarlyTerminateForSkillInvocation(agentMetadata: AgentMetadata, skillName: string): boolean {
+  const shouldEarlyTerminateForInvokedSkill = isSkillInvoked(agentMetadata, skillName);
+  if (shouldEarlyTerminateForInvokedSkill) {
+    const earlyTerminateComment = `✅ ${skillName} is invoked as expected. Terminating the agent run early.`;
+    // Due to follow up mechanism, we may run the agent twice and trigger the early terminate condition twice.
+    // Check if a comment has been made to avoid adding redundant comment.
+    if (!agentMetadata.testComments.some((comment) => comment === earlyTerminateComment)) {
+      agentMetadata.testComments.push(earlyTerminateComment);
+    }
+    return true;
+  }
+
+  const shouldEarlyTerminateForTooLate = getToolCalls(agentMetadata).length > maxToolCallBeforeSkillInvocationTerminate;
+  if (shouldEarlyTerminateForTooLate) {
+    agentMetadata.testComments.push(`⚠️ ${skillName} is not invoked within early tool calls. Terminating the agent run early.`);
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
The helper function for terminating the skill-invocation tests now adds a comment telling the AI grader that this early termination is expected. This would prevent it from claiming the test execution is incomplete as shown in existing reports.

I will apply the same change to other skill-invocation tests to save cost and reduce false positives.