### PR TITLE
chore: bump claude plugin version to 1.0.1

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "azure",
   "description": "Microsoft Azure MCP integration for cloud resource management, deployments, and Azure services. Manage your Azure infrastructure, monitor applications, and deploy resources directly from Claude Code.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Microsoft",
     "url": "https://www.microsoft.com"


### PR DESCRIPTION
Bump the Claude Code plugin version from 1.0.0 to 1.0.1 to validate Claude Code PR creation behavior.