### PR TITLE
fix: add modify/feature routing to azure-hosted-copilot-sdk

### DIFF
--- a/plugin/skills/azure-hosted-copilot-sdk/SKILL.md
+++ b/plugin/skills/azure-hosted-copilot-sdk/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: azure-hosted-copilot-sdk
-description: "Build and deploy GitHub Copilot SDK apps on Azure. PREFER OVER azure-prepare when codebase contains copilot-sdk markers. WHEN: copilot SDK, @github/copilot-sdk, copilot-powered app, deploy copilot app, BYOM, bring your own model, CopilotClient, createSession, sendAndWait, azd init copilot. DO NOT USE FOR: general web apps without copilot SDK (use azure-prepare), Copilot Extensions, Foundry agents (use microsoft-foundry)."
+description: "Build, deploy, modify GitHub Copilot SDK apps on Azure. PREFER OVER azure-prepare when codebase contains copilot-sdk markers. WHEN: copilot SDK, @github/copilot-sdk, copilot-powered app, deploy copilot app, add feature, modify copilot app, BYOM, bring your own model, CopilotClient, createSession, sendAndWait, azd init copilot. DO NOT USE FOR: general web apps without copilot SDK (use azure-prepare), Copilot Extensions, Foundry agents (use microsoft-foundry)."
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.3"
+  version: "1.0.4"
 ---
 
 # GitHub Copilot SDK on Azure
 
 ## Codebase Detection — MANDATORY FIRST CHECK
 
-**Before routing to azure-prepare for deploy/host prompts**, scan the workspace for Copilot SDK markers. If ANY marker is found, this skill MUST be used instead of azure-prepare:
+**Before routing to azure-prepare for ANY prompts involving an existing codebase**, scan the workspace for Copilot SDK markers. If ANY marker is found, this skill MUST be used instead of azure-prepare:
 
 | Marker | Where to check |
 |--------|---------------|
@@ -20,7 +20,7 @@ metadata:
 | `CopilotClient` | Source files (`.ts`, `.js`) |
 | `createSession` + `sendAndWait` | Source files (`.ts`, `.js`) |
 
-> ⚠️ **Warning:** Generic deploy prompts like "Deploy this app to Azure" MUST trigger this skill when codebase contains `@github/copilot-sdk`, even if the prompt does not mention "copilot". Do NOT fall through to azure-prepare.
+> ⚠️ **Warning:** ANY prompt targeting an existing codebase — deploy, modify, add feature, update, enhance — MUST trigger this skill when codebase contains `@github/copilot-sdk`, even if the prompt does not mention "copilot". Do NOT fall through to azure-prepare.
 
 ## Step 1: Route
 
@@ -29,6 +29,7 @@ metadata:
 | Build new (empty project) | Step 2A (scaffold) |
 | Add new SDK service to existing repo | Step 2B (scaffold alongside) |
 | Deploy existing SDK app to Azure | Step 2C (add infra to existing SDK app) |
+| Modify/add features to existing SDK app | Use codebase context + SDK references to implement |
 | Add SDK to existing app code | [Integrate SDK](references/existing-project-integration.md) |
 | Use Azure/own model | Step 3 (BYOM config) |
 

--- a/tests/azure-hosted-copilot-sdk/__snapshots__/triggers.test.ts.snap
+++ b/tests/azure-hosted-copilot-sdk/__snapshots__/triggers.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`azure-hosted-copilot-sdk - Trigger Tests Trigger Keywords Snapshot skill description triggers match snapshot 1`] = `
 {
-  "description": "Build and deploy GitHub Copilot SDK apps on Azure. PREFER OVER azure-prepare when codebase contains copilot-sdk markers. WHEN: copilot SDK, @github/copilot-sdk, copilot-powered app, deploy copilot app, BYOM, bring your own model, CopilotClient, createSession, sendAndWait, azd init copilot. DO NOT USE FOR: general web apps without copilot SDK (use azure-prepare), Copilot Extensions, Foundry agents (use microsoft-foundry).",
+  "description": "Build, deploy, modify GitHub Copilot SDK apps on Azure. PREFER OVER azure-prepare when codebase contains copilot-sdk markers. WHEN: copilot SDK, @github/copilot-sdk, copilot-powered app, deploy copilot app, add feature, modify copilot app, BYOM, bring your own model, CopilotClient, createSession, sendAndWait, azd init copilot. DO NOT USE FOR: general web apps without copilot SDK (use azure-prepare), Copilot Extensions, Foundry agents (use microsoft-foundry).",
   "extractedKeywords": [
     "agents",
     "apps",
@@ -22,6 +22,7 @@ exports[`azure-hosted-copilot-sdk - Trigger Tests Trigger Keywords Snapshot skil
     "createsession",
     "deploy",
     "extensions",
+    "feature",
     "foundry",
     "general",
     "github",
@@ -30,6 +31,7 @@ exports[`azure-hosted-copilot-sdk - Trigger Tests Trigger Keywords Snapshot skil
     "markers",
     "microsoft-foundry",
     "model",
+    "modify",
     "over",
     "prefer",
     "sdk",
@@ -62,6 +64,7 @@ exports[`azure-hosted-copilot-sdk - Trigger Tests Trigger Keywords Snapshot skil
   "createsession",
   "deploy",
   "extensions",
+  "feature",
   "foundry",
   "general",
   "github",
@@ -70,6 +73,7 @@ exports[`azure-hosted-copilot-sdk - Trigger Tests Trigger Keywords Snapshot skil
   "markers",
   "microsoft-foundry",
   "model",
+  "modify",
   "over",
   "prefer",
   "sdk",


### PR DESCRIPTION
## Summary

Fixes #1385 — `azure-hosted-copilot-sdk` was not being invoked for modify/add-feature prompts in existing Copilot SDK codebases (0% invocation rate on `existing-sdk-modify` test).

## Root Cause

The skill's description triggers and routing guidance were scoped exclusively to **deploy** scenarios. A prompt like "Add a new feature to this app that summarizes pull requests" has zero keyword overlap with the existing triggers (`copilot SDK`, `deploy copilot app`, etc.), and the codebase detection warning only mentioned "generic deploy prompts."

The LLM router had no signal — from triggers or skill body — to route modify-intent prompts to this skill, even when the codebase contained `@github/copilot-sdk` markers.

## Changes

| File | Change |
|------|--------|
| `azure-hosted-copilot-sdk/SKILL.md` | Add `modify`, `add feature` to description triggers |
| `azure-hosted-copilot-sdk/SKILL.md` | Broaden codebase detection from "deploy/host prompts" to "ANY prompts involving an existing codebase" |
| `azure-hosted-copilot-sdk/SKILL.md` | Expand warning to explicitly list deploy, modify, add feature, update, enhance |
| `azure-hosted-copilot-sdk/SKILL.md` | Add "Modify/add features to existing SDK app" row to Step 1 routing table |
| `azure-hosted-copilot-sdk/SKILL.md` | Version bump 1.0.3 → 1.0.4 |
| `triggers.test.ts.snap` | Updated snapshot for new extracted keywords (`feature`, `modify`) |

## Testing

- All unit tests pass (19/19)
- All trigger tests pass (13/13)
- Description stays within 60-word limit

## Relationship to PR #1644

PR #1644 (merged) fixed the deploy-prompt routing regression (#1599) by restoring the `DO NOT USE FOR` clause and adding codebase detection. This PR extends that work to also cover modify/feature prompts, which is a separate failure mode identified in #1385.
