### PR TITLE
feat: Wave 0 workflow hardening (security foundation)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,6 +4,9 @@
 # Default owners for everything in the repo
 * @microsoft/ghcp4a
 
+# Workflow files — explicit protection (changes require team review)
+/.github/workflows/ @microsoft/ghcp4a
+
 # Plugin skills owners
 /plugin/skills/appinsights-instrumentation/ @JasonYeMSFT
 /plugin/skills/azure-ai/ @charris-msft

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,51 @@
+# Dependabot configuration
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # npm ecosystem — root package.json
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 10
+
+  # npm ecosystem — scripts/
+  - package-ecosystem: "npm"
+    directory: "/scripts"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+
+  # npm ecosystem — tests/
+  - package-ecosystem: "npm"
+    directory: "/tests"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    open-pull-requests-limit: 5
+
+  # GitHub Actions — keep SHA-pinned actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,18 +22,18 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@603b797f8b14b413fe025cd935a91c16c4782713 # v3
       with:
         languages: ${{ matrix.language }}
         queries: security-and-quality
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+      uses: github/codeql-action/autobuild@603b797f8b14b413fe025cd935a91c16c4782713 # v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@603b797f8b14b413fe025cd935a91c16c4782713 # v3
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -15,9 +15,9 @@ jobs:
     name: Run Evaluations
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Install Azure Developer CLI
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@c495e71ba59e44bfaaac10a32c8ee90d191ca4a3 # v2
       - name: Install waza extension
         run: |
           azd config set alpha.extensions on
@@ -27,7 +27,7 @@ jobs:
         run: azd waza run evals/azure-hosted-copilot-sdk/eval.yaml --output-dir ./results
       - name: Upload results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: eval-results
           path: ./results

--- a/.github/workflows/info-needed-closer.yml
+++ b/.github/workflows/info-needed-closer.yml
@@ -12,7 +12,7 @@ jobs:
     if: github.repository == 'microsoft/GitHub-Copilot-for-Azure'
     steps:
       - name: Checkout Actions
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           repository: "microsoft/vscode-github-triage-actions"
           path: ./actions

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - name: Download report artifact
         id: download
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: token-analysis-report
           run-id: ${{ github.event.workflow_run.id }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: Resolve PR number
         id: pr
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -51,7 +51,7 @@ jobs:
 
       - name: Comment on PR
         if: steps.pr.outputs.number != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Full history for comparison
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -25,11 +25,11 @@ jobs:
 
       - name: Install tests dependencies
         working-directory: ./tests
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Install scripts dependencies
         working-directory: ./scripts
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Typecheck tests
         working-directory: ./tests
@@ -58,12 +58,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0  # Full history for comparison
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -71,7 +71,7 @@ jobs:
 
       - name: Install scripts dependencies
         working-directory: ./scripts
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Check Copilot CLI skill char budget
         working-directory: ./scripts
@@ -79,7 +79,7 @@ jobs:
 
       - name: Check changed markdown files
         id: changed-files
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             **/*.md
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload report artifact
         if: steps.changed-files.outputs.any_changed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: token-analysis-report
           path: combined-report.md
@@ -161,12 +161,12 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
       - name: Check changed skill files
         id: changed-skills
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             plugin/skills/*/SKILL.md
@@ -174,7 +174,7 @@ jobs:
 
       - name: Check all changed plugin skill files
         id: changed-plugin-skills
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             plugin/skills/**
@@ -182,7 +182,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.changed-skills.outputs.any_changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -191,7 +191,7 @@ jobs:
       - name: Install scripts dependencies
         if: steps.changed-skills.outputs.any_changed == 'true'
         working-directory: ./scripts
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Validate skill frontmatter
         if: steps.changed-skills.outputs.any_changed == 'true'
@@ -224,7 +224,7 @@ jobs:
           fi
 
       - name: Validate skills.json
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -363,11 +363,11 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Check changed skill markdown files
         id: changed-markdown
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             plugin/skills/**/*.md
@@ -375,7 +375,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.changed-markdown.outputs.any_changed == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
@@ -384,7 +384,7 @@ jobs:
       - name: Install scripts dependencies
         if: steps.changed-markdown.outputs.any_changed == 'true'
         working-directory: ./scripts
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Validate markdown references
         if: steps.changed-markdown.outputs.any_changed == 'true'

--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # 1. Checkout the current repo
       - name: Checkout current repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: source-repo
 
@@ -86,7 +86,7 @@ jobs:
     steps:
       # 1. Checkout the current repo
       - name: Checkout current repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: source-repo
 

--- a/.github/workflows/skill-factory.yml
+++ b/.github/workflows/skill-factory.yml
@@ -19,13 +19,13 @@ jobs:
       issues: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Issue for Copilot Coding Agent
         id: create-issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           SKILL_NAME: ${{ github.event.inputs.skill_name }}
           SKILL_DESCRIPTION: ${{ github.event.inputs.skill_description }}

--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -67,7 +67,7 @@ jobs:
     steps:
       - name: Checkout repository
         if: github.event_name == 'schedule'
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Resolve inputs based on trigger type
         id: resolve
@@ -192,10 +192,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@c495e71ba59e44bfaaac10a32c8ee90d191ca4a3 # v2
 
       - name: Log in with Azure (Federated Credentials)
         run: |
@@ -206,7 +206,7 @@ jobs:
         shell: pwsh
 
       - name: Azure login
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -229,7 +229,7 @@ jobs:
           done &
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
@@ -237,13 +237,13 @@ jobs:
 
       - name: Setup .NET
         if: contains(needs.resolve-inputs.outputs.skills, 'azure-deploy')
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '10.0.x'
       
       - name: Setup Python
         if: contains(needs.resolve-inputs.outputs.skills, 'azure-deploy')
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -258,7 +258,7 @@ jobs:
       # See https://github.com/github/copilot-sdk/issues/343 for more details.
       - name: Setup Copilot CLI
         id: setup-copilot-cli
-        uses: mvkaran/setup-copilot-cli@v1
+        uses: mvkaran/setup-copilot-cli@d05a47209e6b3185c9c55702bef49f28e6eebef7 # v1
         with:
           token: ${{ secrets.COPILOT_CLI_TOKEN }}
 
@@ -311,7 +311,7 @@ jobs:
       - name: Export report
         if: always()
         id: export-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: integration-report-${{ matrix.skill }}
           path: tests/reports/

--- a/.github/workflows/test-all-skills.yml
+++ b/.github/workflows/test-all-skills.yml
@@ -49,35 +49,38 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'
           cache-dependency-path: tests/package-lock.json
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Run tests
+        env:
+          CI: true
+          SKILL_NAME: ${{ inputs.skill-name }}
+          COVERAGE: ${{ inputs.coverage }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           TEST_ARGS=""
-          if [ -n "${{ inputs.skill-name }}" ]; then
-            TEST_ARGS="--testPathPattern=${{ inputs.skill-name }}"
+          if [ -n "$SKILL_NAME" ]; then
+            TEST_ARGS="--testPathPattern=$SKILL_NAME"
           fi
-          if [ "${{ inputs.coverage }}" = "true" ] || [ "${{ github.event_name }}" = "push" ]; then
+          if [ "$COVERAGE" = "true" ] || [ "$EVENT_NAME" = "push" ]; then
             npm run test:ci -- --coverage $TEST_ARGS
           else
             npm run test:ci -- $TEST_ARGS
           fi
-        env:
-          CI: true
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results-all
           path: tests/reports/junit.xml
@@ -85,7 +88,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-all
           path: tests/coverage/
@@ -140,15 +143,15 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
 
       - name: Download coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: coverage-all
           path: tests/coverage/

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -92,10 +92,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install azd
-        uses: Azure/setup-azd@v2
+        uses: Azure/setup-azd@c495e71ba59e44bfaaac10a32c8ee90d191ca4a3 # v2
 
       - name: Log in with Azure (Federated Credentials)
         run: |
@@ -106,7 +106,7 @@ jobs:
         shell: pwsh
 
       - name: Azure login
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -129,19 +129,19 @@ jobs:
           done &
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
           cache: 'npm'
           cache-dependency-path: tests/package-lock.json
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4
         with:
           dotnet-version: '10.0.x'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.13'
 
@@ -156,7 +156,7 @@ jobs:
       # See https://github.com/github/copilot-sdk/issues/343 for more details.
       - name: Setup Copilot CLI
         id: setup-copilot-cli
-        uses: mvkaran/setup-copilot-cli@v1
+        uses: mvkaran/setup-copilot-cli@d05a47209e6b3185c9c55702bef49f28e6eebef7 # v1
         with:
           token: ${{ secrets.COPILOT_CLI_TOKEN }}
 
@@ -190,7 +190,7 @@ jobs:
 
       - name: Export report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: azure-deploy-${{ matrix.test-group }}-reports
           path: tests/reports/

--- a/.github/workflows/test-skill-reusable.yml
+++ b/.github/workflows/test-skill-reusable.yml
@@ -32,10 +32,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: ${{ inputs.node-version }}
           cache: 'npm'
@@ -45,13 +45,14 @@ jobs:
         run: npm ci
 
       - name: Run tests for ${{ inputs.skill-name }}
-        run: npm run test:ci -- --testPathPattern="${{ inputs.skill-name }}"
         env:
           CI: true
+          SKILL_NAME: ${{ inputs.skill-name }}
+        run: npm run test:ci -- --testPathPattern="$SKILL_NAME"
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: test-results-${{ inputs.skill-name }}
           path: tests/reports/junit.xml
@@ -59,7 +60,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-${{ inputs.skill-name }}
           path: tests/coverage/
@@ -67,8 +68,10 @@ jobs:
 
       - name: Test Report Summary
         if: always()
+        env:
+          SKILL_NAME: ${{ inputs.skill-name }}
         run: |
-          echo "## Test Results - ${{ inputs.skill-name }}" >> $GITHUB_STEP_SUMMARY
+          echo "## Test Results - $SKILL_NAME" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ -f reports/junit.xml ]; then
             TESTS=$(grep -o 'tests="[0-9]*"' reports/junit.xml | head -1 | grep -o '[0-9]*')


### PR DESCRIPTION
## Wave 0: Workflow Hardening (Security Foundation)

Closes #1301

### Changes

| Task | Description |
|------|-------------|
| **W0-1** | Pin 57 GitHub Action references to full commit SHA across 13 workflow files |
| **W0-1a** | Verified zero @vN references remain in non-lock workflow files |
| **W0-2** | Harden npm ci with --ignore-scripts in PR-triggered workflows |
| **W0-3** | Add explicit CODEOWNERS protection for .github/workflows/ |
| **W0-4** | Fix 3 shell expression injection sites - moved user-controlled inputs to env blocks |
| **W0-5** | Add Dependabot config for npm (3 directories) and github-actions ecosystems |

### Security Improvements

- **Supply chain**: All 57 action references now use immutable commit SHAs instead of mutable version tags
- **Script injection**: npm ci --ignore-scripts prevents arbitrary postinstall execution in PR contexts
- **Expression injection**: User-controlled inputs no longer interpolated directly in run blocks
- **Automated updates**: Dependabot will propose weekly updates for both npm deps and GitHub Actions

### Files Changed (14)

- 13 workflow files modified
- 1 CODEOWNERS modified
- 1 new file (dependabot.yml)