### PR TITLE
Add a system prompt modifier to reduce rg name collisions

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -36,11 +36,8 @@ const describeIntegration = skipTests ? describe.skip : describe;
 const deployTestTimeoutMs = 1800000;
 const brownfieldTestTimeoutMs = 2700000;
 
-const pseudoRandomResourceGroupNameSystemPromptModifier: {
-  mode: "append",
-  content: string
-} = {
-  mode: "append",
+const pseudoRandomResourceGroupNameSystemPromptModifier = {
+  mode: "append" as const,
   content: "Use pseudo random name resource group name such that it is less likely to have collision with existing ones."
 };
 

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -36,6 +36,14 @@ const describeIntegration = skipTests ? describe.skip : describe;
 const deployTestTimeoutMs = 1800000;
 const brownfieldTestTimeoutMs = 2700000;
 
+const pseudoRandomResourceGroupNameSystemPromptModifier: {
+  mode: "append",
+  content: string
+} = {
+  mode: "append",
+  content: "Use pseudo random name resource group name such that it is less likely to have collision with existing ones."
+};
+
 describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   const agent = useAgentRunner();
   describe("skill-invocation", () => {
@@ -165,6 +173,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a static whiteboard web app and deploy to Azure using my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -189,6 +198,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a static portfolio website and deploy to Azure using my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -217,6 +227,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a discussion board application and deploy to Azure App Service using my current subscription in westus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -241,6 +252,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a todo list with frontend and API and deploy to Azure App Service using my current subscription in westus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -269,6 +281,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure using my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -293,6 +306,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create an event-driven function app to process messages and deploy to Azure Functions using my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -317,6 +331,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create an azure python function app that takes input from a service bus trigger and does message processing and deploy to Azure using my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -344,6 +359,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a workflow app that orchestrates a multi-step order processing pipeline and deploy to Azure using my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -377,6 +393,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a containerized web application and deploy to Azure Container Apps using my current subscription in swedencentral region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -401,6 +418,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a simple containerized Node.js hello world app and deploy to Azure Container Apps using my current subscription in swedencentral region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -429,6 +447,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a static whiteboard web app and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -453,6 +472,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a static portfolio website and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -480,6 +500,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a discussion board application and deploy to Azure App Service, prefer Terraform over Bicep, in my current subscription in westus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -504,6 +525,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a todo list with frontend and API and deploy to Azure App Service using Terraform infrastructure in my current subscription in westus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -531,6 +553,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a serverless HTTP API using Azure Functions and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -555,6 +578,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create an event-driven function app to process messages and deploy to Azure Functions using Terraform infrastructure in my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -579,6 +603,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a URL shortener service using Azure Functions that creates short links and redirects users to the original URL and deploy to Azure using Terraform infrastructure in my current subscription in eastus2 region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -606,6 +631,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a containerized web application and deploy to Azure Container Apps using Terraform infrastructure in my current subscription in swedencentral region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -630,6 +656,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a simple containerized Node.js hello world app and deploy to Azure Container Apps using Terraform infrastructure in my current subscription in swedencentral region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -654,6 +681,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             workspacePath = workspace;
           },
           prompt: "Create a simple social media application with likes and comments and deploy to Azure using Terraform infrastructure in my current subscription in swedencentral region.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
@@ -689,6 +717,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "Use my current subscription. " +
             "This is for a small scale production environment. " +
             "Use standard SKUs",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -722,6 +751,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${MVCMOVIE90_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -754,6 +784,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${ASPIRE_FUNCTIONS_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -786,6 +817,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${CLIENT_APPS_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -818,6 +850,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${CONTAINER_BUILD_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -850,6 +883,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${CUSTOM_RESOURCES_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: ["Stop if there is no further work; otherwise go with recommended options."],
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -882,6 +916,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${DATABASE_CONTAINERS_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -914,6 +949,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${HEALTH_CHECKS_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -947,6 +983,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${ORLEANS_VOTING_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -980,6 +1017,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "Use my current subscription. " +
             "This is for a small scale production environment. " +
             "Use standard SKUs.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -1012,6 +1050,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${ASPIRE_JAVASCRIPT_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -1044,6 +1083,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${ASPIRE_NODE_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -1076,6 +1116,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "Use my current subscription. " +
             "This is for a small scale production environment. " +
             "Use standard SKUs.",
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
@@ -1108,6 +1149,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
             `The app can be found under ${ASPIRE_PYTHON_SPARSE_PATH}.`,
+          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment


### PR DESCRIPTION
## Description

A common test failure pattern is that the agent discovers a collision of the resource group names, due to picking common names for multiple test cases (e.g. rg-dev). In practice, this has caused the following issues:
- Agent tend to pause and ask the user to tell it how to handle the collision. This makes sense but stalls the deployment and make tests not able to proceed.
- Agent spent additional time trying to handle the collision and time out.

This PR adds a system prompt modifier to azure-deploy tests to tell the agent to use pseudo random resource group names. In my local testing, it has generated names such as rg-discussionboard-5704 which will have less chance to collide with existing resource group names. With this modifier, the test case should still be able to capture the agent behavior of real deployment tasks since real users can easily follow up to resolve the collisions.

Example test failure:
https://agreeable-dune-0f718070f.1.azurestaticapps.net/nightly-runs.html?file=2026-04-11%2F24278353446%2Fazure-deploy%2Fapp-service-deploy%2Fazure-deploy_-_Integration_Tests_app-service-deploy_creates_discussion_board%2Fagent-metadata-2026-04-11T08-25-45-797Z.md

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
