### PR TITLE
fix: Add 'Report deployed endpoint URLs' step to plan template

### DIFF
--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -4,7 +4,7 @@ description: "Prepare Azure apps for deployment (infra Bicep/Terraform, azure.ya
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.6"
+  version: "1.0.7"
 ---
 
 # Azure Prepare

--- a/plugin/skills/azure-prepare/references/plan-template.md
+++ b/plugin/skills/azure-prepare/references/plan-template.md
@@ -176,6 +176,7 @@ For each resource type:
 ### Phase 4: Deployment
 - [ ] Invoke azure-deploy skill
 - [ ] Deployment successful
+- [ ] Report deployed endpoint URLs
 - [ ] Update plan status to "Deployed"
 
 ---


### PR DESCRIPTION
## Problem

In #1413 the deployment succeeded and `azd up` printed endpoint URLs, but the LM produced an empty final response and never relayed them to the user.

The plan template checklist — which the LM follows step by step — had no item requiring it to report the URLs.

## Fix

Add a "Report deployed endpoint URLs" checklist item to Phase 4: Deployment so the LM treats URL reporting as a required step.

Fixes #1413