### PR TITLE
test: instruct agent to write diagram to workspace directory

### DIFF
--- a/tests/azure-resource-visualizer/integration.test.ts
+++ b/tests/azure-resource-visualizer/integration.test.ts
@@ -85,7 +85,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let workspacePath: string | undefined;
 
       const agentMetadata = await agent.run({
-        prompt: "Generate a Mermaid diagram showing my Azure resource group architecture",
+        prompt: "Generate a Mermaid diagram showing my Azure resource group architecture. Save the diagram to an architecture.md file in the current working directory.",
         nonInteractive: true,
         followUp: FOLLOW_UP_PROMPT,
         setup: async (workspace: string) => {
@@ -105,7 +105,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let workspacePath: string | undefined;
 
       const agentMetadata = await agent.run({
-        prompt: "Visualize how my Azure resources are connected and show their relationships",
+        prompt: "Visualize how my Azure resources are connected and show their relationships. Save the diagram to an architecture.md file in the current working directory.",
         nonInteractive: true,
         followUp: FOLLOW_UP_PROMPT,
         setup: async (workspace: string) => {


### PR DESCRIPTION
## Problem

The `azure-resource-visualizer` integration tests assert that a Mermaid diagram file (`architecture*.md`) exists in the workspace directory, but the test prompts did not tell the agent where to write the file. The agent wrote to `/tmp/azure-architecture-diagram.md` instead of the workspace `cwd` (`/tmp/skill-test-XXXXXX/`), so `doesWorkspaceFileIncludePattern` returned `false`.

## Fix

Updated both `resource-group-visualization` test prompts to explicitly instruct the agent to save the diagram to an `architecture.md` file in the current working directory. The test harness sets the agent's `cwd` to the workspace (via `agent-runner.ts:514`), so this ensures the file lands where the assertion checks.

Fixes #1384
Fixes #1387