### PR TITLE
fix(operate): correct ACA operations content (fixes for #1637)

### DIFF
--- a/plugin/skills/azure-prepare/references/services/container-apps/day2-operations.md
+++ b/plugin/skills/azure-prepare/references/services/container-apps/day2-operations.md
@@ -7,8 +7,8 @@ Operational tasks for running Container Apps in production: restart, exec, logs,
 | Action | Command |
 |--------|---------|
 | Restart active revision | `az containerapp revision restart -n $APP -g $RG --revision $REV` |
-| Stop the app (all replicas) | `az containerapp stop -n $APP -g $RG` |
-| Start the app | `az containerapp start -n $APP -g $RG` |
+| Scale to zero (stop) | `az containerapp update -n $APP -g $RG --min-replicas 0 --max-replicas 0` |
+| Resume (restore scaling) | `az containerapp update -n $APP -g $RG --min-replicas 1 --max-replicas 10` |
 | List replicas | `az containerapp replica list -n $APP -g $RG --revision $REV` |
 
 > 💡 **Tip:** Restarting a revision replaces all running replicas gracefully. No new revision is created.
@@ -95,14 +95,16 @@ template: {
 ### Create and Update Secrets
 
 ```bash
-# Add a secret
+# Add a secret (use Key Vault references in production — avoid plaintext secrets)
 az containerapp secret set -n $APP -g $RG \
-  --secrets "db-password=S3cureP@ss"
+  --secrets "db-password=<secret-value>"
 
 # Reference a Key Vault secret (managed identity required)
 az containerapp secret set -n $APP -g $RG \
   --secrets "db-password=keyvaultref:https://myvault.vault.azure.net/secrets/db-pwd,identityref:/subscriptions/.../userAssignedIdentities/my-id"
 ```
+
+> ⚠️ **Warning:** Avoid passing plaintext secrets on the command line — they may appear in shell history and process listings. Prefer Key Vault references or `--file` based approaches.
 
 > 💡 **Tip:** Use Key Vault references instead of plain-text secrets. The Container App pulls the latest value on each new revision or replica start.
 

--- a/plugin/skills/azure-prepare/references/services/container-apps/networking.md
+++ b/plugin/skills/azure-prepare/references/services/container-apps/networking.md
@@ -7,7 +7,7 @@ VNet integration, ingress configuration, custom domains, and TLS for Container A
 | Mode | Visibility | Use Case |
 |------|-----------|----------|
 | External | Internet-accessible | Public APIs, web apps |
-| Internal | VNet-only | Microservices, back-end APIs |
+| Internal | Not internet-accessible; reachable within the environment and VNet (if VNet-injected) | Microservices, back-end APIs |
 | Disabled | No HTTP ingress | Background workers, queue processors |
 
 ### Bicep — External Ingress
@@ -34,7 +34,7 @@ configuration: {
 }
 ```
 
-> 💡 **Tip:** Internal apps get a `*.internal.<env-default-domain>` FQDN accessible only within the VNet.
+> 💡 **Tip:** Internal apps get a `*.internal.<env-default-domain>` FQDN. This is accessible from within the Container Apps environment and, when the environment is VNet-injected, also from the VNet.
 
 ## VNet Integration
 
@@ -42,11 +42,11 @@ Container Apps run inside an environment that can be injected into a VNet subnet
 
 ### Subnet Requirements
 
-| Requirement | Value |
-|------------|-------|
-| Minimum subnet size | `/23` (512 addresses) |
-| Delegation | `Microsoft.App/environments` |
-| Dedicated | Subnet must be exclusive to the Container Apps environment |
+| Requirement | Workload Profiles (default) | Consumption-only (legacy) |
+|------------|---------------------------|--------------------------|
+| Minimum subnet size | `/27` (32 addresses) | `/23` (512 addresses) |
+| Delegation | `Microsoft.App/environments` | None (do not delegate) |
+| Dedicated | Subnet must be exclusive to the Container Apps environment | Same |
 
 ### Bicep — VNet-Integrated Environment
 
@@ -55,7 +55,7 @@ resource subnet 'Microsoft.Network/virtualNetworks/subnets@2023-11-01' = {
   parent: vnet
   name: 'container-apps-subnet'
   properties: {
-    addressPrefix: '10.0.16.0/23'
+    addressPrefix: '10.0.16.0/27'
     delegations: [
       {
         name: 'Microsoft.App.environments'
@@ -116,6 +116,10 @@ Azure automatically provisions and renews TLS certificates for custom domains �
 
 ## IP Restrictions
 
+> ⚠️ **Warning:** All IP restriction rules must be the **same action type** — you cannot mix Allow and Deny rules.
+
+Allow rules implicitly deny all traffic not matching any rule. Deny rules implicitly allow all other traffic.
+
 ```bicep
 configuration: {
   ingress: {
@@ -129,10 +133,10 @@ configuration: {
         description: 'Office network'
       }
       {
-        name: 'deny-all'
-        action: 'Deny'
-        ipAddressRange: '0.0.0.0/0'
-        description: 'Deny all other traffic'
+        name: 'allow-vpn'
+        action: 'Allow'
+        ipAddressRange: '198.51.100.0/24'
+        description: 'VPN gateway'
       }
     ]
   }

--- a/plugin/skills/azure-prepare/references/services/container-apps/revisions.md
+++ b/plugin/skills/azure-prepare/references/services/container-apps/revisions.md
@@ -22,14 +22,15 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
         external: true
         targetPort: 8080
         traffic: [
-          { revisionName: '${appName}--v1', weight: 80 }
-          { revisionName: '${appName}--v2', weight: 20 }
+          { latestRevision: true, weight: 100 }
         ]
       }
     }
   }
 }
 ```
+
+> 💡 **Tip:** At deploy time only one revision exists. Use `latestRevision: true` in Bicep. Configure traffic splitting via CLI after deploying additional revisions.
 
 ## Traffic Splitting Patterns
 
@@ -38,15 +39,18 @@ resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
 Route 100% to the current revision, deploy a new one, validate, then switch:
 
 ```bash
-# Deploy new revision (gets 0% traffic by default in Multiple mode)
+# Deploy new revision (existing traffic rules remain; new revision gets 0% unless configured)
 az containerapp update -n $APP -g $RG --image $NEW_IMAGE
 
-# Test the new revision directly via its URL
+# Get the new revision name
+NEW_REV=$(az containerapp revision list -n $APP -g $RG --query "[0].name" -o tsv)
+
+# Test the new revision directly via its revision-specific URL
 az containerapp revision list -n $APP -g $RG -o table
 
-# Switch 100% traffic to new revision
+# Switch 100% traffic to the new revision
 az containerapp ingress traffic set -n $APP -g $RG \
-  --revision-weight "$APP--new-rev=100"
+  --revision-weight "$NEW_REV=100"
 ```
 
 ### Canary Release
@@ -84,15 +88,19 @@ az containerapp ingress traffic set -n $APP -g $RG \
 
 ## Rollback
 
-Revert instantly by redirecting all traffic to the previous revision:
+Revert instantly by redirecting all traffic to a known-good revision (e.g., one labeled `stable`):
 
 ```bash
-# List active revisions
+# List active revisions and identify the known-good one
 az containerapp revision list -n $APP -g $RG -o table
 
-# Roll back to previous revision
+# Roll back using label-based routing (preferred)
 az containerapp ingress traffic set -n $APP -g $RG \
-  --revision-weight "$APP--previous-rev=100"
+  --label-weight stable=100
+
+# Or roll back to a specific revision by name
+az containerapp ingress traffic set -n $APP -g $RG \
+  --revision-weight "<known-good-revision-name>=100"
 ```
 
 ## Revision Lifecycle


### PR DESCRIPTION
## Summary

Fixes technical errors in the ACA Operate reference files from #1637, validated against official Microsoft ACA documentation.

### Changes

**day2-operations.md:**
- Replace non-existent \z containerapp stop/start\ CLI commands with \z containerapp update --min-replicas 0\
- Remove plaintext password placeholder, add secret exposure warning

**networking.md:**
- Subnet size: \/27\ for workload profiles (default), \/23\ for legacy consumption-only
- IP restrictions: remove invalid Allow+Deny mix (official docs: cannot combine rule types)
- Internal ingress: corrected visibility description

**revisions.md:**
- Bicep: use \latestRevision: true\ instead of non-existent revision names at deploy time
- Blue/green: query actual revision name from \evision list\
- Rollback: use label-based routing or explicit revision name

### Validation
- All fixes verified against official docs at \MicrosoftDocs/azure-docs/articles/container-apps/\
- \zure-prepare\ tests: 46/46 passed
- Token budget: all files under 2000 limit

Builds on #1637.
