### PR TITLE
Stop using gh cli in analyze-test-run

### DIFF
--- a/.github/skills/analyze-test-run/SKILL.md
+++ b/.github/skills/analyze-test-run/SKILL.md
@@ -32,13 +32,9 @@ Downloads artifacts from a GitHub Actions integration test run, generates a summ
 
 1. Extract the numeric run ID from the input (strip URL prefix if needed)
 2. Fetch run metadata:
-   ```bash
-   gh run view <run-id> --repo microsoft/GitHub-Copilot-for-Azure --json jobs,status,conclusion,name
-   ```
-3. Download artifacts to a temp directory:
-   ```bash
-   gh run download <run-id> --repo microsoft/GitHub-Copilot-for-Azure --dir "$TMPDIR/gh-run-<run-id>"
-   ```
+   Use `github` tool to list the Action run with the given `<run-id>` in the "microsoft/GitHub-Copilot-for-Azure" repo. Get its jobs, status, conclusion and name. 
+3. Download this run's artifacts to a temp directory:
+   Use `github` tool to download this run's artifacts to a local directory "$TMPDIR/gh-run-<run-id>".
 4. Locate these files in the downloaded artifacts:
    - `junit.xml` — test pass/fail/skip/error results
    - `*-SKILL-REPORT.md` — generated skill report with per-test details
@@ -111,13 +107,15 @@ Repeat Phase 1–3 for the second run, then produce a side-by-side delta table. 
 
 For Skill Invocation Success Rate that is available and is less than 80%, create a GitHub issue, assign the label with the same name as the skill, and assign it to the code owners listed in .github/CODEOWNERS file based on which skill it is for:
 
+Use `create_issue` tool to create this issue.
 ```
-gh issue create --repo microsoft/GitHub-Copilot-for-Azure \
-  --title "Integration test failure: <skill> – skill-invocation" \
-  --label "bug,integration-test,test-failure,skill-invocation,<skill>" \
-  --body "<body>"
-  --assignee "<codeowners-in-codeowners-file>"
+create_issue:
+   title: "Integration test failure: <skill> – skill-invocation" 
+   labels: ["bug,integration-test,test-failure,skill-invocation,<skill>]
+   assignees: [<codeowners-in-codeowners-file>]
+   body: "<body>"
 ```
+
 Issue body template — see [issue-template.md](references/issue-template.md).
 
 For every test with a `<failure>` element in `junit.xml`:
@@ -133,21 +131,18 @@ For every test with a `<failure>` element in `junit.xml`:
    - **Assertion mismatch** — expected files/links not found
    - **Quota exhaustion** — Azure region quota prevented deployment
 6. Search for existing open issue before creating a new one:
-   ```bash
-   gh issue list --repo microsoft/GitHub-Copilot-for-Azure \
-     --state open \
-     --search "Integration test failure: {skill} in:title" \
-     --json number,title,body
-   ```
+   Use `github` tool to list issues in the "microsoft/GitHub-Copilot-for-Azure" repo with a given title pattern "Integration test failure: {skill} in:title". Focus on their issue number, title and body.
+
    Match criteria: an open issue whose title and body describe a similar problem. If a match is found, skip issue creation for this failure and note the existing issue number(s) in the summary report.
 7. If no existing issue was found, create a GitHub issue, assign the label with the name of the skill, and assign it to the code owners listed in .github/CODEOWNERS file based on which skill it is for:
 
+Use `create_issue` tool to create this issue.
 ```
-gh issue create --repo microsoft/GitHub-Copilot-for-Azure \
-  --title "Integration test failure: <skill> – <keywords> [<root-cause-category>]" \
-  --label "bug,integration-test,test-failure,<skill>" \
-  --body "<body>"
-  --assignee "<codeowners-in-codeowners-file>"
+create_issue:
+   title: "Integration test failure: <skill> – <keywords> [<root-cause-category>]" 
+   labels: ["bug,integration-test,test-failure,<skill>]
+   assignees: [<codeowners-in-codeowners-file>]
+   body: "<body>"
 ```
 
    **Title format:** `Integration test failure: {skill} – {keywords} [{root-cause-category}]`
@@ -164,9 +159,8 @@ Issue body template — see [issue-template.md](references/issue-template.md).
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `gh: command not found` | GitHub CLI not installed | Install with `winget install GitHub.cli` or `brew install gh` |
+| `gh: not authenticated` | GitHub CLI not authenticated | This workflow cannot authenticate to GH CLI with necessary permission by design. Use your Agent tools instead. |
 | `no artifacts found` | Run has no uploadable reports | Verify the run completed the "Export report" step |
-| `HTTP 404` on run view | Invalid run ID or no access | Check the run ID and ensure `gh auth status` is authenticated |
 | `rate limit exceeded` | Too many GitHub API calls | Wait and retry, or use `--limit` on searches |
 
 ## References

--- a/.github/workflows/analyze-test-run.lock.yml
+++ b/.github/workflows/analyze-test-run.lock.yml
@@ -24,7 +24,7 @@
 # Analyzes a GitHub Actions workflow run (given its run ID or URL) and creates
 # GitHub issues for each failing test found in the run's artifacts and logs.
 #
-# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"f8c6bc66772ecbe06dd5aa1c2ae65e524cb0206df6d67074ba2f1739983a47a1","compiler_version":"v0.58.0","strict":true}
+# gh-aw-metadata: {"schema_version":"v2","frontmatter_hash":"0aaedf300e85b15e77492d7045eb04607f6a835e18e5361577e75cb1d82fc4bf","compiler_version":"v0.58.0","strict":true}
 
 name: "Analyze Test Run"
 "on":
@@ -342,7 +342,7 @@ jobs:
           cat > /opt/gh-aw/safeoutputs/tools.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_EOF'
           [
             {
-              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 10 issue(s) can be created. Labels [\"bug\" \"integration-test\"] will be automatically added.",
+              "description": "Create a new GitHub issue for tracking bugs, feature requests, or tasks. Use this for actionable work items that need assignment, labeling, and status tracking. For reports, announcements, or status updates that don't require task tracking, use create_discussion instead. CONSTRAINTS: Maximum 10 issue(s) can be created. Labels [\"bug\" \"integration-test\" \"test-failure\"] will be automatically added.",
               "inputSchema": {
                 "additionalProperties": false,
                 "properties": {
@@ -1144,7 +1144,7 @@ jobs:
           GH_AW_ALLOWED_DOMAINS: "api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,github.com,host.docker.internal,raw.githubusercontent.com,registry.npmjs.org,telemetry.enterprise.githubcopilot.com"
           GITHUB_SERVER_URL: ${{ github.server_url }}
           GITHUB_API_URL: ${{ github.api_url }}
-          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"bug\",\"integration-test\"],\"max\":10},\"missing_data\":{},\"missing_tool\":{}}"
+          GH_AW_SAFE_OUTPUTS_HANDLER_CONFIG: "{\"create_issue\":{\"labels\":[\"bug\",\"integration-test\",\"test-failure\"],\"max\":10},\"missing_data\":{},\"missing_tool\":{}}"
         with:
           github-token: ${{ secrets.GH_AW_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/analyze-test-run.md
+++ b/.github/workflows/analyze-test-run.md
@@ -32,7 +32,7 @@ tools:
 safe-outputs:
   create-issue:
     max: 10
-    labels: [bug, integration-test]
+    labels: [bug, integration-test,test-failure]
 
 engine: copilot
 ---


### PR DESCRIPTION
Logs of analyze-test-run indicate it cannot use gh cli because gh cli requires authentication upfront for all commands,.including those that theoretically don't require authentication such as reading a public repo.

https://github.com/microsoft/GitHub-Copilot-for-Azure/actions/runs/23198710690

On the other hand, the agentic workflow won't be able to use its default ttoken to call gh cli for creating issues. Unlike in regular workflows, the issue: write permission is by design prohibited in agentic workflow for security reasons. We should use the safe_outputs tool to create issues.