### PR TITLE
Pin copilot to 1.0.20

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -5,20 +5,20 @@
       "version": "v8",
       "sha": "ed597411d8f924073f98dfc5c65a23a2325f34cd"
     },
-    "github/gh-aw-actions/setup@v0.64.1": {
-      "repo": "github/gh-aw-actions/setup",
-      "version": "v0.64.1",
-      "sha": "f2ebb97e47f0704f098aeb6f8f32546ddc8fee85"
+    "actions/github-script@v9.0.0": {
+      "repo": "actions/github-script",
+      "version": "v9.0.0",
+      "sha": "d746ffe35508b1917358783b479e04febd2b8f71"
     },
-    "github/gh-aw-actions/setup@v0.65.6": {
+    "github/gh-aw-actions/setup@v0.68.1": {
       "repo": "github/gh-aw-actions/setup",
-      "version": "v0.65.6",
-      "sha": "31130b20a8fd3ef263acbe2091267c0aace07e09"
+      "version": "v0.68.1",
+      "sha": "2fe53acc038ba01c3bbdc767d4b25df31ca5bdfc"
     },
-    "github/gh-aw/actions/setup@v0.64.1": {
+    "github/gh-aw/actions/setup@v0.68.1": {
       "repo": "github/gh-aw/actions/setup",
-      "version": "v0.64.1",
-      "sha": "06c8e7ea94502ecbd1646c53db09c7478f7b0a08"
+      "version": "v0.68.1",
+      "sha": "5a06d310cf45161bde77d070065a1e1489fc411c"
     }
   }
 }

--- a/.github/workflows/analyze-test-run.lock.yml
+++ b/.github/workflows/analyze-test-run.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"f579890f6da9452a0d90e7d671e86bc9417ad9af980d7c9ca1c97062ed626684","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"ed502a329a25cfd0d884923dbfe36de3dddd318a65bb91a5da00740b4f549c2e","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -98,8 +98,8 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
           GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'auto' }}
-          GH_AW_INFO_VERSION: "latest"
-          GH_AW_INFO_AGENT_VERSION: "latest"
+          GH_AW_INFO_VERSION: "v1.0.20"
+          GH_AW_INFO_AGENT_VERSION: "v1.0.20"
           GH_AW_INFO_CLI_VERSION: "v0.67.1"
           GH_AW_INFO_WORKFLOW_NAME: "Analyze Test Run"
           GH_AW_INFO_EXPERIMENTAL: "false"
@@ -170,14 +170,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_971dd02bd6faf87b_EOF'
+          cat << 'GH_AW_PROMPT_3daf30ba407f1d32_EOF'
           <system>
-          GH_AW_PROMPT_971dd02bd6faf87b_EOF
+          GH_AW_PROMPT_3daf30ba407f1d32_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_971dd02bd6faf87b_EOF'
+          cat << 'GH_AW_PROMPT_3daf30ba407f1d32_EOF'
           <safe-output-tools>
           Tools: create_issue(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
@@ -209,12 +209,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_971dd02bd6faf87b_EOF
+          GH_AW_PROMPT_3daf30ba407f1d32_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_971dd02bd6faf87b_EOF'
+          cat << 'GH_AW_PROMPT_3daf30ba407f1d32_EOF'
           </system>
           {{#runtime-import .github/workflows/analyze-test-run.md}}
-          GH_AW_PROMPT_971dd02bd6faf87b_EOF
+          GH_AW_PROMPT_3daf30ba407f1d32_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -363,7 +363,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Install GitHub Copilot CLI
-        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh latest
+        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh v1.0.20
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -385,12 +385,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_065ac5a95f3b20a0_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_e75bf524807ab288_EOF'
           {"create_issue":{"labels":["bug","integration-test"],"max":10},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_065ac5a95f3b20a0_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_e75bf524807ab288_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_578177345fe641f6_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_606ccfd01479862a_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 10 issue(s) can be created. Labels [\"bug\" \"integration-test\"] will be automatically added."
@@ -398,8 +398,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_578177345fe641f6_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_f726ae8433f9de28_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_606ccfd01479862a_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_ffc3f538fa99b2fc_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -508,7 +508,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_f726ae8433f9de28_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_ffc3f538fa99b2fc_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -578,7 +578,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_afcca1d440f2d8d0_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_e07eb26c099f2a0d_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -619,7 +619,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_afcca1d440f2d8d0_EOF
+          GH_AW_MCP_CONFIG_e07eb26c099f2a0d_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1021,7 +1021,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Install GitHub Copilot CLI
-        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh latest
+        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh v1.0.20
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -1119,6 +1119,7 @@ jobs:
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
+      GH_AW_ENGINE_VERSION: "v1.0.20"
       GH_AW_WORKFLOW_ID: "analyze-test-run"
       GH_AW_WORKFLOW_NAME: "Analyze Test Run"
     outputs:

--- a/.github/workflows/analyze-test-run.md
+++ b/.github/workflows/analyze-test-run.md
@@ -40,7 +40,9 @@ safe-outputs:
     max: 10
     labels: [bug, integration-test]
 
-engine: copilot
+engine:
+  id: copilot
+  version: v1.0.20
 timeout-minutes: 30
 ---
 

--- a/.github/workflows/issue-triage.lock.yml
+++ b/.github/workflows/issue-triage.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"6061e3e65ab0c2aa69936edcb38c148870da5a3ed8a76e0168eab7298d2bcc6d","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"2b32867ca6749d231e70e03e3dfb7ad31780296ac9f68e669ac741be884d17e7","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -82,8 +82,8 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
           GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'auto' }}
-          GH_AW_INFO_VERSION: "latest"
-          GH_AW_INFO_AGENT_VERSION: "latest"
+          GH_AW_INFO_VERSION: "v1.0.20"
+          GH_AW_INFO_AGENT_VERSION: "v1.0.20"
           GH_AW_INFO_CLI_VERSION: "v0.67.1"
           GH_AW_INFO_WORKFLOW_NAME: "Issue Triage"
           GH_AW_INFO_EXPERIMENTAL: "false"
@@ -163,14 +163,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_272a184d6426fec8_EOF'
+          cat << 'GH_AW_PROMPT_bc9ec2d0b54d6a1f_EOF'
           <system>
-          GH_AW_PROMPT_272a184d6426fec8_EOF
+          GH_AW_PROMPT_bc9ec2d0b54d6a1f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_272a184d6426fec8_EOF'
+          cat << 'GH_AW_PROMPT_bc9ec2d0b54d6a1f_EOF'
           <safe-output-tools>
           Tools: add_comment, update_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -202,12 +202,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_272a184d6426fec8_EOF
+          GH_AW_PROMPT_bc9ec2d0b54d6a1f_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_272a184d6426fec8_EOF'
+          cat << 'GH_AW_PROMPT_bc9ec2d0b54d6a1f_EOF'
           </system>
           {{#runtime-import .github/workflows/issue-triage.md}}
-          GH_AW_PROMPT_272a184d6426fec8_EOF
+          GH_AW_PROMPT_bc9ec2d0b54d6a1f_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -352,7 +352,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Install GitHub Copilot CLI
-        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh latest
+        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh v1.0.20
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -374,12 +374,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_d1724c24147e94b1_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_a6278017b219c9b1_EOF'
           {"add_comment":{"max":1},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"update_issue":{"allow_body":true,"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_d1724c24147e94b1_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_a6278017b219c9b1_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_cda236c6e7ae5f38_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_df15304c8c7915e4_EOF'
           {
             "description_suffixes": {
               "add_comment": " CONSTRAINTS: Maximum 1 comment(s) can be added.",
@@ -388,8 +388,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_cda236c6e7ae5f38_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_8023d3c6d9b87683_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_df15304c8c7915e4_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_b2368a1fcf7b0722_EOF'
           {
             "add_comment": {
               "defaultMax": 1,
@@ -537,7 +537,7 @@ jobs:
               "customValidation": "requiresOneOf:status,title,body"
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_8023d3c6d9b87683_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_b2368a1fcf7b0722_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -607,7 +607,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_cce9d39e01bb8c56_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_4b9d3b406138f83c_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -648,7 +648,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_cce9d39e01bb8c56_EOF
+          GH_AW_MCP_CONFIG_4b9d3b406138f83c_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1052,7 +1052,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Install GitHub Copilot CLI
-        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh latest
+        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh v1.0.20
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -1125,6 +1125,7 @@ jobs:
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
+      GH_AW_ENGINE_VERSION: "v1.0.20"
       GH_AW_WORKFLOW_ID: "issue-triage"
       GH_AW_WORKFLOW_NAME: "Issue Triage"
     outputs:

--- a/.github/workflows/issue-triage.md
+++ b/.github/workflows/issue-triage.md
@@ -26,7 +26,9 @@ safe-outputs:
   add-comment:
     max: 1
 
-engine: copilot
+engine:
+  id: copilot
+  version: v1.0.20
 ---
 
 # Issue Triage

--- a/.github/workflows/weekly-repo-status.lock.yml
+++ b/.github/workflows/weekly-repo-status.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"e1985b30479641e3a059d37879cfad21f4e335a6da163b4a8eb3eaf37cececf1","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"598aa26c6cc7c258138773be2152843f5d734af8e24c853c3ddf3cb229046e46","compiler_version":"v0.67.1","strict":true,"agent_id":"copilot"}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
 #  | |_| | __ _  ___ _ __ | |_ _  ___ 
@@ -85,8 +85,8 @@ jobs:
           GH_AW_INFO_ENGINE_ID: "copilot"
           GH_AW_INFO_ENGINE_NAME: "GitHub Copilot CLI"
           GH_AW_INFO_MODEL: ${{ vars.GH_AW_MODEL_AGENT_COPILOT || 'auto' }}
-          GH_AW_INFO_VERSION: "latest"
-          GH_AW_INFO_AGENT_VERSION: "latest"
+          GH_AW_INFO_VERSION: "v1.0.20"
+          GH_AW_INFO_AGENT_VERSION: "v1.0.20"
           GH_AW_INFO_CLI_VERSION: "v0.67.1"
           GH_AW_INFO_WORKFLOW_NAME: "Weekly Repo Status"
           GH_AW_INFO_EXPERIMENTAL: "false"
@@ -156,14 +156,14 @@ jobs:
         run: |
           bash ${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh
           {
-          cat << 'GH_AW_PROMPT_0c6fbccf6721db65_EOF'
+          cat << 'GH_AW_PROMPT_0e113c2b8a53eb53_EOF'
           <system>
-          GH_AW_PROMPT_0c6fbccf6721db65_EOF
+          GH_AW_PROMPT_0e113c2b8a53eb53_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0c6fbccf6721db65_EOF'
+          cat << 'GH_AW_PROMPT_0e113c2b8a53eb53_EOF'
           <safe-output-tools>
           Tools: create_issue, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -195,12 +195,12 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_0c6fbccf6721db65_EOF
+          GH_AW_PROMPT_0e113c2b8a53eb53_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_0c6fbccf6721db65_EOF'
+          cat << 'GH_AW_PROMPT_0e113c2b8a53eb53_EOF'
           </system>
           {{#runtime-import .github/workflows/weekly-repo-status.md}}
-          GH_AW_PROMPT_0c6fbccf6721db65_EOF
+          GH_AW_PROMPT_0e113c2b8a53eb53_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
@@ -344,7 +344,7 @@ jobs:
             const { main } = require('${{ runner.temp }}/gh-aw/actions/checkout_pr_branch.cjs');
             await main();
       - name: Install GitHub Copilot CLI
-        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh latest
+        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh v1.0.20
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -366,12 +366,12 @@ jobs:
           mkdir -p ${RUNNER_TEMP}/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_e6df615d50408dbf_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/config.json << 'GH_AW_SAFE_OUTPUTS_CONFIG_858fdabd6a75fa5a_EOF'
           {"create_issue":{"labels":["report","weekly-status"],"max":1,"title_prefix":"[repo-status] "},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_e6df615d50408dbf_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_858fdabd6a75fa5a_EOF
       - name: Write Safe Outputs Tools
         run: |
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_1da8e5f12227050c_EOF'
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/tools_meta.json << 'GH_AW_SAFE_OUTPUTS_TOOLS_META_b95c7a7d740520c6_EOF'
           {
             "description_suffixes": {
               "create_issue": " CONSTRAINTS: Maximum 1 issue(s) can be created. Title will be prefixed with \"[repo-status] \". Labels [\"report\" \"weekly-status\"] will be automatically added."
@@ -379,8 +379,8 @@ jobs:
             "repo_params": {},
             "dynamic_tools": []
           }
-          GH_AW_SAFE_OUTPUTS_TOOLS_META_1da8e5f12227050c_EOF
-          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_fed619c466ab2686_EOF'
+          GH_AW_SAFE_OUTPUTS_TOOLS_META_b95c7a7d740520c6_EOF
+          cat > ${RUNNER_TEMP}/gh-aw/safeoutputs/validation.json << 'GH_AW_SAFE_OUTPUTS_VALIDATION_76839d8399e2d398_EOF'
           {
             "create_issue": {
               "defaultMax": 1,
@@ -489,7 +489,7 @@ jobs:
               }
             }
           }
-          GH_AW_SAFE_OUTPUTS_VALIDATION_fed619c466ab2686_EOF
+          GH_AW_SAFE_OUTPUTS_VALIDATION_76839d8399e2d398_EOF
           node ${RUNNER_TEMP}/gh-aw/actions/generate_safe_outputs_tools.cjs
       - name: Generate Safe Outputs MCP Server Config
         id: safe-outputs-config
@@ -559,7 +559,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.14'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_744c4e51915e3502_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
+          cat << GH_AW_MCP_CONFIG_4783ea3375df3959_EOF | bash ${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh
           {
             "mcpServers": {
               "github": {
@@ -600,7 +600,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_744c4e51915e3502_EOF
+          GH_AW_MCP_CONFIG_4783ea3375df3959_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1010,7 +1010,7 @@ jobs:
           mkdir -p /tmp/gh-aw/threat-detection
           touch /tmp/gh-aw/threat-detection/detection.log
       - name: Install GitHub Copilot CLI
-        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh latest
+        run: ${RUNNER_TEMP}/gh-aw/actions/install_copilot_cli.sh v1.0.20
         env:
           GH_HOST: github.com
       - name: Install AWF binary
@@ -1081,6 +1081,7 @@ jobs:
       GH_AW_EFFECTIVE_TOKENS: ${{ needs.agent.outputs.effective_tokens }}
       GH_AW_ENGINE_ID: "copilot"
       GH_AW_ENGINE_MODEL: ${{ needs.agent.outputs.model }}
+      GH_AW_ENGINE_VERSION: "v1.0.20"
       GH_AW_WORKFLOW_ID: "weekly-repo-status"
       GH_AW_WORKFLOW_NAME: "Weekly Repo Status"
       GH_AW_WORKFLOW_SOURCE: "githubnext/agentics/workflows/daily-repo-status.md@3a74730dbaddf484a9002a4bf34cd588cace7767"

--- a/.github/workflows/weekly-repo-status.md
+++ b/.github/workflows/weekly-repo-status.md
@@ -29,7 +29,9 @@ safe-outputs:
     title-prefix: "[repo-status] "
     labels: [report, weekly-status]
 source: githubnext/agentics/workflows/daily-repo-status.md@3a74730dbaddf484a9002a4bf34cd588cace7767
-engine: copilot
+engine:
+  id: copilot
+  version: v1.0.20
 ---
 
 # Weekly Repo Status


### PR DESCRIPTION
## Description

This is the suggested workaround for the following agent workflow failures:
- https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/1822
- https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/1825

Suggested in:
https://github.com/github/gh-aw/issues/25550#issuecomment-4218551795

This PR also updated gh-aw to the latest version and recompiled the workflows.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)