### PR TITLE
Publish daily scheduled integration test report to storage

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -167,6 +167,7 @@ jobs:
       model-override: ${{ inputs.model-override }}
       test-pattern: ${{ needs.resolve-inputs.outputs.deploy-test-pattern }}
       debug: ${{ needs.resolve-inputs.outputs.debug == 'true' }}
+      publish-reports: ${{ github.event_name == 'schedule' }}
     secrets:
       COPILOT_CLI_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
 

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -45,6 +45,11 @@ on:
         required: false
         type: boolean
         default: false
+      publish-reports:
+        description: 'Whether to publish reports to Azure Storage'
+        required: false
+        type: boolean
+        default: false
     secrets:
       COPILOT_CLI_TOKEN:
         required: true
@@ -198,7 +203,7 @@ jobs:
           retention-days: 30
 
       - name: Publish report to Azure Storage
-        if: always() && github.event_name == 'schedule' && vars.REPORT_STORAGE_ACCOUNT != ''
+        if: always() && inputs.publish-reports && vars.REPORT_STORAGE_ACCOUNT != ''
         env:
           RUN_ID: ${{ github.run_id }}
           JOB_ID: ${{ github.job }}


### PR DESCRIPTION
I am also working on a webapp to display the daily scheduled test reports from the published report data.

The web app looks like this right now.
<img width="1400" height="974" alt="image" src="https://github.com/user-attachments/assets/4fe9adab-410a-4aa7-a8e2-054825d13ea8" />
