### PR TITLE
Upgrade node in all integration test workflow

### DIFF
--- a/.github/workflows/test-all-skills.yml
+++ b/.github/workflows/test-all-skills.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: tests/package-lock.json
 


### PR DESCRIPTION
This would suppress the warnings emitted by the integration test runs.