### PR TITLE
Add PowerShell equivalents for complex bash scripts in azure-deploy skill

### DIFF
--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute Azure deployments for ALREADY-PREPARED applications that h
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.13"
+  version: "1.0.14"
 ---
 
 # Azure Deploy

--- a/plugin/skills/azure-deploy/references/recipes/azcli/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/azcli/verify.md
@@ -49,6 +49,21 @@ HOSTNAME=$(az staticwebapp show --name <app-name> --resource-group <rg-name> --q
 echo "https://$HOSTNAME"
 ```
 
+**PowerShell:**
+```powershell
+# Container Apps
+$Fqdn = az containerapp show --name <app-name> --resource-group <rg-name> --query "properties.configuration.ingress.fqdn" -o tsv
+Write-Output "https://$Fqdn"
+
+# App Service
+$Hostname = az webapp show --name <app-name> --resource-group <rg-name> --query "defaultHostName" -o tsv
+Write-Output "https://$Hostname"
+
+# Static Web Apps
+$Hostname = az staticwebapp show --name <app-name> --resource-group <rg-name> --query "defaultHostname" -o tsv
+Write-Output "https://$Hostname"
+```
+
 > ⚠️ **These commands return bare hostnames without a scheme.** Always prepend `https://` when presenting URLs to the user. For example, report `https://myapp.azurewebsites.net`, never `myapp.azurewebsites.net`.
 
 Present a summary including all service URLs as fully-qualified `https://` links. Do NOT end your response without including them.

--- a/plugin/skills/azure-deploy/references/recipes/azd/ef-migrations.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/ef-migrations.md
@@ -11,6 +11,12 @@ find . -type d -name "Migrations" 2>/dev/null
 find . -name "*.csproj" -exec grep -l "Microsoft.EntityFrameworkCore" {} \;
 ```
 
+**PowerShell:**
+```powershell
+Get-ChildItem -Recurse -Directory -Filter "Migrations" -ErrorAction SilentlyContinue
+Get-ChildItem -Recurse -Filter "*.csproj" | Select-String -List "Microsoft.EntityFrameworkCore" | Select-Object -ExpandProperty Path
+```
+
 ## Deployment Methods
 
 ### Method 1: azd Hook (Recommended)
@@ -35,7 +41,20 @@ cd src/api  # Adjust path
 dotnet ef database update --connection "$CONNECTION_STRING"
 ```
 
-> 💡 Make executable: `chmod +x scripts/*.sh`. For PowerShell: Use `azd env get-values | ForEach-Object` pattern.
+**scripts/apply-migrations.ps1:**
+
+```powershell
+$ErrorActionPreference = 'Stop'
+azd env get-values | ForEach-Object {
+    $name, $value = $_.Split('=', 2)
+    Set-Item "env:$name" $value
+}
+$ConnectionString = "Server=tcp:${env:SQL_SERVER}.database.windows.net,1433;Database=${env:SQL_DATABASE};Authentication=Active Directory Default;Encrypt=True;"
+Set-Location src/api  # Adjust path
+dotnet ef database update --connection $ConnectionString
+```
+
+> 💡 Make executable: `chmod +x scripts/*.sh`.
 
 ### Method 2: SQL Script (Production)
 
@@ -45,6 +64,14 @@ Generate idempotent script for review before applying:
 dotnet ef migrations script --idempotent --output migrations.sql
 az sql db query --server "$SQL_SERVER" --database "$SQL_DATABASE" \
   --auth-mode ActiveDirectoryDefault --queries "$(cat migrations.sql)"
+```
+
+**PowerShell:**
+```powershell
+dotnet ef migrations script --idempotent --output migrations.sql
+$MigrationsSql = Get-Content migrations.sql -Raw
+az sql db query --server $env:SQL_SERVER --database $env:SQL_DATABASE `
+  --auth-mode ActiveDirectoryDefault --queries $MigrationsSql
 ```
 
 ### Method 3: Application Startup (Dev Only)
@@ -103,6 +130,53 @@ az sql db query --server "$SQL_SERVER" --database "$SQL_DATABASE" \
 cd src/api
 CONNECTION_STRING="Server=tcp:${SQL_SERVER}.database.windows.net,1433;Database=${SQL_DATABASE};Authentication=Active Directory Default;Encrypt=True;"
 dotnet ef database update --connection "$CONNECTION_STRING"
+```
+
+**PowerShell equivalent:**
+```powershell
+$ErrorActionPreference = 'Stop'
+azd env get-values | ForEach-Object {
+    $name, $value = $_.Split('=', 2)
+    Set-Item "env:$name" $value
+}
+
+# Grant SQL access
+$SqlQuery = @"
+IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = '$($env:SERVICE_API_NAME)')
+  CREATE USER [$($env:SERVICE_API_NAME)] FROM EXTERNAL PROVIDER;
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.database_role_members drm
+  JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id
+  JOIN sys.database_principals m ON drm.member_principal_id = m.principal_id
+  WHERE r.name = 'db_datareader' AND m.name = '$($env:SERVICE_API_NAME)'
+)
+  ALTER ROLE db_datareader ADD MEMBER [$($env:SERVICE_API_NAME)];
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.database_role_members drm
+  JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id
+  JOIN sys.database_principals m ON drm.member_principal_id = m.principal_id
+  WHERE r.name = 'db_datawriter' AND m.name = '$($env:SERVICE_API_NAME)'
+)
+  ALTER ROLE db_datawriter ADD MEMBER [$($env:SERVICE_API_NAME)];
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.database_role_members drm
+  JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id
+  JOIN sys.database_principals m ON drm.member_principal_id = m.principal_id
+  WHERE r.name = 'db_ddladmin' AND m.name = '$($env:SERVICE_API_NAME)'
+)
+  ALTER ROLE db_ddladmin ADD MEMBER [$($env:SERVICE_API_NAME)];
+"@
+
+az sql db query --server $env:SQL_SERVER --database $env:SQL_DATABASE `
+  --auth-mode ActiveDirectoryDefault --queries $SqlQuery
+
+# Apply migrations
+Set-Location src/api
+$ConnectionString = "Server=tcp:$($env:SQL_SERVER).database.windows.net,1433;Database=$($env:SQL_DATABASE);Authentication=Active Directory Default;Encrypt=True;"
+dotnet ef database update --connection $ConnectionString
 ```
 
 ## Prerequisites

--- a/plugin/skills/azure-deploy/references/recipes/azd/errors.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/errors.md
@@ -48,6 +48,13 @@ az role assignment list --scope $(az acr show --name <acr-name> --resource-group
   --assignee-object-id "$PRINCIPAL_ID" --query "[].roleDefinitionName" -o tsv
 ```
 
+**PowerShell:**
+```powershell
+$PrincipalId = az containerapp identity show --name <app-name> --resource-group <resource-group> --query principalId -o tsv
+$AcrScope = az acr show --name <acr-name> --resource-group <resource-group> --query id -o tsv
+az role assignment list --scope $AcrScope --assignee-object-id $PrincipalId --query "[].roleDefinitionName" -o tsv
+```
+
 3. **If AcrPull is missing, assign it:**
 ```bash
 az role assignment create \
@@ -55,6 +62,16 @@ az role assignment create \
   --assignee-principal-type ServicePrincipal \
   --role AcrPull \
   --scope $(az acr show --name <acr-name> --resource-group <resource-group> --query id -o tsv)
+```
+
+**PowerShell:**
+```powershell
+$AcrScope = az acr show --name <acr-name> --resource-group <resource-group> --query id -o tsv
+az role assignment create `
+  --assignee-object-id $PrincipalId `
+  --assignee-principal-type ServicePrincipal `
+  --role AcrPull `
+  --scope $AcrScope
 ```
 
 4. **Wait for propagation, then redeploy:**
@@ -75,6 +92,27 @@ for attempt in 1 2 3 4 5; do
     exit 1
   fi
 done
+```
+
+**PowerShell:**
+```powershell
+azd env set AZURE_CONTAINER_REGISTRY_ENDPOINT (az acr show --name <acr-name> --resource-group <resource-group> --query loginServer -o tsv)
+
+for ($attempt = 1; $attempt -le 5; $attempt++) {
+    Write-Output "Waiting for RBAC propagation (attempt $attempt/5)..."
+    Start-Sleep -Seconds 60
+
+    azd deploy --no-prompt
+    if ($LASTEXITCODE -eq 0) {
+        Write-Output "Deployment succeeded after RBAC propagation."
+        break
+    }
+
+    if ($attempt -eq 5) {
+        Write-Output "Deployment still failing after 5 minutes. Re-check AcrPull assignment and Container App revision status."
+        exit 1
+    }
+}
 ```
 
 > 💡 **Prevention:** To avoid this in future deployments, ensure the Bicep template includes the `AcrPull` role assignment with `principalType: 'ServicePrincipal'`, and consider using `azd provision` + `azd deploy` as separate steps instead of `azd up` to allow RBAC propagation time between infrastructure creation and app deployment.
@@ -114,6 +152,14 @@ docker push <acr-name>.azurecr.io/<image>:<tag>
 ACR_USER=$(az acr credential show --name <acr-name> --query username -o tsv)
 ACR_PASS=$(az acr credential show --name <acr-name> --query "passwords[0].value" -o tsv)
 docker login <acr-name>.azurecr.io -u "$ACR_USER" -p "$ACR_PASS"
+docker push <acr-name>.azurecr.io/<image>:<tag>
+```
+
+**PowerShell (Method 2):**
+```powershell
+$AcrUser = az acr credential show --name <acr-name> --query username -o tsv
+$AcrPass = az acr credential show --name <acr-name> --query "passwords[0].value" -o tsv
+docker login <acr-name>.azurecr.io -u $AcrUser -p $AcrPass
 docker push <acr-name>.azurecr.io/<image>:<tag>
 ```
 

--- a/plugin/skills/azure-deploy/references/recipes/azd/post-deployment.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/post-deployment.md
@@ -42,6 +42,19 @@ APP_NAME=$SERVICE_API_NAME  # or SERVICE_WEB_NAME
 # See sql-managed-identity.md for connection patterns
 ```
 
+**PowerShell:**
+```powershell
+# Get the app identity name from azd
+azd env get-values | ForEach-Object {
+    $name, $value = $_.Split('=', 2)
+    Set-Item "env:$name" $value
+}
+$AppName = $env:SERVICE_API_NAME  # or SERVICE_WEB_NAME
+
+# Connect as Entra admin and grant permissions
+# See sql-managed-identity.md for connection patterns
+```
+
 ### Step 2: Apply EF Core Migrations
 
 Apply Entity Framework migrations to create database schema.
@@ -67,6 +80,19 @@ curl -f "$ENDPOINT/health" || echo "Health check failed"
 
 # Test database connectivity
 curl -f "$ENDPOINT/api/test-db" || echo "Database connection failed"
+```
+
+**PowerShell:**
+```powershell
+# Get app endpoint
+$Endpoint = azd env get-values | Select-String -Pattern 'SERVICE_.*_URI' |
+    Select-Object -First 1 | ForEach-Object { ($_ -split '=', 2)[1] }
+
+# Health check
+try { Invoke-WebRequest "$Endpoint/health" } catch { Write-Output "Health check failed" }
+
+# Test database connectivity
+try { Invoke-WebRequest "$Endpoint/api/test-db" } catch { Write-Output "Database connection failed" }
 ```
 
 **Expected Result:**

--- a/plugin/skills/azure-deploy/references/recipes/azd/sql-managed-identity.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/sql-managed-identity.md
@@ -28,6 +28,29 @@ az sql db query \
   "
 ```
 
+**PowerShell:**
+```powershell
+azd env get-values | ForEach-Object {
+    $name, $value = $_.Split('=', 2)
+    Set-Item "env:$name" $value
+}
+$AppName = $env:SERVICE_API_NAME  # or SERVICE_WEB_NAME
+
+$SqlQuery = @"
+CREATE USER [$AppName] FROM EXTERNAL PROVIDER;
+ALTER ROLE db_datareader ADD MEMBER [$AppName];
+ALTER ROLE db_datawriter ADD MEMBER [$AppName];
+ALTER ROLE db_ddladmin ADD MEMBER [$AppName];
+"@
+
+az sql db query `
+  --server $env:SQL_SERVER `
+  --database $env:SQL_DATABASE `
+  --resource-group $env:AZURE_RESOURCE_GROUP `
+  --auth-mode ActiveDirectoryDefault `
+  --queries $SqlQuery
+```
+
 ## Database Roles
 
 | Role | Permissions | Use For |
@@ -93,7 +116,53 @@ az sql db query \
   "
 ```
 
-> 💡 Make executable: `chmod +x scripts/*.sh`. For PowerShell: Use `azd env get-values | ForEach-Object` pattern.
+**scripts/grant-sql-access.ps1:**
+
+```powershell
+$ErrorActionPreference = 'Stop'
+azd env get-values | ForEach-Object {
+    $name, $value = $_.Split('=', 2)
+    Set-Item "env:$name" $value
+}
+
+$SqlQuery = @"
+IF NOT EXISTS (SELECT * FROM sys.database_principals WHERE name = '$($env:SERVICE_API_NAME)')
+  CREATE USER [$($env:SERVICE_API_NAME)] FROM EXTERNAL PROVIDER;
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.database_role_members drm
+  JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id
+  JOIN sys.database_principals m ON drm.member_principal_id = m.principal_id
+  WHERE r.name = 'db_datareader' AND m.name = '$($env:SERVICE_API_NAME)'
+)
+  ALTER ROLE db_datareader ADD MEMBER [$($env:SERVICE_API_NAME)];
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.database_role_members drm
+  JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id
+  JOIN sys.database_principals m ON drm.member_principal_id = m.principal_id
+  WHERE r.name = 'db_datawriter' AND m.name = '$($env:SERVICE_API_NAME)'
+)
+  ALTER ROLE db_datawriter ADD MEMBER [$($env:SERVICE_API_NAME)];
+
+IF NOT EXISTS (
+  SELECT 1 FROM sys.database_role_members drm
+  JOIN sys.database_principals r ON drm.role_principal_id = r.principal_id
+  JOIN sys.database_principals m ON drm.member_principal_id = m.principal_id
+  WHERE r.name = 'db_ddladmin' AND m.name = '$($env:SERVICE_API_NAME)'
+)
+  ALTER ROLE db_ddladmin ADD MEMBER [$($env:SERVICE_API_NAME)];
+"@
+
+az sql db query `
+  --server $env:SQL_SERVER `
+  --database $env:SQL_DATABASE `
+  --resource-group $env:AZURE_RESOURCE_GROUP `
+  --auth-mode ActiveDirectoryDefault `
+  --queries $SqlQuery
+```
+
+> 💡 Make executable: `chmod +x scripts/*.sh`.
 
 ## Verification
 
@@ -109,6 +178,26 @@ az sql db query --server "$SQL_SERVER" --database "$SQL_DATABASE" \
     JOIN sys.database_principals dr ON drm.role_principal_id = dr.principal_id
     WHERE dp.name = '$APP_NAME'
   "
+```
+
+**PowerShell:**
+```powershell
+azd env get-values | ForEach-Object {
+    $name, $value = $_.Split('=', 2)
+    Set-Item "env:$name" $value
+}
+$AppName = $env:SERVICE_API_NAME  # or SERVICE_WEB_NAME
+
+$SqlQuery = @"
+SELECT dp.name AS UserName, dr.name AS RoleName
+FROM sys.database_principals dp
+JOIN sys.database_role_members drm ON dp.principal_id = drm.member_principal_id
+JOIN sys.database_principals dr ON drm.role_principal_id = dr.principal_id
+WHERE dp.name = '$AppName'
+"@
+
+az sql db query --server $env:SQL_SERVER --database $env:SQL_DATABASE `
+  --auth-mode ActiveDirectoryDefault --queries $SqlQuery
 ```
 
 Expected: UserName matches `$APP_NAME`, RoleName includes `db_datareader`, `db_datawriter`, `db_ddladmin`.

--- a/plugin/skills/azure-deploy/references/recipes/azd/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/verify.md
@@ -26,6 +26,16 @@ ENDPOINT=$(azd env get-values | grep -E "SERVICE_.*_URI|.*_ENDPOINT" | head -1 |
 curl -f "$ENDPOINT/health" || curl -f "$ENDPOINT"
 ```
 
+**PowerShell:**
+```powershell
+# Get endpoint
+$Endpoint = azd env get-values | Select-String -Pattern 'SERVICE_.*_URI|.*_ENDPOINT' |
+    Select-Object -First 1 | ForEach-Object { ($_ -split '=', 2)[1] }
+
+# Test endpoint
+try { Invoke-WebRequest "$Endpoint/health" } catch { Invoke-WebRequest $Endpoint }
+```
+
 Expected: HTTP 200 response.
 
 ## Step 3: Report Results to User
@@ -81,6 +91,23 @@ az sql db query \
   --queries "SELECT name, type_desc FROM sys.database_principals WHERE type = 'E'"
 ```
 
+**PowerShell:**
+```powershell
+# Load environment variables
+azd env get-values | ForEach-Object {
+    $name, $value = $_.Split('=', 2)
+    Set-Item "env:$name" $value
+}
+
+# Check managed identity user exists in database
+az sql db query `
+  --server $env:SQL_SERVER `
+  --database $env:SQL_DATABASE `
+  --resource-group $env:AZURE_RESOURCE_GROUP `
+  --auth-mode ActiveDirectoryDefault `
+  --queries "SELECT name, type_desc FROM sys.database_principals WHERE type = 'E'"
+```
+
 **Expected:** Should list the App Service or Container App managed identity.
 
 ### Verify Database Schema
@@ -94,6 +121,16 @@ az sql db query \
   --database "$SQL_DATABASE" \
   --resource-group "$AZURE_RESOURCE_GROUP" \
   --auth-mode ActiveDirectoryDefault \
+  --queries "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE'"
+```
+
+**PowerShell:**
+```powershell
+az sql db query `
+  --server $env:SQL_SERVER `
+  --database $env:SQL_DATABASE `
+  --resource-group $env:AZURE_RESOURCE_GROUP `
+  --auth-mode ActiveDirectoryDefault `
   --queries "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE='BASE TABLE'"
 ```
 

--- a/plugin/skills/azure-deploy/references/recipes/terraform/README.md
+++ b/plugin/skills/azure-deploy/references/recipes/terraform/README.md
@@ -76,6 +76,20 @@ az containerapp update \
   --image $ACR_NAME.azurecr.io/myapp:latest
 ```
 
+**PowerShell:**
+```powershell
+$AcrName = terraform output -raw acr_name
+$AppName = terraform output -raw container_app_name
+$RgName = terraform output -raw resource_group_name
+
+az acr build --registry $AcrName --image myapp:latest ./src/api
+
+az containerapp update `
+  --name $AppName `
+  --resource-group $RgName `
+  --image "$AcrName.azurecr.io/myapp:latest"
+```
+
 ## References
 
 - [Verification steps](./verify.md)

--- a/plugin/skills/azure-deploy/references/troubleshooting.md
+++ b/plugin/skills/azure-deploy/references/troubleshooting.md
@@ -162,6 +162,18 @@ azd env set AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID $(az identity list --re
 azd env set MANAGED_IDENTITY_CLIENT_ID $(az identity list --resource-group <resource-group-name> --query "[0].clientId" -o tsv)
 ```
 
+**PowerShell:**
+```powershell
+# Set the container registry endpoint
+azd env set AZURE_CONTAINER_REGISTRY_ENDPOINT (az acr list --resource-group <resource-group-name> --query "[0].loginServer" -o tsv)
+
+# Set the managed identity resource ID
+azd env set AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID (az identity list --resource-group <resource-group-name> --query "[0].id" -o tsv)
+
+# Set the managed identity client ID
+azd env set MANAGED_IDENTITY_CLIENT_ID (az identity list --resource-group <resource-group-name> --query "[0].clientId" -o tsv)
+```
+
 Then retry deployment:
 ```bash
 azd deploy --no-prompt


### PR DESCRIPTION
## Summary

Adds 20 PowerShell equivalent code blocks across 8 reference docs in the `azure-deploy` skill, covering all bash scripts that use shell-specific features (command substitution, `eval`, loops, conditionals, pipes, variable assignment). Bumps skill version 1.0.13 → 1.0.14.

## Files changed

| File | PS blocks added | Patterns covered |
|------|:-:|---|
| `recipes/azd/errors.md` | 4 | Retry loop, ACR role check, role assignment, admin creds |
| `recipes/azd/ef-migrations.md` | 4 | `find`, migration script, SQL script, combined hook |
| `recipes/azd/sql-managed-identity.md` | 3 | Quick grant, hook script, verification |
| `recipes/azd/verify.md` | 3 | Health check, SQL access, schema check |
| `recipes/azd/post-deployment.md` | 2 | eval setup, verify endpoint |
| `recipes/terraform/README.md` | 1 | terraform output → az containerapp update |
| `recipes/azcli/verify.md` | 1 | Endpoint URL extraction |
| `troubleshooting.md` | 1 | Container registry env vars |

Simple single-command bash blocks (e.g., `azd up`, `az group delete`) were left as-is since they are cross-platform compatible.