### PR TITLE
Recommend adding reference over skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,8 @@ plugin/skills/your-skill-name/
 
 ### Creating a New Skill
 
+> ⚠️ Char count of skill descriptions in this repo is close to the char count budget in tools like Copilot CLI. Exceeding the char count budget may result in any skill being truncated at runtime, causing inconsistent agent behavior. Consider adding the new content to an existing skill or rebrand an existing skill to cover the new content.
+
 _NOTE:_ If you open the repo in VS Code, you can use the "Azure Skill Brainstormer" or "Azure Skill Creator" agents in Copilot to help you build out an initial version of the skill.
 - The Creator agents expects you already know what scenarios the skill should address
 - The Brainstormer agent will help you identify scenarios


### PR DESCRIPTION
Add a section in the contributing guide to describe the skill description char count budget issue and encourage contributors to add references to existing skills over adding new skills.