### PR TITLE
fix: clarify that plan.md must be created in workspace root, not session-state folder

### DIFF
--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -4,7 +4,7 @@ description: "Prepare Azure apps for deployment (infra Bicep/Terraform, azure.ya
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.6"
+  version: "1.0.7"
 ---
 
 # Azure Prepare
@@ -28,7 +28,7 @@ Activate this skill when user wants to:
 
 ## Rules
 
-1. **Plan first** — Create `.azure/plan.md` before any code generation
+1. **Plan first** — Create `.azure/plan.md` **in the workspace root directory** (not the session-state folder) before any code generation
 2. **Get approval** — Present plan to user before execution
 3. **Research before generating** — Load references and invoke related skills
 4. **Update plan progressively** — Mark steps complete as you go
@@ -49,6 +49,10 @@ Activate this skill when user wants to:
 > 4. **EXECUTE** — Only after approval, execute the plan step by step
 >
 > The `.azure/plan.md` file is the **source of truth** for this workflow and for azure-validate and azure-deploy skills. Without it, those skills will fail.
+>
+> ⚠️ **CRITICAL: `.azure/plan.md` must be created inside the workspace root** (e.g., `/tmp/my-project/.azure/plan.md`). This is **NOT** the session-state `plan.md` used for internal workflow tracking. These are two different files:
+> - **`<workspace>/.azure/plan.md`** — The deployment plan artifact read by azure-validate and azure-deploy. **You must create this.**
+> - **`~/.copilot/session-state/<id>/plan.md`** — Internal session notes. This file is NOT visible to other skills.
 
 ---
 


### PR DESCRIPTION
## Problem

In integration test run [#106](https://github.com/microsoft/GitHub-Copilot-for-Azure/actions/runs/23334425692), the "creates event-driven function app with Terraform" test failed because the LM never invoked the `azure-validate` or `azure-deploy` skills. Analysis of the agent metadata showed that the LM wrote `plan.md` to the Copilot session-state folder (`~/.copilot/session-state/{id}/plan.md`) instead of the workspace root (`{workspace}/.azure/plan.md`). Since `.azure/plan.md` never existed in the project directory, the LM did not recognize the project as ready for the validate/deploy skill chain and instead ran `terraform apply` directly, which got stuck on RBAC role assignments and never created the function app.

## Changes

Updates `azure-prepare/SKILL.md` to explicitly disambiguate the two `plan.md` files:

- **Rule 1**: Added "in the workspace root directory (not the session-state folder)" to the plan-first rule.
- **PLAN-FIRST WORKFLOW callout**: Added a critical warning block that distinguishes:
  - `{workspace}/.azure/plan.md` -- the deployment plan artifact read by azure-validate and azure-deploy.
  - `~/.copilot/session-state/{id}/plan.md` -- internal session notes, not visible to other skills.

Version bumped from 1.0.6 to 1.0.7.

Fixes #1408
Fixes #1419
