### PR TITLE
fix: Report deployment URLs

### DIFF
--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute Azure deployments for ALREADY-PREPARED applications that h
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.5"
+  version: "1.0.6"
 ---
 
 # Azure Deploy
@@ -65,6 +65,7 @@ Activate this skill when user wants to:
 | 5 | **Post-Deploy** — Configure SQL managed identity and apply EF migrations if applicable | [Post-Deployment](references/recipes/azd/post-deployment.md) |
 | 6 | **Handle Errors** — See recipe's `errors.md` | — |
 | 7 | **Verify Success** — Confirm deployment completed and endpoints are accessible | [Verification](references/recipes/azd/verify.md) |
+| 8 | **Report Results** — Present deployed endpoint URLs to the user | [Verification](references/recipes/azd/verify.md) |
 
 > **⛔ VALIDATION PROOF CHECK**
 >

--- a/plugin/skills/azure-deploy/references/recipes/azcli/README.md
+++ b/plugin/skills/azure-deploy/references/recipes/azcli/README.md
@@ -17,6 +17,7 @@ Deploy to Azure using Azure CLI.
 | 2 | Deploy infrastructure | `az deployment sub create` |
 | 3 | Deploy application | Service-specific commands |
 | 4 | Verify | `az resource list` |
+| 5 | **Report** | Present deployed endpoint URLs to the user — see [Verification](verify.md) |
 
 ## Infrastructure Deployment
 

--- a/plugin/skills/azure-deploy/references/recipes/azcli/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/azcli/verify.md
@@ -28,3 +28,19 @@ az webapp show \
   --resource-group <rg-name> \
   --query "{state:state, hostNames:hostNames}"
 ```
+
+## Report Results to User
+
+> ⛔ **MANDATORY** — You **MUST** present the deployed endpoint URLs to the user in your response.
+
+Extract endpoints using the appropriate command for the service type:
+
+```bash
+# Container Apps
+az containerapp show --name <app-name> --resource-group <rg-name> --query "properties.configuration.ingress.fqdn" -o tsv
+
+# App Service
+az webapp show --name <app-name> --resource-group <rg-name> --query "defaultHostName" -o tsv
+```
+
+Present a summary including all service URLs. Do NOT end your response without including them.

--- a/plugin/skills/azure-deploy/references/recipes/azd/README.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/README.md
@@ -21,6 +21,7 @@ Deploy to Azure using Azure Developer CLI (azd).
 | 2 | **Deploy** | `azd up --no-prompt` |
 | 3 | **Post-Deploy** | [Post-Deployment Steps](post-deployment.md) — If using SQL + managed identity |
 | 4 | **Verify** | See [Verification](verify.md) |
+| 5 | **Report** | Present deployed endpoint URLs to the user — see [Verification](verify.md) Step 3 |
 
 > ⚠️ **Important:** For .NET Aspire projects or projects using azd "limited mode" (no explicit `infra/` folder), verify that `azd provision` populated all required environment variables. If `azd deploy` fails with errors about missing `AZURE_CONTAINER_REGISTRY_ENDPOINT`, `AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID`, or `MANAGED_IDENTITY_CLIENT_ID`, see [Error Handling](errors.md#missing-container-registry-variables) for the resolution.
 

--- a/plugin/skills/azure-deploy/references/recipes/azd/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/verify.md
@@ -28,7 +28,39 @@ curl -f "$ENDPOINT/health" || curl -f "$ENDPOINT"
 
 Expected: HTTP 200 response.
 
-## Step 3: Post-Deployment Verification (if applicable)
+## Step 3: Report Results to User
+
+> ⛔ **MANDATORY** — You **MUST** present the deployed endpoint URLs to the user in your response. A deployment is not considered complete until the user has received the URLs.
+
+Extract all endpoints from the `azd up` / `azd deploy` output or by running:
+
+```bash
+azd show
+```
+
+**Present a summary to the user that includes:**
+
+| Item | Source |
+|------|--------|
+| Deployed service endpoint(s) | `Endpoint:` lines from `azd` output or `azd show` |
+| Aspire Dashboard URL (if applicable) | `Aspire Dashboard:` line from `azd` output |
+| Azure Portal deployment link (if available) | Portal URL from provisioning output |
+
+Example response format:
+
+```
+✅ Deployment succeeded!
+
+| Service | Endpoint |
+|---------|----------|
+| apiservice | https://apiservice.xxx.azurecontainerapps.io |
+
+Aspire Dashboard: https://aspire-dashboard.xxx.azurecontainerapps.io
+```
+
+> ⚠️ **Do NOT end your response without including the endpoint URLs.** If `azd` printed endpoint URLs in its output, you already have them — extract and present them. If the output was truncated, run `azd show` to retrieve them.
+
+## Step 4: Post-Deployment Verification (if applicable)
 
 For deployments with Azure SQL Database and managed identity:
 

--- a/plugin/skills/azure-deploy/references/recipes/bicep/README.md
+++ b/plugin/skills/azure-deploy/references/recipes/bicep/README.md
@@ -17,6 +17,7 @@ Deploy to Azure using Bicep templates directly.
 | 2 | Build (optional) | `az bicep build --file main.bicep` |
 | 3 | Deploy | `az deployment sub create` |
 | 4 | Verify | `az resource list` |
+| 5 | **Report** | Present deployed endpoint URLs to the user — see [Verification](verify.md) |
 
 ## Deployment Commands
 

--- a/plugin/skills/azure-deploy/references/recipes/bicep/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/bicep/verify.md
@@ -17,3 +17,15 @@ az deployment sub show \
 ```bash
 curl -s https://<endpoint>/health | jq .
 ```
+
+## Report Results to User
+
+> ⛔ **MANDATORY** — You **MUST** present the deployed endpoint URLs to the user in your response.
+
+Extract endpoints from deployment outputs:
+
+```bash
+az deployment sub show --name main --query properties.outputs
+```
+
+Present a summary including all service URLs. Do NOT end your response without including them.

--- a/plugin/skills/azure-deploy/references/recipes/cicd/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/cicd/verify.md
@@ -15,3 +15,9 @@ az resource list --resource-group <rg-name> --output table
 ```bash
 curl -s https://<endpoint>/health | jq .
 ```
+
+## Report Results to User
+
+> ⛔ **MANDATORY** — You **MUST** present the deployed endpoint URLs to the user in your response.
+
+Extract endpoints from the pipeline output or query them directly via `az` CLI. Present a summary including all service URLs. Do NOT end your response without including them.

--- a/plugin/skills/azure-deploy/references/recipes/terraform/README.md
+++ b/plugin/skills/azure-deploy/references/recipes/terraform/README.md
@@ -19,6 +19,7 @@ Deploy to Azure using Terraform.
 | 3 | Apply | `terraform apply tfplan` |
 | 4 | Get outputs | `terraform output` |
 | 5 | Deploy app | Service-specific commands |
+| 6 | **Report** | Present deployed endpoint URLs to the user — see [Verification](verify.md) |
 
 ## Deployment Commands
 

--- a/plugin/skills/azure-deploy/references/recipes/terraform/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/terraform/verify.md
@@ -16,3 +16,15 @@ curl -s https://$(terraform output -raw api_url)/health | jq .
 ```bash
 az resource list --resource-group $(terraform output -raw resource_group_name) --output table
 ```
+
+## Report Results to User
+
+> ⛔ **MANDATORY** — You **MUST** present the deployed endpoint URLs to the user in your response.
+
+Extract endpoints from Terraform outputs:
+
+```bash
+terraform output -raw api_url
+```
+
+Present a summary including all service URLs. Do NOT end your response without including them.


### PR DESCRIPTION
Fixes #1284.

Update the various deploy recipes to make a stronger statement about reporting deployment URLs to the user. Sometimes the LM just wouldn't show these to the user, even if the deployment succeeded and the URL had been provided by the relevant tool.