### PR TITLE
test: Fix standalone Bicep parameter file pattern in integration test

### DIFF
--- a/tests/azure-prepare/integration.test.ts
+++ b/tests/azure-prepare/integration.test.ts
@@ -714,7 +714,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       expect(workspacePath).toBeDefined();
       expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
       expectFiles(workspacePath!,
-        [/plan\.md$/, /infra\/.*\.bicep$/, /infra\/.*\.(parameters\.json|bicepparam)$/],
+        [/plan\.md$/, /infra\/.*\.bicep$/, /infra\/(.*\.bicepparam|(.*\.)?parameters\.json)$/],
         [/azure\.yaml$/, /\.tf$/],
       );
     });


### PR DESCRIPTION
The regex `\/infra\/.*\.(parameters\.json|bicepparam)$/\` required a dot before parameters.json, so it matched main.parameters.json but not parameters.json. The azure-prepare skill generates the latter form, causing the standalone Bicep recipe test to fail.

Changed the pattern to `\/infra\/(.*\.bicepparam|(.*\.)?parameters\.json)$` so the dot-prefix is optional for parameters.json while still required for .bicepparam files.

Fixes #1416