### PR TITLE
Scaling back Dependabot for minor+ updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      minor:
+        update-types:
+          - "minor"
     ignore:
       - dependency-name: "*"
-        update-types: 
+        update-types:
           - "version-update:semver-patch"
     open-pull-requests-limit: 10
 
@@ -21,9 +25,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      minor:
+        update-types:
+          - "minor"
     ignore:
       - dependency-name: "*"
-        update-types: 
+        update-types:
           - "version-update:semver-patch"
     open-pull-requests-limit: 5
 
@@ -33,9 +41,13 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    groups:
+      minor:
+        update-types:
+          - "minor"
     ignore:
       - dependency-name: "*"
-        update-types: 
+        update-types:
           - "version-update:semver-patch"
     open-pull-requests-limit: 5
 
@@ -47,6 +59,6 @@ updates:
       day: "monday"
     ignore:
       - dependency-name: "*"
-        update-types: 
+        update-types:
           - "version-update:semver-patch"
     open-pull-requests-limit: 10


### PR DESCRIPTION


## Description

Scaling back Dependabot for minor+ updates only to reduce noice

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
