### PR TITLE
Create skill-fixer agent to provide basic guidelines

### DIFF
--- a/.github/agents/skill-fixer.agent.md
+++ b/.github/agents/skill-fixer.agent.md
@@ -1,0 +1,13 @@
+---
+# Fill in the fields below to create a basic custom agent for your repository.
+# The Copilot CLI can be used for local testing: https://gh.io/customagents/cli
+# To make this agent available, merge this file into the default repository branch.
+# For format details, see: https://gh.io/customagents/config
+
+name:
+description:
+---
+
+# My Agent
+
+When working on updating any skills in this repo, make sure to bump skill version in the same PR.


### PR DESCRIPTION
Create skill-fixer agent to provide basic guidelines. Currently, it includes skill bumping rule.