### PR TITLE
fix: azure-prepare: add proactive Step 4b for Aspire + Functions secret storage

### DIFF
--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -4,7 +4,7 @@ description: "Prepare Azure apps for deployment (infra Bicep/Terraform, azure.ya
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.1.15"
+  version: "1.1.16"
 ---
 
 # Azure Prepare

--- a/plugin/skills/azure-prepare/references/aspire.md
+++ b/plugin/skills/azure-prepare/references/aspire.md
@@ -177,6 +177,65 @@ services:
     host: containerapp
 ```
 
+### ⛔ Step 4b: Fix Azure Functions Secret Storage (MANDATORY for Aspire + Functions)
+
+**MANDATORY: After `azd init --from-code` succeeds, check if the AppHost contains Azure Functions and fix secret storage configuration.**
+
+This step **MUST** run BEFORE `azd up` or `azd provision`. Skipping it causes a runtime failure: `Secret initialization from Blob storage failed`.
+
+**1. Detect Azure Functions in the AppHost:**
+
+```bash
+APPHOST_DIR=$(dirname "$(find . -name '*.AppHost.csproj' | head -1)")
+grep -n "AddAzureFunctionsProject" "$APPHOST_DIR"/*.cs
+```
+
+**PowerShell:**
+```powershell
+$appHostDir = (Get-ChildItem -Recurse -Filter "*.AppHost.csproj" | Select-Object -First 1).DirectoryName
+Get-ChildItem -Path $appHostDir -Filter "*.cs" | Select-String "AddAzureFunctionsProject"
+```
+
+**If `AddAzureFunctionsProject` is NOT found → skip to Step 5.**
+
+**2. Check if `AzureWebJobsSecretStorageType` is already configured:**
+
+```bash
+grep -n "AzureWebJobsSecretStorageType" "$APPHOST_DIR"/*.cs
+```
+
+**PowerShell:**
+```powershell
+Get-ChildItem -Path $appHostDir -Filter "*.cs" | Select-String "AzureWebJobsSecretStorageType"
+```
+
+**If already present → skip to Step 5.**
+
+**3. Add the environment variable to the Functions builder chain:**
+
+Use the `edit` tool to add `.WithEnvironment("AzureWebJobsSecretStorageType", "Files")` to the `AddAzureFunctionsProject` builder chain in the AppHost source file.
+
+**Before:**
+```csharp
+var functions = builder.AddAzureFunctionsProject<Projects.MyFunctions>("functions")
+    .WithHostStorage(storage)
+    .WithReference(queues);
+```
+
+**After:**
+```csharp
+var functions = builder.AddAzureFunctionsProject<Projects.MyFunctions>("functions")
+    .WithHostStorage(storage)
+    .WithEnvironment("AzureWebJobsSecretStorageType", "Files")
+    .WithReference(queues);
+```
+
+> 💡 **Tip:** Place `.WithEnvironment(...)` immediately after `.WithHostStorage(...)` for clarity.
+
+> ⚠️ **Why this is required:** When Aspire uses `WithHostStorage(storage)`, it configures identity-based storage URIs (e.g., `AzureWebJobsStorage__blobServiceUri`). Azure Functions' secret/key manager does **not** support these identity-based URIs — it requires either a connection string or file-based storage. Setting `AzureWebJobsSecretStorageType=Files` switches to file-system key storage, bypassing the incompatible blob dependency.
+
+See [aspire-functions-secrets reference](services/functions/aspire-containerapps.md) for additional details.
+
 ## Flags Reference
 
 ### azd init for Aspire

--- a/plugin/skills/azure-prepare/references/aspire.md
+++ b/plugin/skills/azure-prepare/references/aspire.md
@@ -196,7 +196,7 @@ $appHostDir = (Get-ChildItem -Recurse -Filter "*.AppHost.csproj" | Select-Object
 Get-ChildItem -Path $appHostDir -Filter "*.cs" | Select-String "AddAzureFunctionsProject"
 ```
 
-**If `AddAzureFunctionsProject` is NOT found → skip to Step 5.**
+**If `AddAzureFunctionsProject` is NOT found → skip this step.**
 
 **2. Check if `AzureWebJobsSecretStorageType` is already configured:**
 
@@ -209,7 +209,7 @@ grep -n "AzureWebJobsSecretStorageType" "$APPHOST_DIR"/*.cs
 Get-ChildItem -Path $appHostDir -Filter "*.cs" | Select-String "AzureWebJobsSecretStorageType"
 ```
 
-**If already present → skip to Step 5.**
+**If already present → skip this step.**
 
 **3. Add the environment variable to the Functions builder chain:**
 

--- a/plugin/skills/azure-prepare/references/generate.md
+++ b/plugin/skills/azure-prepare/references/generate.md
@@ -19,7 +19,6 @@ grep -r "Aspire\.Hosting\|Aspire\.AppHost\.Sdk" . --include="*.csproj"
 2. ⛔ **STOP** - Do NOT manually create `infra/` files
 3. ✅ **USE** - `azd init --from-code -e <env-name>` instead
 4. 📖 **READ** - [aspire.md](aspire.md) and [recipes/azd/aspire.md](recipes/azd/aspire.md) for complete guidance
-5. ⚠️ **FIX** - If AppHost has `AddAzureFunctionsProject`, you **MUST** add `AzureWebJobsSecretStorageType` — see [aspire.md Step 4b](aspire.md#-step-4b-fix-azure-functions-secret-storage-mandatory-for-aspire--functions)
 
 **Why this is critical:**
 - Aspire AppHost auto-generates infrastructure from code

--- a/plugin/skills/azure-prepare/references/generate.md
+++ b/plugin/skills/azure-prepare/references/generate.md
@@ -19,6 +19,7 @@ grep -r "Aspire\.Hosting\|Aspire\.AppHost\.Sdk" . --include="*.csproj"
 2. ⛔ **STOP** - Do NOT manually create `infra/` files
 3. ✅ **USE** - `azd init --from-code -e <env-name>` instead
 4. 📖 **READ** - [aspire.md](aspire.md) and [recipes/azd/aspire.md](recipes/azd/aspire.md) for complete guidance
+5. ⚠️ **FIX** - If AppHost has `AddAzureFunctionsProject`, you **MUST** add `AzureWebJobsSecretStorageType` — see [aspire.md Step 4b](aspire.md#-step-4b-fix-azure-functions-secret-storage-mandatory-for-aspire--functions)
 
 **Why this is critical:**
 - Aspire AppHost auto-generates infrastructure from code

--- a/plugin/skills/azure-prepare/references/scan.md
+++ b/plugin/skills/azure-prepare/references/scan.md
@@ -65,7 +65,7 @@ Before classifying components, grep dependency files for SDKs that require a spe
 - Use `azd init --from-code -e <environment-name>` instead of manual azure.yaml creation
 - The `--from-code` flag automatically detects the AppHost and generates appropriate configuration
 - The `-e` flag is **required** for non-interactive environments (agents, CI/CD)
-- ⚠️ **CRITICAL:** Aspire projects using Container Apps require environment variable setup BEFORE deployment. See [aspire.md](aspire.md) for proactive configuration steps to avoid deployment failures.
+- ⚠️ **CRITICAL:** If the AppHost contains `AddAzureFunctionsProject`, you **MUST** add `.WithEnvironment("AzureWebJobsSecretStorageType", "Files")` to the Functions builder chain BEFORE deployment. Without this, Functions will fail at startup with `Secret initialization from Blob storage failed`. See [aspire.md](aspire.md) Step 4b for the complete detection and fix procedure.
 - See [aspire.md](aspire.md) for detailed Aspire-specific guidance
 
 ## Output


### PR DESCRIPTION
## Problem

The integration test `sets AzureWebJobsSecretStorageType for aspire-with-azure-functions` fails because the agent running `azure-prepare` does not edit `AppHost.cs` to add `.WithEnvironment("AzureWebJobsSecretStorageType", "Files")`. The guidance for this fix existed only in a **Troubleshooting** section of `aspire.md` (reactive—framed as error recovery) and in `aspire-containerapps.md` (not linked from any workflow step). Because the agent follows the workflow steps and never encounters an error before deployment, it never reaches this guidance.

## Fix

Adds a new **Step 4b** to `azure-prepare/references/aspire.md` that runs after `azd init` succeeds and before deployment. This step:

1. Detects `AddAzureFunctionsProject` in the AppHost source
2. Checks whether `AzureWebJobsSecretStorageType` is already configured
3. If missing, edits `AppHost.cs` to add `.WithEnvironment("AzureWebJobsSecretStorageType", "Files")`

Cross-references are added in `scan.md` (with the specific variable name and link to Step 4b) and `generate.md` (as item 5 in the Aspire checklist) so the agent encounters this requirement at multiple points in the workflow.

This is the right fix because the root cause is a **skill instruction gap**, not a model failure. The agent followed the documented workflow correctly—it just was never told to do this proactive edit. Moving the guidance from a reactive troubleshooting section into a mandatory workflow step ensures it runs before deployment.

Fixes #1860