### PR TITLE
Early terminate foundry skill invocation tests

### DIFF
--- a/tests/microsoft-foundry/foundry-agent/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/integration.test.ts
@@ -14,7 +14,7 @@ import {
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../../utils/agent-runner";
-import { softCheckSkill } from "../../utils/evaluate";
+import { softCheckSkill, shouldEarlyTerminateForSkillInvocation } from "../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 const RUNS_PER_PROMPT = 5;
@@ -36,7 +36,8 @@ describeIntegration(`${SKILL_NAME}_foundry-agent - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a new prompt agent with gpt-4o model in Foundry"
+            prompt: "Create a new prompt agent with gpt-4o model in Foundry",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -54,7 +55,8 @@ describeIntegration(`${SKILL_NAME}_foundry-agent - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Troubleshoot my Foundry agent that is returning errors"
+            prompt: "Troubleshoot my Foundry agent that is returning errors",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);

--- a/tests/microsoft-foundry/integration.test.ts
+++ b/tests/microsoft-foundry/integration.test.ts
@@ -14,7 +14,7 @@ import {
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../utils/agent-runner";
-import { softCheckSkill, isSkillInvoked } from "../utils/evaluate";
+import { softCheckSkill, isSkillInvoked, shouldEarlyTerminateForSkillInvocation } from "../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 const RUNS_PER_PROMPT = 5;
@@ -37,7 +37,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "How do I deploy an AI model from the Microsoft Foundry catalog?"
+            prompt: "How do I deploy an AI model from the Microsoft Foundry catalog?",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -55,7 +56,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Build a RAG application with Microsoft Foundry using knowledge indexes"
+            prompt: "Build a RAG application with Microsoft Foundry using knowledge indexes",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -73,7 +75,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Grant a user the Azure AI User role on my Foundry project"
+            prompt: "Grant a user the Azure AI User role on my Foundry project",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -91,7 +94,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create a service principal for my Foundry CI/CD pipeline"
+            prompt: "Create a service principal for my Foundry CI/CD pipeline",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -109,7 +113,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Set up managed identity roles for my Foundry project to access Azure Storage"
+            prompt: "Set up managed identity roles for my Foundry project to access Azure Storage",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -127,7 +132,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Who has access to my Foundry project? List all role assignments"
+            prompt: "Who has access to my Foundry project? List all role assignments",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -145,7 +151,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Make Bob a project manager in my Azure AI Foundry"
+            prompt: "Make Bob a project manager in my Azure AI Foundry",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -163,7 +170,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Can I deploy models to my Foundry project? Check my permissions"
+            prompt: "Can I deploy models to my Foundry project? Check my permissions",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -201,7 +209,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Create an evaluation dataset from my Foundry agent traces"
+            prompt: "Create an evaluation dataset from my Foundry agent traces",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -219,7 +228,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Version my Foundry evaluation dataset and compare regressions"
+            prompt: "Version my Foundry evaluation dataset and compare regressions",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -233,5 +243,4 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       }
     });
   });
-
 });

--- a/tests/microsoft-foundry/models/deploy/capacity/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/capacity/integration.test.ts
@@ -14,7 +14,7 @@ import {
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../../../../utils/agent-runner";
-import { softCheckSkill } from "../../../../utils/evaluate";
+import { softCheckSkill, shouldEarlyTerminateForSkillInvocation } from "../../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 const RUNS_PER_PROMPT = 5;
@@ -35,7 +35,8 @@ describeIntegration(`${SKILL_NAME}_capacity - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Find available capacity for gpt-4o across all Azure regions"
+            prompt: "Find available capacity for gpt-4o across all Azure regions",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -53,7 +54,8 @@ describeIntegration(`${SKILL_NAME}_capacity - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Which Azure regions have gpt-4o available with enough TPM capacity?"
+            prompt: "Which Azure regions have gpt-4o available with enough TPM capacity?",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);

--- a/tests/microsoft-foundry/models/deploy/customize-deployment/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/customize-deployment/integration.test.ts
@@ -14,7 +14,7 @@ import {
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../../../../utils/agent-runner";
-import { softCheckSkill } from "../../../../utils/evaluate";
+import { softCheckSkill, shouldEarlyTerminateForSkillInvocation } from "../../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 const RUNS_PER_PROMPT = 5;
@@ -35,7 +35,8 @@ describeIntegration(`${SKILL_NAME}_customize-deployment - Integration Tests`, ()
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Deploy gpt-4o with custom SKU and capacity configuration"
+            prompt: "Deploy gpt-4o with custom SKU and capacity configuration",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -53,7 +54,8 @@ describeIntegration(`${SKILL_NAME}_customize-deployment - Integration Tests`, ()
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Deploy gpt-4o with provisioned throughput PTU in my Foundry project"
+            prompt: "Deploy gpt-4o with provisioned throughput PTU in my Foundry project",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);

--- a/tests/microsoft-foundry/models/deploy/deploy-model-optimal-region/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/deploy-model-optimal-region/integration.test.ts
@@ -14,7 +14,7 @@ import {
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../../../../utils/agent-runner";
-import { softCheckSkill } from "../../../../utils/evaluate";
+import { softCheckSkill, shouldEarlyTerminateForSkillInvocation } from "../../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 const RUNS_PER_PROMPT = 5;
@@ -35,7 +35,8 @@ describeIntegration(`${SKILL_NAME}_deploy-model-optimal-region - Integration Tes
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Deploy gpt-4o quickly to the optimal region"
+            prompt: "Deploy gpt-4o quickly to the optimal region",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -53,7 +54,8 @@ describeIntegration(`${SKILL_NAME}_deploy-model-optimal-region - Integration Tes
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Deploy gpt-4o to the best available region with high availability"
+            prompt: "Deploy gpt-4o to the best available region with high availability",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);

--- a/tests/microsoft-foundry/models/deploy/deploy-model/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/deploy-model/integration.test.ts
@@ -14,7 +14,7 @@ import {
   shouldSkipIntegrationTests,
   getIntegrationSkipReason,
 } from "../../../../utils/agent-runner";
-import { softCheckSkill } from "../../../../utils/evaluate";
+import { softCheckSkill, shouldEarlyTerminateForSkillInvocation } from "../../../../utils/evaluate";
 
 const SKILL_NAME = "microsoft-foundry";
 const RUNS_PER_PROMPT = 5;
@@ -35,7 +35,8 @@ describeIntegration(`${SKILL_NAME}_deploy-model - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Deploy gpt-4o model to my Azure project"
+            prompt: "Deploy gpt-4o model to my Azure project",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -53,7 +54,8 @@ describeIntegration(`${SKILL_NAME}_deploy-model - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Where can I deploy gpt-4o? Check capacity across regions"
+            prompt: "Where can I deploy gpt-4o? Check capacity across regions",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);
@@ -71,7 +73,8 @@ describeIntegration(`${SKILL_NAME}_deploy-model - Integration Tests`, () => {
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         try {
           const agentMetadata = await agent.run({
-            prompt: "Deploy gpt-4o with custom SKU and capacity settings"
+            prompt: "Deploy gpt-4o with custom SKU and capacity settings",
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
           softCheckSkill(agentMetadata, SKILL_NAME);


### PR DESCRIPTION
To save test cost and reduce the chance of time out.