### PR TITLE
De-duplicate azure-deploy tests

### DIFF
--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -67,7 +67,7 @@ jobs:
           INPUT: ${{ inputs.test-pattern }}
         run: |
           # Default test groups if input is empty
-          DEFAULT='["skill-invocation","static-web-apps-deploy","app-service-deploy","azure-functions-deploy","vanilla-azure-container-apps-deploy","terraform-static-web-apps-deploy","terraform-app-service-deploy","terraform-azure-functions-deploy","terraform-azure-container-apps-deploy","brownfield-dotnet","brownfield-javascript","brownfield-python"]'
+          DEFAULT='["skill-invocation","vanilla-static-web-apps-deploy","vanilla-app-service-deploy","vanilla-azure-functions-deploy","vanilla-azure-container-apps-deploy","terraform-static-web-apps-deploy","terraform-app-service-deploy","terraform-azure-functions-deploy","terraform-azure-container-apps-deploy","brownfield-dotnet","brownfield-javascript","brownfield-python"]'
           
           if [ -z "$INPUT" ]; then
             echo "matrix=$DEFAULT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -20,7 +20,7 @@ on:
           - claude-sonnet-4.5
           - claude-opus-4.5
       test-pattern:
-        description: 'Optional: Comma separated patterns by name or describe block (e.g. "creates todo list", "static-web-apps-deploy", "Terraform"). If empty, all tests will be run.'
+        description: 'Optional: Comma separated patterns by name or describe block (e.g. "creates todo list", "vanilla-static-web-apps-deploy", "Terraform"). If empty, all tests will be run.'
         required: false
         type: string
         default: ''

--- a/tests/README.md
+++ b/tests/README.md
@@ -129,7 +129,7 @@ npm install
 | `npm run test:unit` | Run unit and trigger tests only (fast, no auth) |
 | `npm run test:integration` | Run integration tests (requires Copilot CLI auth, az auth, azd auth) |
 | `npm run test:integration -- azure-deploy` | Run integration tests for a specific skill |
-| `npm run test:integration -- azure-deploy static-web-apps-deploy` | Run integration tests for a specific describe group |
+| `npm run test:integration -- azure-deploy vanilla-static-web-apps-deploy` | Run integration tests for a specific describe group |
 | `npm run test:integration -- azure-deploy "creates simple containerized Node.js"` | Run a specific test |
 | `npm run test:skill -- azure-ai` | Run all tests for a specific skill |
 | `npm run test:ci` | Run tests for CI (excludes integration tests) |

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -259,7 +259,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   });
 
   // Azure Functions
-  describe("azure-functions-deploy", () => {
+  describe("vanilla-azure-functions-deploy", () => {
     test("creates serverless HTTP API", async () => {
       await withTestResult(async () => {
         let workspacePath: string | undefined;

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -155,7 +155,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   // azd auth login
   const FOLLOW_UP_PROMPT = ["Go with recommended options and proceed with Azure deployment."];
   // Static Web Apps (SWA)
-  describe("static-web-apps-deploy", () => {
+  describe("vanilla-static-web-apps-deploy", () => {
     test("creates whiteboard application", async () => {
       await withTestResult(async () => {
         let workspacePath: string | undefined;

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -207,7 +207,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   });
 
   // App Service
-  describe("app-service-deploy", () => {
+  describe("vanilla-app-service-deploy", () => {
     test("creates discussion board", async () => {
       await withTestResult(async () => {
         let workspacePath: string | undefined;


### PR DESCRIPTION
## Description

Since "app-service-deploy" is a substring of "terraform-app-service-deploy", our nightly tests are running its tests twice. Chaning the describe group name to only run it once.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
