### PR TITLE
fix: add defense-in-depth SQL Entra-only auth checks

### DIFF
--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -4,7 +4,7 @@ description: "Prepare Azure apps for deployment (infra Bicep/Terraform, azure.ya
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.1.3"
+  version: "1.1.4"
 ---
 
 # Azure Prepare

--- a/plugin/skills/azure-prepare/references/generate.md
+++ b/plugin/skills/azure-prepare/references/generate.md
@@ -95,6 +95,7 @@ project-root/
 - Use Key Vault for sensitive values
 - Managed Identity for service auth
 - HTTPS only, TLS 1.2+
+- SQL Server Bicep must use Entra-only auth — omit `administratorLogin` and `administratorLoginPassword` entirely (see [services/sql-database/bicep.md](services/sql-database/bicep.md))
 
 ### Runtime Configuration
 

--- a/plugin/skills/azure-prepare/references/research.md
+++ b/plugin/skills/azure-prepare/references/research.md
@@ -101,13 +101,20 @@ Add research findings to `.azure/deployment-plan.md` under a `## Research Summar
 
 ## Common Research Patterns
 
-### Web Application + API + Database
+### Web Application + API + Database (Cosmos DB)
 
 1. Load: [services/container-apps/README.md](services/container-apps/README.md) → [bicep.md](services/container-apps/bicep.md), [scaling.md](services/container-apps/scaling.md)
 2. Load: [services/cosmos-db/README.md](services/cosmos-db/README.md) → [partitioning.md](services/cosmos-db/partitioning.md)
 3. Load: [services/key-vault/README.md](services/key-vault/README.md)
 4. Invoke: `azure-observability` (monitoring setup)
 5. Review service-specific security guidance directly before generation
+
+### Container Apps + API + SQL Database
+
+1. Load: [services/container-apps/README.md](services/container-apps/README.md) → [bicep.md](services/container-apps/bicep.md), [scaling.md](services/container-apps/scaling.md)
+2. Load: [services/sql-database/README.md](services/sql-database/README.md) → [bicep.md](services/sql-database/bicep.md), [auth.md](services/sql-database/auth.md)
+3. Load: [services/key-vault/README.md](services/key-vault/README.md)
+4. Review [auth.md](services/sql-database/auth.md) directly for Entra-only auth configuration
 
 ### App Service + API + SQL Database
 

--- a/plugin/skills/azure-prepare/references/security.md
+++ b/plugin/skills/azure-prepare/references/security.md
@@ -60,6 +60,7 @@ az identity list --output table
 - [ ] Enable MFA for all users
 - [ ] Apply least privilege RBAC
 - [ ] Use Microsoft Entra ID for authentication
+- [ ] SQL Server: Entra-only auth — do NOT generate `administratorLogin` or `administratorLoginPassword` (see [sql-database/auth.md](services/sql-database/auth.md))
 - [ ] Review access regularly
 
 ### Managed Identity


### PR DESCRIPTION
Fixes #1661.

## Problem

In integration test run [#135](https://github.com/microsoft/GitHub-Copilot-for-Azure/actions/runs/23899869938), the `entra-sql-auth` test failed because the agent generated SQL Server Bicep containing `administratorLoginPassword` despite correctly setting `azureADOnlyAuthentication: true`. The root cause: the agent never loaded the `sql-database/auth.md` or `sql-database/bicep.md` reference files that explicitly prohibit this property. PR #1550 addressed the primary discovery issue by adding more cross-reference links, but the prohibition language still lives only in those leaf reference files.

## How this helps

This PR adds **defense-in-depth** by surfacing the SQL Entra-only auth requirement at three workflow stages, so the agent encounters the prohibition even if it shortcuts the reference chain:

1. **`research.md`** — New "Container Apps + API + SQL Database" research pattern (mirrors the existing App Service + SQL pattern) that explicitly loads `auth.md` and `bicep.md`
2. **`security.md`** — New checklist item in the Identity & Access section: *"SQL Server: Entra-only auth — do NOT generate `administratorLogin` or `administratorLoginPassword`"*
3. **`generate.md`** — New security requirement: *"SQL Server Bicep must use Entra-only auth — omit `administratorLogin` and `administratorLoginPassword` entirely"*