### PR TITLE
test: Remove health-checks-ui integration test

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -926,39 +926,6 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       });
     }, brownfieldTestTimeoutMs);
 
-    test("does not deploy aspire health-checks-ui", async () => {
-      await withTestResult(async () => {
-        const HEALTH_CHECKS_SPARSE_PATH = "samples/health-checks-ui";
-
-        const agentMetadata = await agent.run({
-          setup: async (workspace: string) => {
-            await cloneRepo({
-              repoUrl: ASPIRE_SAMPLES_REPO,
-              targetDir: workspace,
-              depth: 1,
-              sparseCheckoutPath: HEALTH_CHECKS_SPARSE_PATH,
-            });
-          },
-          prompt:
-            "Please deploy this application to Azure. " +
-            "Use the eastus2 region. " +
-            "Use my current subscription. " +
-            "This is for a small scale production environment. " +
-            "Use standard SKUs. " +
-            `The app can be found under ${HEALTH_CHECKS_SPARSE_PATH}.`,
-          systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
-          nonInteractive: true,
-          followUp: FOLLOW_UP_PROMPT,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
-        });
-
-        softCheckDeploySkills(agentMetadata);
-        const containsDeployLinks = hasDeployLinks(agentMetadata);
-
-        // This app contains custom Aspire resource types that Azure Developer CLI cannot deploy to Azure.
-        expect(containsDeployLinks).toBe(false); //should not deploy
-      });
-    }, brownfieldTestTimeoutMs);
 
     test("deploys aspire orleans-voting", async () => {
       await withTestResult(async () => {

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -926,7 +926,6 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       });
     }, brownfieldTestTimeoutMs);
 
-
     test("deploys aspire orleans-voting", async () => {
       await withTestResult(async () => {
         const ORLEANS_VOTING_SPARSE_PATH = "samples/orleans-voting";


### PR DESCRIPTION
## Problem

The `does not deploy aspire health-checks-ui` integration test asserts that the agent should NOT deploy the `samples/health-checks-ui` Aspire application. However, the agent found a valid workaround (wrapping `AddDockerComposeEnvironment()` in an `IsRunMode` conditional) and successfully deployed all four services, causing the assertion `expect(containsDeployLinks).toBe(false)` to fail.

## Fix

Remove the test case entirely. The health-checks-ui sample is not meaningfully deployable to Azure, and a user asking Copilot to deploy it would indicate they do not understand the application. Rather than trying to engineer the agent's behavior for an unrealistic user scenario, the test is removed.

Fixes #1849