### PR TITLE
update: Enable cron job for msbench report generation pipeline

### DIFF
--- a/pipelines/azure-benchmark-report.yml
+++ b/pipelines/azure-benchmark-report.yml
@@ -14,13 +14,13 @@ parameters:
 trigger: none
 pr: none
 
-# schedules:
-# - cron: '0 8 * * *'
-#   displayName: 'Daily 8am UTC'
-#   branches:
-#     include:
-#     - main
-#   always: true
+schedules:
+- cron: '0 11 * * *'
+  displayName: 'Daily 11am UTC'
+  branches:
+    include:
+    - main
+  always: true
 
 stages:
 - stage: ReportBenchmark


### PR DESCRIPTION
Enable cron job for msbench report generation pipeline.
Benchmarks are scheduled to run at 8am UTC daily Mon-Friday.
Reports are scheduled to be generated at 11am UTC daily.
