### PR TITLE
Collect non-integration test results in dashboard data

### DIFF
--- a/.github/workflows/dashboard-collect.yml
+++ b/.github/workflows/dashboard-collect.yml
@@ -31,8 +31,11 @@ jobs:
           cache: 'npm'
           cache-dependency-path: scripts/package-lock.json
 
-      - name: Install dependencies
+      - name: Install scripts dependencies
         run: cd scripts && npm ci
+
+      - name: Install tests dependencies
+        run: cd tests && npm ci
 
       - name: Run non-integration tests
         run: cd tests && npm run test:ci

--- a/.github/workflows/dashboard-collect.yml
+++ b/.github/workflows/dashboard-collect.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Install dependencies
         run: cd scripts && npm ci
 
+      - name: Run non-integration tests
+        run: cd tests && npm run test:ci
+
       - name: Collect dashboard data
         run: npm run dashboard:collect
 


### PR DESCRIPTION
## Description

The dashboard:collect command optionally reads the latest local test results and include them in the produced data.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
