### PR TITLE
Add org info for msbench runs

### DIFF
--- a/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
@@ -162,7 +162,7 @@
             "--benchmark", $Benchmark,
             "--model", $m,
             "--env", "GITHUB_MCP_SERVER_TOKEN",
-            "--tag", "org=Azure",
+            "--tag", 'org="CoreAI Cloud and Tools"',
             "--no-wait"
         )
 

--- a/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
@@ -162,6 +162,7 @@
             "--benchmark", $Benchmark,
             "--model", $m,
             "--env", "GITHUB_MCP_SERVER_TOKEN",
+            "--tag", "org=Azure",
             "--no-wait"
         )
 

--- a/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
@@ -16,7 +16,7 @@
     - https://github.com/devdiv-microsoft/MicrosoftSweBench/wiki
 
 .PARAMETER Benchmark
-    Benchmark identifier. Default: azure
+    Benchmark identifier. Default: azure.skill
 
 .PARAMETER Model
     One or more model identifiers to benchmark.

--- a/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
@@ -26,7 +26,7 @@
 #>
 
     param(
-        [string]$Benchmark = "azure",
+        [string]$Benchmark = "azure.skill",
         [string[]]$Model = @(
             "claude-sonnet-4.5-autodev-test",
             "claude-opus-4.5-autodev-test",


### PR DESCRIPTION
## Description

Add `CoreAI Cloud and Tools` as the Organization for msbench runs. Update default to run only azure skills benchmarks.

