### PR TITLE
Use a test-specific followUp prompt for "does not deploy aspire custom resources"

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -851,7 +851,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "Use standard SKUs. " +
             `The app can be found under ${CUSTOM_RESOURCES_SPARSE_PATH}.`,
           nonInteractive: true,
-          followUp: FOLLOW_UP_PROMPT,
+          followUp: ["Stop if there is no further work; otherwise go with recommended options."],
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
         });
 


### PR DESCRIPTION
The default `FOLLOW_UP_PROMPT` ("Go with recommended options and proceed with Azure deployment.") improperly encourages the agent to continue with a deployment even when there is nothing to deploy. In the `does not deploy aspire custom resources` test, the Aspire app contains only non-deployable custom resources (`TalkingClock`, `TestResource` with `.ExcludeFromManifest()`). The agent correctly identifies this and creates a plan saying the app is not deployable, but then the follow-up prompt pushes it to add a new Web API project and deploy anyway—causing the `containsDeployLinks` assertion to fail.

This PR replaces the follow-up prompt for this specific test with one that allows the agent to stop when it determines there is no further work.

Fixes #1591