### PR TITLE
Expand deploy link pattern

### DIFF
--- a/tests/azure-deploy/utils.ts
+++ b/tests/azure-deploy/utils.ts
@@ -28,13 +28,13 @@ export function softCheckContainerDeployEnvVars(agentMetadata: AgentMetadata): v
  */
 const DEPLOY_LINK_PATTERNS = [
   // Azure App Service URLs (matches domain followed by path, query, fragment, whitespace, or punctuation)
-  /https?:\/\/[\w.-]+\.azurewebsites\.net(?=[/\s?#)\]]|$)/i,
+  /https?:\/\/[\w.-]+\.azurewebsites\.net(?=[/\s.`'"?#)\]]|$)/i,
   // Azure Static Web Apps URLs
-  /https:\/\/[\w.-]+\.azurestaticapps\.net(?=[/\s?#)\]]|$)/i,
+  /https:\/\/[\w.-]+\.azurestaticapps\.net(?=[/\s.`'"?#)\]]|$)/i,
   // Azure Container Apps URLs
-  /https:\/\/[\w.-]+\.azurecontainerapps\.io(?=[/\s?#)\]]|$)/i,
+  /https:\/\/[\w.-]+\.azurecontainerapps\.io(?=[/\s.`'"?#)\]]|$)/i,
   // static website from a storage account
-  /https:\/\/[\w.-]+\.web\.core\.windows\.net(?=[/\s?#)\]]|$)/i
+  /https:\/\/[\w.-]+\.web\.core\.windows\.net(?=[/\s.`'"?#)\]]|$)/i
 ];
 
 /**


### PR DESCRIPTION
Addresses #1291

Agent response may include the deploy url in the following ways that don't pass the existing pattern.

- Wrapped in backticks 
```
`https://name.azurecontainerapps.io`
```

The expanded pattern also considers the possiblity of the url ending with a period, single quote or double quote.