### PR TITLE
Agentic workflow improvements

### DIFF
--- a/.github/skills/analyze-test-run/SKILL.md
+++ b/.github/skills/analyze-test-run/SKILL.md
@@ -4,7 +4,7 @@ description: "Analyze a GitHub Actions integration test run and produce a skill 
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.1"
+  version: "1.0.2"
 ---
 
 # Analyze Test Run
@@ -120,14 +120,14 @@ For every test with a `<failure>` element in `junit.xml`:
    - **Timeout** — test exceeded time limit
    - **Assertion mismatch** — expected files/links not found
    - **Quota exhaustion** — Azure region quota prevented deployment
-6. Search for an existing open issue before creating a new one:
+6. Search for existing open issue before creating a new one:
    ```bash
    gh issue list --repo microsoft/GitHub-Copilot-for-Azure \
-     --state open --label "integration-test" \
-     --search "Integration test failure: {skill} – {keywords} in:title" \
-     --json number,title --jq '.[0].number'
+     --state open \
+     --search "Integration test failure: {skill} in:title" \
+     --json number,title,body
    ```
-   Match criteria: an open issue whose title contains the same `{skill}` and `{keywords}` tokens. If a match is found, skip issue creation for this failure and note the existing issue number in the summary report.
+   Match criteria: an open issue whose title and body describe a similar problem. If a match is found, skip issue creation for this failure and note the existing issue number(s) in the summary report.
 7. If no existing issue was found, create a GitHub issue:
 
 ```

--- a/.github/workflows/analyze-test-run.lock.yml
+++ b/.github/workflows/analyze-test-run.lock.yml
@@ -24,7 +24,7 @@
 # Analyzes a GitHub Actions workflow run (given its run ID or URL) and creates
 # GitHub issues for each failing test found in the run's artifacts and logs.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"5d64f39d36379a2f0c037dc5902c3d2f20b8e26356ac0e727b46ae82d3f48658","compiler_version":"v0.57.2","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f8c6bc66772ecbe06dd5aa1c2ae65e524cb0206df6d67074ba2f1739983a47a1","compiler_version":"v0.57.2","strict":true}
 
 name: "Analyze Test Run"
 "on":
@@ -340,7 +340,7 @@ jobs:
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
             {
-              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 10 issue(s) can be created. Labels [\"bug\" \"test-failure\"] will be automatically added.",
+              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 10 issue(s) can be created. Labels [\"bug\" \"integration-test\"] will be automatically added.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -1155,7 +1155,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"bug\",\"test-failure\"],\"max\":10},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"bug\",\"integration-test\"],\"max\":10},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
1. When creating new issues for integration test failures, improve the logic for finding duplicates. Currently we look for existing issues with exactly the same title as the issue we would open. This isn't good enough, as it is unlikely the LM would produce exactly the same title every time even with identical inputs. Instead, we now find all open integration test failures for the given skill and check the information in the body to look for similarities.
2. Recompile analyze-test-run.md to produce analyze-test-run.lock.yml, which is actually what the workflow looks at. This wasn't done the last time the .md was updated, with the result that issues can't be tagged with the "integration-test" label.