### PR TITLE
Adjust cleanup script to delete app services after 12 hours

### DIFF
--- a/eng/scripts/test-sub-cleanup.ps1
+++ b/eng/scripts/test-sub-cleanup.ps1
@@ -324,8 +324,8 @@ function FindOrCreateDeleteAfterTag {
         (Get-AzResource -ResourceGroupName $ResourceGroup.ResourceGroupName `
                 -ResourceType 'Microsoft.Web/serverfarms' -ErrorAction SilentlyContinue)
         if ($hasAppServiceResources) {
-            Write-Host " Resource group '$($ResourceGroup.ResourceGroupName)' contains App Service or App Service Plan resources, setting DeleteAfter to 1 day."
-            $deleteAfter = [datetime]::UtcNow.AddDays(1)
+            Write-Host " Resource group '$($ResourceGroup.ResourceGroupName)' contains App Service or App Service Plan resources, setting DeleteAfter to 12 hours later."
+            $deleteAfter = [datetime]::UtcNow.AddHours(12)
         }
         else {
             $deleteAfter = [datetime]::UtcNow.AddDays(5)


### PR DESCRIPTION
## Description

Adjust cleanup script to delete app services after 12 hours

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
