### PR TITLE
test: accept .bicepparam as valid Bicep parameter file in standalone Bicep test

### DIFF
--- a/tests/azure-prepare/integration.test.ts
+++ b/tests/azure-prepare/integration.test.ts
@@ -714,7 +714,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       expect(workspacePath).toBeDefined();
       expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
       expectFiles(workspacePath!,
-        [/plan\.md$/, /infra\/.*\.bicep$/, /infra\/.*\.parameters\.json$/],
+        [/plan\.md$/, /infra\/.*\.bicep$/, /infra\/.*\.(parameters\.json|bicepparam)$/],
         [/azure\.yaml$/, /\.tf$/],
       );
     });


### PR DESCRIPTION
The azure-prepare standalone Bicep recipe test expected only .parameters.json files, but the agent generated a .bicepparam file (the modern native Bicep parameter format). Both formats are valid for standalone Bicep deployments.

Update the regex to accept either .parameters.json or .bicepparam.

Fixes #1388