### PR TITLE
Use azure's custom dataset for MSBench run

### DIFF
--- a/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-CopilotBenchmarks.ps1
@@ -162,6 +162,7 @@
             "--benchmark", $Benchmark,
             "--model", $m,
             "--env", "GITHUB_MCP_SERVER_TOKEN",
+            "--dataset", (Join-Path $targetDir "metadata.csv"),
             "--tag", 'org="CoreAI Cloud and Tools"',
             "--no-wait"
         )


### PR DESCRIPTION
## Description

MSBench currently doesn't have real-time indexing of all the benchmarks it have. This has caused newly added benchmark scenarios being left behind by the nightly runs. To work around this issue, the MSBench team suggests us to use the custom dataset switch and feeding the latest azure benchmark scenarios index file in their predefined format.
