### PR TITLE
Improve testing prompt for a terraform deployment case

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -479,7 +479,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           setup: async (workspace: string) => {
             workspacePath = workspace;
           },
-          prompt: "Create a discussion board application and deploy to Azure App Service using Terraform infrastructure in my current subscription in eastus2 region.",
+          prompt: "Create a discussion board application and deploy to Azure App Service, prefer Terraform over Bicep, in my current subscription in eastus2 region.",
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,


### PR DESCRIPTION
## Description

The agent chose to use az cli command over azd command for deployment, because the agent over-interpreted the user prompt — "deploy to Azure App Service using Terraform infrastructure" — as a request for pure Terraform, when the skill's own recipe-selection logic says azd+Terraform should be the default.

Update test prompt to see if it improves the deployment flow.

## Related Issues

Fixes #1716
