### PR TITLE
fix: ensure deploy skill always emits fully-qualified https:// URLs

### DIFF
--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute Azure deployments for ALREADY-PREPARED applications that h
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.7"
+  version: "1.0.8"
 ---
 
 # Azure Deploy
@@ -65,7 +65,11 @@ Activate this skill when user wants to:
 | 5 | **Post-Deploy** — Configure SQL managed identity and apply EF migrations if applicable | [Post-Deployment](references/recipes/azd/post-deployment.md) |
 | 6 | **Handle Errors** — See recipe's `errors.md` | — |
 | 7 | **Verify Success** — Confirm deployment completed and endpoints are accessible | [Verification](references/recipes/azd/verify.md) |
-| 8 | **Report Results** — Present deployed endpoint URLs to the user | [Verification](references/recipes/azd/verify.md) |
+| 8 | **Report Results** — Present deployed endpoint URLs to the user as fully-qualified `https://` links | [Verification](references/recipes/azd/verify.md) |
+
+> **⛔ URL FORMAT RULE**
+>
+> When presenting endpoint URLs to the user, you **MUST** always use fully-qualified URLs with the `https://` scheme (e.g. `https://myapp.azurewebsites.net`, not `myapp.azurewebsites.net`). Many Azure CLI commands return bare hostnames without a scheme — always prepend `https://` before presenting them.
 
 > **⛔ VALIDATION PROOF CHECK**
 >

--- a/plugin/skills/azure-deploy/references/recipes/azcli/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/azcli/verify.md
@@ -37,10 +37,18 @@ Extract endpoints using the appropriate command for the service type:
 
 ```bash
 # Container Apps
-az containerapp show --name <app-name> --resource-group <rg-name> --query "properties.configuration.ingress.fqdn" -o tsv
+FQDN=$(az containerapp show --name <app-name> --resource-group <rg-name> --query "properties.configuration.ingress.fqdn" -o tsv)
+echo "https://$FQDN"
 
 # App Service
-az webapp show --name <app-name> --resource-group <rg-name> --query "defaultHostName" -o tsv
+HOSTNAME=$(az webapp show --name <app-name> --resource-group <rg-name> --query "defaultHostName" -o tsv)
+echo "https://$HOSTNAME"
+
+# Static Web Apps
+HOSTNAME=$(az staticwebapp show --name <app-name> --resource-group <rg-name> --query "defaultHostname" -o tsv)
+echo "https://$HOSTNAME"
 ```
 
-Present a summary including all service URLs. Do NOT end your response without including them.
+> ⚠️ **These commands return bare hostnames without a scheme.** Always prepend `https://` when presenting URLs to the user. For example, report `https://myapp.azurewebsites.net`, never `myapp.azurewebsites.net`.
+
+Present a summary including all service URLs as fully-qualified `https://` links. Do NOT end your response without including them.

--- a/plugin/skills/azure-deploy/references/recipes/azd/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/verify.md
@@ -60,6 +60,8 @@ Aspire Dashboard: https://aspire-dashboard.xxx.azurecontainerapps.io
 
 > ⚠️ If output was truncated, run `azd show` to retrieve endpoint URLs.
 
+> ⚠️ **Always use fully-qualified URLs with the `https://` scheme.** If a command returns a bare hostname (e.g. `myapp.azurestaticapps.net`), prepend `https://` before presenting it to the user.
+
 ## Step 4: Post-Deployment Verification (if applicable)
 
 For deployments with Azure SQL Database and managed identity:

--- a/plugin/skills/azure-deploy/references/recipes/bicep/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/bicep/verify.md
@@ -28,4 +28,4 @@ Extract endpoints from deployment outputs:
 az deployment sub show --name main --query properties.outputs
 ```
 
-Present a summary including all service URLs. Do NOT end your response without including them.
+Present a summary including all service URLs as fully-qualified `https://` links. If a deployment output returns a bare hostname (e.g. `myapp.azurewebsites.net`), always prepend `https://`. Do NOT end your response without including them.

--- a/plugin/skills/azure-deploy/references/recipes/cicd/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/cicd/verify.md
@@ -20,4 +20,4 @@ curl -s https://<endpoint>/health | jq .
 
 > ⛔ **MANDATORY** — You **MUST** present the deployed endpoint URLs to the user in your response.
 
-Extract endpoints from the pipeline output or query them directly via `az` CLI. Present a summary including all service URLs. Do NOT end your response without including them.
+Extract endpoints from the pipeline output or query them directly via `az` CLI. Present a summary including all service URLs as fully-qualified `https://` links. If any command returns a bare hostname (e.g. `myapp.azurewebsites.net`), always prepend `https://`. Do NOT end your response without including them.

--- a/plugin/skills/azure-deploy/references/recipes/terraform/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/terraform/verify.md
@@ -27,4 +27,4 @@ Extract endpoints from Terraform outputs:
 terraform output -raw api_url
 ```
 
-Present a summary including all service URLs. Do NOT end your response without including them.
+Present a summary including all service URLs as fully-qualified `https://` links. If a Terraform output returns a bare hostname (e.g. `myapp.azurewebsites.net`), always prepend `https://`. Do NOT end your response without including them.


### PR DESCRIPTION
## Problem

Azure CLI commands like `az webapp show --query defaultHostName` and `az staticwebapp show --query defaultHostname` return bare hostnames without a scheme prefix (e.g. `gray-grass-094fc790f.4.azurestaticapps.net`). The LM was presenting these bare hostnames to the user, causing the `hasDeployLinks` test assertion to fail since the regex requires the `https://` prefix.

## Changes

- **SKILL.md** — Added a URL FORMAT RULE callout and updated Step 8 description (version bump 1.0.7 → 1.0.8)
- **azcli/verify.md** — Rewrote CLI examples to capture hostname into a variable and echo with `https://` prefix; added Static Web Apps example; added explicit warning
- **azd/verify.md** — Added reminder to prepend `https://` to bare hostnames
- **bicep/verify.md** — Updated to require fully-qualified `https://` links
- **terraform/verify.md** — Updated to require fully-qualified `https://` links
- **cicd/verify.md** — Updated to require fully-qualified `https://` links

Fixes #1411