### PR TITLE
Restore current plugin version before checking for skill content changes

### DIFF
--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -59,7 +59,19 @@ jobs:
           #   --verbose   list changes
           rsync --archive --delete --verbose "$SOURCE_DIR" "$TARGET_DIR"
 
-      # 5. Bump version if content changed
+      # 5. Restore version in plugin.json files to CURRENT_VERSION
+      - name: Restore version in plugin.json files
+        run: |
+          CURRENT_VERSION="${{ steps.version.outputs.current }}"
+          TARGET_DIR="target-repo/.github/plugins/azure-skills/"
+          for f in "${TARGET_DIR}.claude-plugin/plugin.json" "${TARGET_DIR}.plugin/plugin.json"; do
+            if [ -f "$f" ]; then
+              jq --arg v "$CURRENT_VERSION" '.version = $v' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+              echo "Restored $f to version $CURRENT_VERSION"
+            fi
+          done
+
+      # 6. Bump version if content changed
       - name: Bump version if content changed
         working-directory: target-repo
         run: |
@@ -115,7 +127,7 @@ jobs:
           # Reset staging so the commit step handles it cleanly
           git reset HEAD
 
-      # 6. Commit changes and create a PR
+      # 7. Commit changes and create a PR
       - name: Commit and push changes
         id: commit
         working-directory: target-repo
@@ -222,7 +234,19 @@ jobs:
             fi
           done
 
-      # 7. Bump version if content changed
+      # 7. Restore version in plugin.json files to CURRENT_VERSION
+      - name: Restore version in plugin.json files
+        run: |
+          CURRENT_VERSION="${{ steps.version.outputs.current }}"
+          TARGET_DIR="target-repo/.github/plugins/azure-skills/"
+          for f in "${TARGET_DIR}.claude-plugin/plugin.json" "${TARGET_DIR}.plugin/plugin.json" "target-repo/plugin.json"; do
+            if [ -f "$f" ]; then
+              jq --arg v "$CURRENT_VERSION" '.version = $v' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+              echo "Restored $f to version $CURRENT_VERSION"
+            fi
+          done
+
+      # 8. Bump version if content changed
       - name: Bump version if content changed
         working-directory: target-repo
         run: |
@@ -279,7 +303,7 @@ jobs:
           # Reset staging so the commit step handles it cleanly
           git reset HEAD
 
-      # 8. Commit changes and create a PR
+      # 9. Commit changes and create a PR
       - name: Commit and push changes
         id: commit
         working-directory: target-repo


### PR DESCRIPTION
Fix an issue of the plugin version bumping logic in the current publishing pipeline. The plugin version in this repo remains as 1.0.1 forever. When syncing to microsoft/skills and microsoft/azure-skills repos, it resets the plugin version to 1.0.1. When there isn't any skill content change, this led to a plugin version reset PR, which is undesired. This PR adds a step to restore plugin versions after syncing skill contents to the current version in microsoft/skills and microsoft/azure-skills repos before checking if a new bump needed.