### PR TITLE
 Update AKS cost spike integration test prompts with specific time window

### DIFF
--- a/tests/azure-cost/integration.test.ts
+++ b/tests/azure-cost/integration.test.ts
@@ -236,7 +236,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          prompt: "Why did my AKS cluster spend suddenly increase this week? Help me find the cause",
+          prompt: "My AKS cluster costs spiked unexpectedly last Sunday from 2am to 4pm EST, help me investigate",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
         softCheckSkill(agentMetadata, SKILL_NAME);
@@ -276,7 +276,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
     test("response mentions monitoring commands for AKS cost anomaly prompt", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        prompt: "My AKS cluster costs spiked unexpectedly this week, help me investigate"
+        prompt: "My AKS cluster costs spiked unexpectedly last Sunday from 2am to 4pm EST, help me investigate"
       });
       softCheckSkill(agentMetadata, SKILL_NAME);
       const mentionsMonitoring = doesAssistantMessageIncludeKeyword(agentMetadata, "kubectl top") ||


### PR DESCRIPTION

  Updated two AKS cost anomaly prompts in the azure-cost-optimization integration tests to include a specific day and time window, making them more
  realistic and deterministic for testing purposes.

  Changes:

   - skill-invocation test: replaced vague weekly spike prompt with a specific Sunday time window
   - aks-cost-optimization response-quality test: updated to match the same specific time window prompt

  Before:

   - "Why did my AKS cluster spend suddenly increase this week? Help me find the cause"
   - "My AKS cluster costs spiked unexpectedly this week, help me investigate"

  After:

   - "My AKS cluster costs spiked unexpectedly last Sunday from 2am to 4pm EST, help me investigate" (both)