### PR TITLE
fix: update regex lookahead in DEPLOY_LINK_PATTERNS

### DIFF
--- a/tests/azure-deploy/utils.ts
+++ b/tests/azure-deploy/utils.ts
@@ -23,18 +23,19 @@ export function softCheckContainerDeployEnvVars(agentMetadata: AgentMetadata): v
 }
 
 /**
- * Common Azure deployment link patterns
- * Patterns ensure the domain ends properly to prevent matching evil.com/azurewebsites.net or similar
+ * Common Azure deployment link patterns.
+ * Lookahead ensures the domain ends properly (not a substring of a longer host).
+ * Includes `*` to handle markdown bold-wrapped URLs (`**url**`).
  */
 const DEPLOY_LINK_PATTERNS = [
-  // Azure App Service URLs (matches domain followed by path, query, fragment, whitespace, or punctuation)
-  /https?:\/\/[\w.-]+\.azurewebsites\.net(?=[/\s.`'"?#)\]]|$)/i,
+  // Azure App Service URLs
+  /https?:\/\/[\w.-]+\.azurewebsites\.net(?=[/\s.`'"?#)\]*]|$)/i,
   // Azure Static Web Apps URLs
-  /https:\/\/[\w.-]+\.azurestaticapps\.net(?=[/\s.`'"?#)\]]|$)/i,
+  /https:\/\/[\w.-]+\.azurestaticapps\.net(?=[/\s.`'"?#)\]*]|$)/i,
   // Azure Container Apps URLs
-  /https:\/\/[\w.-]+\.azurecontainerapps\.io(?=[/\s.`'"?#)\]]|$)/i,
+  /https:\/\/[\w.-]+\.azurecontainerapps\.io(?=[/\s.`'"?#)\]*]|$)/i,
   // static website from a storage account
-  /https:\/\/[\w.-]+\.web\.core\.windows\.net(?=[/\s.`'"?#)\]]|$)/i
+  /https:\/\/[\w.-]+\.web\.core\.windows\.net(?=[/\s.`'"?#)\]*]|$)/i
 ];
 
 /**


### PR DESCRIPTION
The lookahead (?=[/\s.\'"?#)\]]|\$) caused false negatives when the LM wrapped deployment URLs in markdown bold (**url**), because * was not in the allowed trailing characters. Here the lookahead has been updated to include *. 

The lookahead may not actually be necessary, but removing it causes CodeQL to complain. Updating it was easier than figuring out if and how we can safely remove it.

Fixes #1342.