### PR TITLE
Tighten access to integration test dashboard

### DIFF
--- a/dashboard/public/staticwebapp.config.json
+++ b/dashboard/public/staticwebapp.config.json
@@ -11,7 +11,6 @@
         {
             "route": "/*",
             "allowedRoles": [
-                "authenticated",
                 "reader"
             ]
         }


### PR DESCRIPTION
I have given skill owners the new reader role. Now I am removing the authenticated role so people without explicit permissions won't have access.