### PR TITLE
Bump eslint-plugin-jest

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -16,7 +16,7 @@
         "cross-env": "^10.1.0",
         "eslint": "^9.0.0",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-jest": "^29.15.0",
+        "eslint-plugin-jest": "^29.15.1",
         "gray-matter": "^4.0.3",
         "html-entities": "^2.6.0",
         "jest": "^30.3.0",
@@ -3832,9 +3832,9 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "29.15.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.0.tgz",
-      "integrity": "sha512-ZCGr7vTH2WSo2hrK5oM2RULFmMruQ7W3cX7YfwoTiPfzTGTFBMmrVIz45jZHd++cGKj/kWf02li/RhTGcANJSA==",
+      "version": "29.15.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.1.tgz",
+      "integrity": "sha512-6BjyErCQauz3zfJvzLw/kAez2lf4LEpbHLvWBfEcG4EI0ZiRSwjoH2uZulMouU8kRkBH+S0rhqn11IhTvxKgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3847,7 +3847,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "jest": "*",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <7.0.0"
       },
       "peerDependenciesMeta": {
         "@typescript-eslint/eslint-plugin": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -33,7 +33,7 @@
     "cross-env": "^10.1.0",
     "eslint": "^9.0.0",
     "eslint-plugin-import": "^2.32.0",
-    "eslint-plugin-jest": "^29.15.0",
+    "eslint-plugin-jest": "^29.15.1",
     "gray-matter": "^4.0.3",
     "html-entities": "^2.6.0",
     "jest": "^30.3.0",


### PR DESCRIPTION
Update the version of eslint-plugin-jest. This will help unblock an update to TypeScript 6.0 (#1575).