### PR TITLE
fix(telemetry): strip "azure:" prefix from skill names for Claude Code

### DIFF
--- a/plugin/hooks/scripts/track-telemetry.ps1
+++ b/plugin/hooks/scripts/track-telemetry.ps1
@@ -89,6 +89,12 @@ $filePath = $null
 # Check for skill invocation via 'skill'/'Skill' tool
 if ($toolName -eq "skill" -or $toolName -eq "Skill") {
     $skillName = $toolInput.skill
+    # Claude Code prefixes skill names with the plugin name: "plugin-name:skill-name"
+    # Since this plugin is named "azure", a skill like "azure-prepare" becomes "azure:azure-prepare"
+    # Strip the "azure:" prefix to get the actual skill name (e.g., "azure:azure-prepare" -> "azure-prepare")
+    if ($skillName -and $skillName.StartsWith("azure:")) {
+        $skillName = $skillName.Substring(6)
+    }
     if ($skillName) {
         $eventType = "skill_invocation"
         $shouldTrack = $true

--- a/plugin/hooks/scripts/track-telemetry.sh
+++ b/plugin/hooks/scripts/track-telemetry.sh
@@ -115,6 +115,10 @@ filePath=""
 # Check for skill invocation via 'skill'/'Skill' tool
 if [ "$toolName" = "skill" ] || [ "$toolName" = "Skill" ]; then
     skillName=$(extract_toolargs_field "$rawInput" "skill")
+    # Claude Code prefixes skill names with the plugin name: "plugin-name:skill-name"
+    # Since this plugin is named "azure", a skill like "azure-prepare" becomes "azure:azure-prepare"
+    # Strip the "azure:" prefix to get the actual skill name (e.g., "azure:azure-prepare" -> "azure-prepare")
+    skillName="${skillName#azure:}"
     if [ -n "$skillName" ]; then
         eventType="skill_invocation"
         shouldTrack=true


### PR DESCRIPTION
We want to check if the skill name is allowlisted and we dont accidentally emit skilll-names not owned by us. this change was made on azure mcp server side. updating the script to be aligned with it