### PR TITLE
Fail deployment-validation tests immediately on premature azd up/deploy

### DIFF
--- a/tests/azure-validate/integration.test.ts
+++ b/tests/azure-validate/integration.test.ts
@@ -16,6 +16,7 @@ import {
 } from "../utils/agent-runner";
 import {
   hasValidationCommand,
+  hasDeploymentCommand,
   matchesFileEdit,
 } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
@@ -160,11 +161,14 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         nonInteractive: true,
         followUp: FOLLOW_UP_PROMPT,
         shouldEarlyTerminate: (metadata) =>
-          hasValidationCommand(metadata) || isSkillInvoked(metadata, "azure-deploy"),
+          hasValidationCommand(metadata) || hasDeploymentCommand(metadata) || isSkillInvoked(metadata, "azure-deploy"),
       });
 
       const deployInvoked = isSkillInvoked(agentMetadata, "azure-deploy");
       expect(deployInvoked).toBe(false);
+
+      const deploymentCommandRan = hasDeploymentCommand(agentMetadata);
+      expect(deploymentCommandRan).toBe(false);
 
       const validateInvoked = isSkillInvoked(agentMetadata, SKILL_NAME);
       const validationCommandRan = hasValidationCommand(agentMetadata);
@@ -177,11 +181,14 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         nonInteractive: true,
         followUp: FOLLOW_UP_PROMPT,
         shouldEarlyTerminate: (metadata) =>
-          hasValidationCommand(metadata) || isSkillInvoked(metadata, "azure-deploy"),
+          hasValidationCommand(metadata) || hasDeploymentCommand(metadata) || isSkillInvoked(metadata, "azure-deploy"),
       });
 
       const deployInvoked = isSkillInvoked(agentMetadata, "azure-deploy");
       expect(deployInvoked).toBe(false);
+
+      const deploymentCommandRan = hasDeploymentCommand(agentMetadata);
+      expect(deploymentCommandRan).toBe(false);
 
       const validateInvoked = isSkillInvoked(agentMetadata, SKILL_NAME);
       const validationCommandRan = hasValidationCommand(agentMetadata);
@@ -194,11 +201,14 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         nonInteractive: true,
         followUp: FOLLOW_UP_PROMPT,
         shouldEarlyTerminate: (metadata) =>
-          hasValidationCommand(metadata) || isSkillInvoked(metadata, "azure-deploy"),
+          hasValidationCommand(metadata) || hasDeploymentCommand(metadata) || isSkillInvoked(metadata, "azure-deploy"),
       });
 
       const deployInvoked = isSkillInvoked(agentMetadata, "azure-deploy");
       expect(deployInvoked).toBe(false);
+
+      const deploymentCommandRan = hasDeploymentCommand(agentMetadata);
+      expect(deploymentCommandRan).toBe(false);
 
       const validateInvoked = isSkillInvoked(agentMetadata, SKILL_NAME);
       const validationCommandRan = hasValidationCommand(agentMetadata);

--- a/tests/azure-validate/integration.test.ts
+++ b/tests/azure-validate/integration.test.ts
@@ -167,6 +167,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       const deployInvoked = isSkillInvoked(agentMetadata, "azure-deploy");
       expect(deployInvoked).toBe(false);
 
+      // A deployment command (azd up/deploy) means the agent skipped validation entirely.
       const deploymentCommandRan = hasDeploymentCommand(agentMetadata);
       expect(deploymentCommandRan).toBe(false);
 
@@ -187,6 +188,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       const deployInvoked = isSkillInvoked(agentMetadata, "azure-deploy");
       expect(deployInvoked).toBe(false);
 
+      // A deployment command (azd up/deploy) means the agent skipped validation entirely.
       const deploymentCommandRan = hasDeploymentCommand(agentMetadata);
       expect(deploymentCommandRan).toBe(false);
 
@@ -207,6 +209,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       const deployInvoked = isSkillInvoked(agentMetadata, "azure-deploy");
       expect(deployInvoked).toBe(false);
 
+      // A deployment command (azd up/deploy) means the agent skipped validation entirely.
       const deploymentCommandRan = hasDeploymentCommand(agentMetadata);
       expect(deploymentCommandRan).toBe(false);
 

--- a/tests/azure-validate/utils.ts
+++ b/tests/azure-validate/utils.ts
@@ -12,7 +12,32 @@ const VALIDATION_COMMAND_PATTERNS = [
   /terraform\s+validate/,
 ];
 
+/**
+ * Deployment command patterns that indicate the agent is executing
+ * a deployment rather than stopping at validation. Tests that expect
+ * the agent to terminate at validation can use {@link hasDeploymentCommand}
+ * in `shouldEarlyTerminate` to abort immediately instead of waiting
+ * for a 20-minute timeout.
+ */
+const DEPLOYMENT_COMMAND_PATTERNS = [
+  /azd\s+up\b/,
+  /azd\s+deploy\b/,
+];
+
 const SHELL_TOOL_NAMES = ["powershell", "bash"];
+
+/**
+ * Return all shell commands from agent metadata.
+ */
+function getShellCommands(metadata: AgentMetadata): string[] {
+  return getToolCalls(metadata)
+    .filter(event => SHELL_TOOL_NAMES.includes(event.data.toolName))
+    .map(event => {
+      const data = event.data as Record<string, unknown>;
+      const args = data.arguments as { command?: string } | undefined;
+      return args?.command ?? "";
+    });
+}
 
 /**
  * Check if any shell tool call (powershell or bash) contains a validation command
@@ -22,13 +47,23 @@ const SHELL_TOOL_NAMES = ["powershell", "bash"];
  * once a validation command has been issued, without waiting for deployment.
  */
 export function hasValidationCommand(metadata: AgentMetadata): boolean {
-  const shellCalls = getToolCalls(metadata).filter(event => SHELL_TOOL_NAMES.includes(event.data.toolName));
-  return shellCalls.some(event => {
-    const data = event.data as Record<string, unknown>;
-    const args = data.arguments as { command?: string } | undefined;
-    const cmd = args?.command ?? "";
-    return VALIDATION_COMMAND_PATTERNS.some(pattern => pattern.test(cmd));
-  });
+  return getShellCommands(metadata).some(cmd =>
+    VALIDATION_COMMAND_PATTERNS.some(pattern => pattern.test(cmd)),
+  );
+}
+
+/**
+ * Check if any shell tool call contains a deployment command
+ * (`azd up` or `azd deploy`).
+ *
+ * Use in `shouldEarlyTerminate` alongside {@link hasValidationCommand}
+ * so that tests fail fast when the agent skips validation and jumps
+ * straight to deployment.
+ */
+export function hasDeploymentCommand(metadata: AgentMetadata): boolean {
+  return getShellCommands(metadata).some(cmd =>
+    DEPLOYMENT_COMMAND_PATTERNS.some(pattern => pattern.test(cmd)),
+  );
 }
 
 /**

--- a/tests/azure-validate/utils.ts
+++ b/tests/azure-validate/utils.ts
@@ -1,5 +1,5 @@
 import { type AgentMetadata } from "../utils/agent-runner";
-import { getToolCalls } from "../utils/evaluate";
+import { getToolCalls, matchesCommand } from "../utils/evaluate";
 
 /**
  * Validation command patterns that indicate the agent is performing
@@ -24,21 +24,6 @@ const DEPLOYMENT_COMMAND_PATTERNS = [
   /azd\s+deploy\b/,
 ];
 
-const SHELL_TOOL_NAMES = ["powershell", "bash"];
-
-/**
- * Return all shell commands from agent metadata.
- */
-function getShellCommands(metadata: AgentMetadata): string[] {
-  return getToolCalls(metadata)
-    .filter(event => SHELL_TOOL_NAMES.includes(event.data.toolName))
-    .map(event => {
-      const data = event.data as Record<string, unknown>;
-      const args = data.arguments as { command?: string } | undefined;
-      return args?.command ?? "";
-    });
-}
-
 /**
  * Check if any shell tool call (powershell or bash) contains a validation command
  * (azd provision, az deployment ... validate, or terraform validate).
@@ -47,9 +32,7 @@ function getShellCommands(metadata: AgentMetadata): string[] {
  * once a validation command has been issued, without waiting for deployment.
  */
 export function hasValidationCommand(metadata: AgentMetadata): boolean {
-  return getShellCommands(metadata).some(cmd =>
-    VALIDATION_COMMAND_PATTERNS.some(pattern => pattern.test(cmd)),
-  );
+  return VALIDATION_COMMAND_PATTERNS.some(p => matchesCommand(metadata, p));
 }
 
 /**
@@ -61,9 +44,7 @@ export function hasValidationCommand(metadata: AgentMetadata): boolean {
  * straight to deployment.
  */
 export function hasDeploymentCommand(metadata: AgentMetadata): boolean {
-  return getShellCommands(metadata).some(cmd =>
-    DEPLOYMENT_COMMAND_PATTERNS.some(pattern => pattern.test(cmd)),
-  );
+  return DEPLOYMENT_COMMAND_PATTERNS.some(p => matchesCommand(metadata, p));
 }
 
 /**


### PR DESCRIPTION
## Problem

The `deployment-validation` integration tests (e.g. "terminates at validation for containerized web app on Container Apps") expect the agent to stop at the validation phase. However, when the agent skips validation and runs `azd up` or `azd deploy` directly, the `shouldEarlyTerminate` callback did not detect this — so the test sat waiting the full 20-minute Jest timeout before failing.

In [run #138](https://github.com/microsoft/GitHub-Copilot-for-Azure/actions/runs/23945698791), the agent ran `azd up --no-prompt` immediately after scaffolding, bypassing the `azure-prepare` → `azure-validate` → `azure-deploy` workflow. The test burned 20 minutes before timing out.

## Fix

- Added a `hasDeploymentCommand()` helper to `tests/azure-validate/utils.ts` that detects `azd up` and `azd deploy` in shell tool calls.
- Updated `shouldEarlyTerminate` in all three `deployment-validation` tests to also trigger on deployment commands, so the session aborts within seconds instead of waiting for the timeout.
- Added an explicit `expect(hasDeploymentCommand(...)).toBe(false)` assertion so the failure message clearly indicates the agent ran a deployment command before validation.

Fixes #1694