### PR TITLE
fix: remove apiKey tokens from SKILL.md to prevent LLM priming (#1696)

### DIFF
--- a/evals/azure-hosted-copilot-sdk/tasks/byom-config.yaml
+++ b/evals/azure-hosted-copilot-sdk/tasks/byom-config.yaml
@@ -22,5 +22,8 @@ expected:
   output_not_contains:
     - "error"
     - "failed"
+    - "apiKey"
+    - "AZURE_OPENAI_API_KEY"
+    - "AZURE_OPENAI_KEY"
   behavior:
     max_tool_calls: 10

--- a/plugin/skills/azure-hosted-copilot-sdk/SKILL.md
+++ b/plugin/skills/azure-hosted-copilot-sdk/SKILL.md
@@ -4,7 +4,7 @@ description: "Build, deploy, modify GitHub Copilot SDK apps on Azure. PREFER OVE
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.4"
+  version: "1.0.5"
 ---
 
 # GitHub Copilot SDK on Azure
@@ -57,7 +57,7 @@ Three model paths (layers on top of 2A/2B):
 | **GitHub specific** | `model: "<name>"` — use `listModels()` to discover |
 | **Azure BYOM** | `model` + `provider` with `bearerToken` via `DefaultAzureCredential` |
 
-> ⚠️ **BYOM Auth — MANDATORY**: Azure BYOM configurations MUST use `DefaultAzureCredential` (local dev) or `ManagedIdentityCredential` (production) to obtain a `bearerToken`. **NEVER** use static API keys (`apiKey`), `AZURE_OPENAI_API_KEY`, or `AZURE_OPENAI_KEY` environment variables in BYOM provider configuration. See [auth-best-practices.md](references/auth-best-practices.md) for the credential pattern and [model config ref](references/azure-model-config.md) for the full BYOM code example.
+> ⚠️ **BYOM Auth — MANDATORY**: Azure BYOM configurations MUST use `DefaultAzureCredential` (local dev) or `ManagedIdentityCredential` (production) to obtain a `bearerToken`. The ONLY supported auth pattern is `bearerToken` in the provider config. See [auth-best-practices.md](references/auth-best-practices.md) for the credential pattern and [model config ref](references/azure-model-config.md) for the full BYOM code example.
 
 See [model config ref](references/azure-model-config.md).
 
@@ -69,4 +69,4 @@ Invoke **azure-prepare** (skip its Step 0 routing — scaffolding is done) → *
 
 - Read `AGENTS.md` in user's repo before changes
 - Docker required (`docker info`)
-- BYOM auth: always `bearerToken` via `DefaultAzureCredential` or `ManagedIdentityCredential` — never `apiKey` or `AZURE_OPENAI_API_KEY`/`AZURE_OPENAI_KEY`
+- BYOM auth: ONLY `bearerToken` via `DefaultAzureCredential` or `ManagedIdentityCredential` — no other auth pattern is supported


### PR DESCRIPTION
Fixes #1696

## Summary

PR #1685 (merged yesterday) tried to fix the BYOM apiKey leak by adding "NEVER use apiKey" warnings to SKILL.md. **This backfired** — mentioning `apiKey`, `AZURE_OPENAI_API_KEY`, and `AZURE_OPENAI_KEY` in the skill context primed the LLM to emit those exact tokens during generation.

### Root Cause

LLMs use token frequency for generation. Negative examples ("NEVER use apiKey") still inject `apiKey` into the model's context window, reinforcing the pattern. The reference files (`azure-model-config.md`, etc.) were already clean — the SKILL.md warnings were the source of contamination.

### Why PR #1685 Wasn't Caught

| Gap | Detail |
|-----|--------|
| **No integration tests** | PR ran unit tests (42/42) but integration tests require real agent runs and weren't triggered |
| **Waza eval is mock-only** | `executor: mock` doesn't invoke the real agent |
| **Waza eval didn't check apiKey** | `byom-config.yaml` had `output_not_contains: [error, failed]` but no apiKey check |

### Fix

| File | Change |
|------|--------|
| `SKILL.md` | Removed ALL `apiKey`/`AZURE_OPENAI_API_KEY`/`AZURE_OPENAI_KEY` mentions. Replaced with positive-only guidance: "ONLY bearerToken via DefaultAzureCredential". Version 1.0.4 to 1.0.5 |
| `byom-config.yaml` | Added `apiKey`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_KEY` to `output_not_contains` |

### Verification

- `grep -ri` for apiKey patterns in `plugin/skills/azure-hosted-copilot-sdk/` returns **zero matches**
- 42/42 unit + trigger tests pass
- No lint/type errors

### Testing

The real validation requires an integration test run against this branch. The BYOM content-quality test (`countApiKeyInByomConfig === 0`) is the definitive check.
