### PR TITLE
infra: Update azure-skills copy

### DIFF
--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -131,9 +131,12 @@ jobs:
           TARGET_DIRS=("target-repo/.github/plugins/azure-skills/" "target-repo/skills/" "target-repo/plugin.json" "target-repo/.mcp.json")
           for target in "${TARGET_DIRS[@]}"; do
             if [ -e "$target" ]; then
-              grep -rl --include='*.md' --include='*.json' 'https://github.com/microsoft/github-copilot-for-azure' "$target" | while IFS= read -r file; do
-                sed -i 's|https://github.com/microsoft/GitHub-Copilot-for-Azure|https://github.com/microsoft/azure-skills|g' "$file"
-              done
+              if matches=$(grep -rli --include='*.md' --include='*.json' 'https://github.com/microsoft/github-copilot-for-azure' "$target"); then
+                echo "$matches" | while IFS= read -r file; do
+                  sed -i 's|https://github.com/microsoft/GitHub-Copilot-for-Azure|https://github.com/microsoft/azure-skills|g' "$file"
+                  sed -i 's|https://github.com/microsoft/github-copilot-for-azure|https://github.com/microsoft/azure-skills|g' "$file"
+                done
+              fi
             fi
           done
 


### PR DESCRIPTION
Currently the publish-to-marketplace.yml pipeline copies all of the "plugin" directory in this repo to the ".github/plugins/azure-skills" directory in the microsoft/azure-skills repo. This is really where we want the files to live long-term, especially as it allows us to put a different plugin in the same repo.

However, VS Code currently only looks for plugins at the repo root, not in a subdirectory. Until the plugin support improves, we need to copy the plugin.json, .mcp.json, and skills directory to the repo root as well as the current location. Here we update the pipeline to do that.

Note that currently azure-skills uses symlinks to try and achieve the same thing without needing to duplicate files, but it turns out that whether or not this works in practice depends very much on an individual user's git settings. Having two copies is annoying but will be much more reliable.