### PR TITLE
Fix line ending for bash script created on windows for linux and mac

### DIFF
--- a/plugin/hooks/scripts/track-telemetry.sh
+++ b/plugin/hooks/scripts/track-telemetry.sh
@@ -202,3 +202,4 @@ fi
 
 # Output success to stdout (required by hooks)
 return_success
+


### PR DESCRIPTION
Fix line ending for bash script created on windows for linux and mac