### PR TITLE
Add code owner for azure-kubernetes skill to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,6 +19,7 @@
 /plugin/skills/azure-diagnostics/ @tmeschter @saikoumudi
 /plugin/skills/azure-enterprise-infra-planner/ @Jbrocket @micha31r @arunrab
 /plugin/skills/azure-hosted-copilot-sdk/ @jongio
+/plugin/skills/azure-kubernetes/ @saikoumudi
 /plugin/skills/azure-kusto/ @saikoumudi
 /plugin/skills/azure-messaging/ @kashifkhan
 /plugin/skills/azure-prepare/ @tmeschter @wbreza


### PR DESCRIPTION
Adding @saikoumudi as codeowner for the azure-kubernetes skill.