### PR TITLE
Copy .claude-plugin/plugin.json to repo root for Claude marketplace support

### DIFF
--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -211,18 +211,20 @@ jobs:
           #   --verbose   list changes
           rsync --archive --delete --verbose "$SOURCE_DIR" "$TARGET_DIR"
 
-      # 5. Copy plugin.json, .mcp.json, and skills/ to the repo root
+      # 5. Copy plugin.json, .mcp.json, .claude-plugin/plugin.json, and skills/ to the repo root
       - name: Copy plugin files to repo root
         run: |
           cp "source-repo/plugin/.plugin/plugin.json" "target-repo/plugin.json"
           cp "source-repo/plugin/.mcp.json" "target-repo/.mcp.json"
+          mkdir -p "target-repo/.claude-plugin/"
+          cp "source-repo/plugin/.claude-plugin/plugin.json" "target-repo/.claude-plugin/plugin.json"
           mkdir -p "target-repo/skills/"
           rsync --archive --delete --verbose "source-repo/plugin/skills/" "target-repo/skills/"
 
       # 6. Replace repository URLs in synced files
       - name: Replace repository URLs
         run: |
-          TARGET_DIRS=("target-repo/.github/plugins/azure-skills/" "target-repo/skills/" "target-repo/plugin.json" "target-repo/.mcp.json")
+          TARGET_DIRS=("target-repo/.github/plugins/azure-skills/" "target-repo/skills/" "target-repo/plugin.json" "target-repo/.mcp.json" "target-repo/.claude-plugin/plugin.json")
           for target in "${TARGET_DIRS[@]}"; do
             if [ -e "$target" ]; then
               if matches=$(grep -rli --include='*.md' --include='*.json' 'https://github.com/microsoft/github-copilot-for-azure' "$target"); then
@@ -239,7 +241,7 @@ jobs:
         run: |
           CURRENT_VERSION="${{ steps.version.outputs.current }}"
           TARGET_DIR="target-repo/.github/plugins/azure-skills/"
-          for f in "${TARGET_DIR}.claude-plugin/plugin.json" "${TARGET_DIR}.plugin/plugin.json" "target-repo/plugin.json"; do
+          for f in "${TARGET_DIR}.claude-plugin/plugin.json" "${TARGET_DIR}.plugin/plugin.json" "target-repo/plugin.json" "target-repo/.claude-plugin/plugin.json"; do
             if [ -f "$f" ]; then
               jq --arg v "$CURRENT_VERSION" '.version = $v' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
               echo "Restored $f to version $CURRENT_VERSION"
@@ -254,6 +256,7 @@ jobs:
             ".github/plugins/azure-skills/.claude-plugin/plugin.json"
             ".github/plugins/azure-skills/.plugin/plugin.json"
             "plugin.json"
+            ".claude-plugin/plugin.json"
           )
 
           git add --all


### PR DESCRIPTION
Updates the sync-to-microsoft-azure-skills job in the publish-to-marketplace workflow to copy .claude-plugin/plugin.json to the repo root of microsoft/azure-skills, enabling the Azure plugin to be discoverable in the Claude marketplace.

**Changes:**
- **Step 5** — Copy .claude-plugin/plugin.json to target-repo/.claude-plugin/
- **Step 6** — Rewrite GitHub URLs in the new file
- **Step 7** — Restore version before diffing
- **Step 8** — Bump version alongside other plugin.json files