### PR TITLE
Setup terraform in deploy test workflow

### DIFF
--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -102,6 +102,9 @@ jobs:
       - name: Install azd
         uses: Azure/setup-azd@c495e71ba59e44bfaaac10a32c8ee90d191ca4a3 # v2
 
+      - name: Setup terraform
+        uses: hashicorp/setup-terraform@v4
+
       - name: Log in with Azure (Federated Credentials)
         run: |
           azd auth login `

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -103,7 +103,7 @@ jobs:
         uses: Azure/setup-azd@c495e71ba59e44bfaaac10a32c8ee90d191ca4a3 # v2
 
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
 
       - name: Log in with Azure (Federated Credentials)
         run: |


### PR DESCRIPTION
## Description

Terraform deploy tests require terraform to be installed. Setting it up ahead of time allows the test cases to focus on deployment. They will be less likely to hit terraform installation issues or time out.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
