### PR TITLE
feat(azure-compute): add pre-flight safety checks to VM troubleshooter

### DIFF
--- a/plugin/skills/azure-compute/SKILL.md
+++ b/plugin/skills/azure-compute/SKILL.md
@@ -4,7 +4,7 @@ description: "Azure VM and VMSS router for recommendations, pricing, autoscale, 
 license: MIT
 metadata:
   author: Microsoft
-  version: "2.1.0"
+  version: "2.2.0"
 ---
 
 # Azure Compute Skill

--- a/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/cannot-connect-to-vm.md
+++ b/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/cannot-connect-to-vm.md
@@ -24,8 +24,40 @@ Index of VM connectivity troubleshooting references. Route to the appropriate fi
 1. Identify the symptom category from the routing table above
 2. Open the matching reference file for the Symptoms → Solutions table and Quick Commands
 3. Narrow to the specific solution row matching the user's symptom
-4. Fetch the linked documentation URL for the latest guidance
-5. Summarize diagnostic steps and resolution, referencing the official docs
+4. **Before any extension-backed operation, run [Pre-Flight Safety Checks](#pre-flight-safety-checks)**
+5. Fetch the linked documentation URL for the latest guidance
+6. Summarize diagnostic steps and resolution, referencing the official docs
+
+---
+
+## Pre-Flight Safety Checks
+
+> ⚠️ **Warning:** Always run these checks before any command that depends on the VM agent or extensions (`az vm user update`, `az vm user reset-ssh`, `az vm user reset-remote-desktop`, `az vm run-command invoke`). Running extension-backed operations on a VM with an unhealthy agent or stuck extensions can **deadlock the VM** and require manual portal recovery.
+
+```bash
+# 1. Check VM power state, provisioning state, and agent status
+az vm get-instance-view --name <vm-name> -g <resource-group> \
+  --query "instanceView.{powerState:[statuses[?starts_with(code,'PowerState/')]][0][0].code, provisioningState:[statuses[?starts_with(code,'ProvisioningState/')]][0][0].code, vmAgentStatus:vmAgent.statuses[0].displayStatus}" -o json
+
+# 2. Check existing extension states
+az vm extension list --vm-name <vm-name> -g <resource-group> \
+  --query "[].{name:name, provisioningState:provisioningState}" -o table
+```
+
+| Check | Safe Value | Unsafe — Do NOT proceed |
+| ----- | ---------- | ----------------------- |
+| Power state | `PowerState/running` | Any other value, missing, or query error |
+| Provisioning state | `ProvisioningState/succeeded` | `Updating`, `Creating`, `Failed`, `Deleting`, missing, or query error |
+| VM agent status | `Ready` | `Not Ready`, `null`, missing, or query error |
+| Extension states | All `Succeeded` or no extensions | Any extension in `Creating`, `Updating`, `Deleting`, or `Failed` |
+
+> 💡 **Tip:** If a check returns `null`, empty, or the CLI command itself errors, treat the result as **unsafe**.
+
+**If any check is unsafe:**
+1. **Stop.** Do NOT run any extension-backed command.
+2. Inform the user which check(s) failed and what the current state is.
+3. Use non-agent alternatives: **Serial Console**, **offline repair VM**, or **Portal-based actions**.
+4. If the state appears transient (e.g., VM just started, provisioning briefly not `succeeded`), wait 30–60 seconds and **re-run the checks only** — do not run the extension command until all checks pass.
 
 ---
 
@@ -34,8 +66,8 @@ Index of VM connectivity troubleshooting references. Route to the appropriate fi
 If the issue doesn't match any symptom above, or if the documented solutions don't resolve it:
 
 1. **Check Azure Resource Health** — Portal > VM > Resource health (checks for platform-level issues)
-2. **Restart the VM** — `az vm restart --name <vm-name> -g <resource-group>`
-3. **Redeploy the VM** — `az vm redeploy --name <vm-name> -g <resource-group>` (moves to new host)
+2. **Offer to restart the VM** (requires user approval) — `az vm restart --name <vm-name> -g <resource-group>`
+3. **Offer to redeploy the VM** (requires user approval — moves to new host) — `az vm redeploy --name <vm-name> -g <resource-group>`
 4. **Comprehensive troubleshooting:**
    - Windows: [Troubleshoot RDP connections](https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-connection)
    - Linux: [Troubleshoot SSH connections](https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/linux/troubleshoot-ssh-connection)

--- a/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/credential-auth-errors.md
+++ b/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/credential-auth-errors.md
@@ -26,26 +26,30 @@ User can reach the VM but authentication fails.
 
 ## Quick Commands — Windows
 
+> ⚠️ **Warning:** Commands below use the VM agent/extensions. Run [Pre-Flight Safety Checks](cannot-connect-to-vm.md#pre-flight-safety-checks) before using them.
+
 ```bash
-# Reset password
+# ⚡ Reset password
 az vm user update --name <vm-name> -g <resource-group> -u <username> -p '<new-password>'
 
-# Reset RDP configuration (also re-enables NLA)
+# ⚡ Reset RDP configuration (also re-enables NLA)
 az vm user reset-remote-desktop --name <vm-name> -g <resource-group>
 ```
 
 ## Quick Commands — Linux
 
+> ⚠️ **Warning:** Commands below use the VM agent/extensions. Run [Pre-Flight Safety Checks](cannot-connect-to-vm.md#pre-flight-safety-checks) before using them.
+
 ```bash
-# Reset SSH public key
+# ⚡ Reset SSH public key
 az vm user update --name <vm-name> -g <resource-group> \
   -u <username> --ssh-key-value "<ssh-public-key>"
 
-# Reset password for Linux VM
+# ⚡ Reset password for Linux VM
 az vm user update --name <vm-name> -g <resource-group> \
   -u <username> -p '<new-password>'
 
-# Unlock a locked account via Run Command
+# ⚡ Unlock a locked account via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunShellScript --scripts "passwd -u <username>"
 ```

--- a/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/firewall-blocking.md
+++ b/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/firewall-blocking.md
@@ -17,16 +17,18 @@ Guest OS firewall (Windows Firewall or Linux iptables/firewalld) is blocking inb
 
 ## Quick Commands — Windows
 
+> ⚠️ **Warning:** Commands marked with ⚡ use the VM agent/extensions. Run [Pre-Flight Safety Checks](cannot-connect-to-vm.md#pre-flight-safety-checks) before using them.
+
 ```bash
-# Reset RDP config (re-enables RDP, creates firewall rule for 3389)
+# ⚡ Reset RDP config (re-enables RDP, creates firewall rule for 3389)
 az vm user reset-remote-desktop --name <vm-name> -g <resource-group>
 
-# Query Windows Firewall rules via Run Command
+# ⚡ Query Windows Firewall rules via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunPowerShellScript \
   --scripts "netsh advfirewall firewall show rule name='Remote Desktop - User Mode (TCP-In)'"
 
-# Enable Remote Desktop firewall rule via Run Command
+# ⚡ Enable Remote Desktop firewall rule via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunPowerShellScript \
   --scripts "netsh advfirewall firewall set rule group='Remote Desktop' new enable=yes"
@@ -34,16 +36,18 @@ az vm run-command invoke --name <vm-name> -g <resource-group> \
 
 ## Quick Commands — Linux
 
+> ⚠️ **Warning:** Commands below use the VM agent/extensions. Run [Pre-Flight Safety Checks](cannot-connect-to-vm.md#pre-flight-safety-checks) before using them.
+
 ```bash
-# Check iptables rules via Run Command
+# ⚡ Check iptables rules via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunShellScript --scripts "iptables -L -n --line-numbers"
 
-# Allow SSH through iptables via Run Command
+# ⚡ Allow SSH through iptables via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunShellScript --scripts "iptables -I INPUT -p tcp --dport 22 -j ACCEPT"
 
-# Check firewalld status and open SSH via Run Command
+# ⚡ Check firewalld status and open SSH via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunShellScript \
   --scripts "firewall-cmd --state && firewall-cmd --add-service=ssh --permanent && firewall-cmd --reload"

--- a/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/network-connectivity.md
+++ b/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/network-connectivity.md
@@ -45,12 +45,14 @@ az vm repair reset-nic --name <vm-name> -g <resource-group> --yes
 
 ## Quick Commands — Linux
 
+> ⚠️ **Warning:** Commands below use the VM agent/extensions. Run [Pre-Flight Safety Checks](cannot-connect-to-vm.md#pre-flight-safety-checks) before using them.
+
 ```bash
-# Check network interface status via Run Command
+# ⚡ Check network interface status via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunShellScript --scripts "ip link show; ip addr show"
 
-# Bring interface up via Run Command
+# ⚡ Bring interface up via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunShellScript --scripts "ip link set eth0 up && dhclient eth0"
 ```

--- a/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/rdp-connectivity.md
+++ b/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/rdp-connectivity.md
@@ -24,6 +24,8 @@ User is trying to RDP into a Windows VM but the connection fails (timeout, refus
 
 ## Quick Commands
 
+> ⚠️ **Warning:** Commands marked with ⚡ use the VM agent/extensions. Run [Pre-Flight Safety Checks](cannot-connect-to-vm.md#pre-flight-safety-checks) before using them.
+
 ```bash
 # Check VM power state
 az vm get-instance-view --name <vm-name> -g <resource-group> \
@@ -32,10 +34,10 @@ az vm get-instance-view --name <vm-name> -g <resource-group> \
 # Check NSG rules
 az network nsg rule list --nsg-name <nsg-name> -g <resource-group> -o table
 
-# Reset RDP configuration to defaults (re-enables RDP, resets port, restarts TermService)
+# ⚡ Reset RDP configuration to defaults (re-enables RDP, resets port, restarts TermService)
 az vm user reset-remote-desktop --name <vm-name> -g <resource-group>
 
-# Reset VM password
+# ⚡ Reset VM password
 az vm user update --name <vm-name> -g <resource-group> -u <username> -p '<new-password>'
 
 # IP Flow Verify — test if NSG allows traffic

--- a/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/rdp-service-config.md
+++ b/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/rdp-service-config.md
@@ -16,17 +16,19 @@ VM is reachable but the RDP service itself is broken or misconfigured.
 
 ## Quick Commands
 
+> ⚠️ **Warning:** Commands marked with ⚡ use the VM agent/extensions. Run [Pre-Flight Safety Checks](cannot-connect-to-vm.md#pre-flight-safety-checks) before using them.
+
 ```bash
-# Reset all RDP configuration to defaults
+# ⚡ Reset all RDP configuration to defaults
 az vm user reset-remote-desktop --name <vm-name> -g <resource-group>
 
-# Check TermService status via Run Command
+# ⚡ Check TermService status via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunPowerShellScript --scripts "Get-Service TermService | Select-Object Status, StartType"
 
-# Restart VM (if RDP service is unrecoverable)
+# Restart VM (if RDP service is unrecoverable — requires user approval)
 az vm restart --name <vm-name> -g <resource-group>
 
-# Redeploy VM (moves to new host — last resort)
+# Redeploy VM (moves to new host — last resort, requires user approval)
 az vm redeploy --name <vm-name> -g <resource-group>
 ```

--- a/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/ssh-connectivity.md
+++ b/plugin/skills/azure-compute/workflows/vm-troubleshooter/references/ssh-connectivity.md
@@ -20,27 +20,29 @@ User is trying to SSH into a Linux VM but the connection fails.
 
 ## Quick Commands
 
+> ⚠️ **Warning:** Commands marked with ⚡ use the VM agent/extensions. Run [Pre-Flight Safety Checks](cannot-connect-to-vm.md#pre-flight-safety-checks) before using them.
+
 ```bash
-# Reset SSH configuration to defaults (resets sshd_config, restarts sshd)
+# ⚡ Reset SSH configuration to defaults (resets sshd_config, restarts sshd)
 az vm user reset-ssh --name <vm-name> -g <resource-group>
 
-# Reset SSH public key for a user
+# ⚡ Reset SSH public key for a user
 az vm user update --name <vm-name> -g <resource-group> \
   -u <username> --ssh-key-value "<ssh-public-key>"
 
-# Reset password for Linux VM
+# ⚡ Reset password for Linux VM
 az vm user update --name <vm-name> -g <resource-group> \
   -u <username> -p '<new-password>'
 
-# Check if sshd is running via Run Command
+# ⚡ Check if sshd is running via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunShellScript --scripts "systemctl status sshd"
 
-# Check SELinux status via Run Command
+# ⚡ Check SELinux status via Run Command
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunShellScript --scripts "getenforce"
 
-# Set SELinux to permissive mode (temporary — survives until reboot)
+# ⚡ Set SELinux to permissive mode (temporary — survives until reboot)
 az vm run-command invoke --name <vm-name> -g <resource-group> \
   --command-id RunShellScript --scripts "setenforce 0"
 ```

--- a/plugin/skills/azure-compute/workflows/vm-troubleshooter/vm-troubleshooter.md
+++ b/plugin/skills/azure-compute/workflows/vm-troubleshooter/vm-troubleshooter.md
@@ -32,6 +32,24 @@ Activate this skill when user mentions:
 
 ---
 
+## Guardrails
+
+- **Default to read-only diagnostics.** Gather evidence before suggesting any fix.
+- Do not run extension-backed commands (`az vm user update`, `az vm user reset-ssh`, `az vm user reset-remote-desktop`, `az vm run-command invoke`) without first passing [Pre-Flight Safety Checks](#phase-25-pre-flight-safety-checks-before-extension-backed-operations).
+- Do not restart, redeploy, deallocate, or delete a VM unless the user explicitly asks for remediation.
+- Do not conclude root cause without quoting the evidence that supports it (e.g., NSG rule output, VM agent status, extension state).
+- When multiple issues are found (e.g., NSG + credential), fix the network-layer issue first before attempting agent-dependent fixes.
+
+## Evidence Order
+
+Gather diagnostic evidence in this order before suggesting remediation:
+
+1. **VM state:** power state, provisioning state, VM agent health, extension states
+2. **Network layer:** public IP, NSG rules (NIC + subnet), effective routes, IP flow verify
+3. **Guest OS layer (if agent is healthy):** service status via Run Command, firewall rules, sshd/TermService config
+
+---
+
 ## Workflow
 
 ### Phase 1: Determine User Intent
@@ -48,7 +66,7 @@ Infer the connectivity issue from the user's message. If the issue is clear, pro
 
 If unclear, ask: **"Are you trying to connect via RDP (Windows) or SSH (Linux), and what error message or behavior are you seeing?"**
 
-If the user shares an Azure VM name or resource ID, attempt to use the azure-resource-lookup skill if available. If not available, attempt to the use the Azure CLI.
+If the user shares an Azure VM name or resource ID, attempt to use the azure-resource-lookup skill if available. If not available, attempt to use the Azure CLI.
 
 ### Phase 2: Route to Solution
 
@@ -58,6 +76,29 @@ If additional details are needed to narrow to a specific solution row, ask the u
 - "What error message do you see in the RDP dialog?"
 - "Does the connection time out, or do you get an error immediately?"
 - "Is this a Windows or Linux VM?"
+
+### Phase 2.5: Pre-Flight Safety Checks (Before Extension-Backed Operations)
+
+> ⚠️ **Warning:** This phase is **mandatory** before running any command that depends on the VM agent or extensions. Skipping these checks can deadlock the VM and require manual portal recovery.
+
+**Extension-backed commands include:** `az vm user update`, `az vm user reset-ssh`, `az vm user reset-remote-desktop`, `az vm run-command invoke`, and any operation that installs or invokes a VM extension.
+
+Run the pre-flight checks from [references/cannot-connect-to-vm.md — Pre-Flight Safety Checks](references/cannot-connect-to-vm.md#pre-flight-safety-checks) and evaluate:
+
+| Check | Required Value | If Failed |
+| ----- | -------------- | --------- |
+| VM power state | `PowerState/running` | Start the VM first |
+| VM provisioning state | `ProvisioningState/succeeded` | Do NOT run extension commands. Wait for current operation to complete, or use Serial Console / offline repair |
+| VM agent status | `Ready` | Do NOT run extension commands. Use Serial Console or offline repair instead |
+| Existing extensions | No extensions in `Creating`, `Updating`, or `Deleting` state | Do NOT add new extensions. Wait for completion, remove stuck extensions via Portal, or use Serial Console |
+
+> 💡 **Tip:** If any check returns `null`, empty, or the CLI command itself errors, treat the result as **unsafe**.
+
+**If any check fails:**
+1. **Stop.** Do NOT attempt any extension-backed remediation.
+2. **Inform the user** which check(s) failed and what the current state is.
+3. **Suggest non-agent alternatives:** Serial Console, offline repair VM, or Portal-based actions.
+4. If the state appears transient (e.g., VM just started), wait 30–60 seconds and **re-run the pre-flight checks** — do not run the extension command until all checks pass.
 
 ### Phase 3: Fetch Documentation
 
@@ -87,8 +128,8 @@ Combine the fetched documentation with the quick commands from the reference fil
 If the symptom doesn't match any solution in the reference file, or the fix doesn't resolve the issue:
 
 1. Check Azure Resource Health: `az vm get-instance-view --name <vm> -g <rg> --query "instanceView.statuses" -o table`
-2. Try restart: `az vm restart --name <vm> -g <rg>`
-3. Try redeploy: `az vm redeploy --name <vm> -g <rg>`
+2. Offer to restart the VM (requires user approval): `az vm restart --name <vm> -g <rg>`
+3. Offer to redeploy the VM (requires user approval — moves to new host): `az vm redeploy --name <vm> -g <rg>`
 4. Fetch the comprehensive guide: [Troubleshoot RDP connections](https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/windows/troubleshoot-rdp-connection) or [Troubleshoot SSH connections](https://learn.microsoft.com/en-us/troubleshoot/azure/virtual-machines/linux/troubleshoot-ssh-connection)
 
 ---
@@ -102,6 +143,8 @@ If the symptom doesn't match any solution in the reference file, or the fix does
 | Run Command times out                  | VM agent not responding         | Route to "VM Agent Not Responding" section in reference file                       |
 | Serial Console not available           | Boot diagnostics not enabled    | Run `az vm boot-diagnostics enable` first                                          |
 | Password reset fails                   | VMAccess extension error        | Check reference file for VMAccess alternatives (offline reset, Serial Console)     |
+| VM stuck in "Updating" after extension op | Extension deadlocked the VM agent | Do NOT add more extensions. Remove stuck extensions via Portal, then restart. See [Pre-Flight Safety Checks](references/cannot-connect-to-vm.md#pre-flight-safety-checks) |
+| `VMAgentStatusCommunicationError`      | Agent not reporting status      | Do NOT run extension commands. Use Serial Console or offline repair VM             |
 
 ---
 


### PR DESCRIPTION
Add guardrails and pre-flight safety checks to prevent running extension-backed commands (az vm user update, az vm run-command invoke, etc.) on VMs with unhealthy agents or stuck extensions.

Changes:
- Add Guardrails and Evidence Order sections to vm-troubleshooter.md
- Add Phase 2.5: Pre-Flight Safety Checks (mandatory gate before extension-backed operations)
- Add pre-flight CLI commands and safe/unsafe decision table to cannot-connect-to-vm.md
- Add warning callouts and extension markers to all 6 sub-reference Quick Commands blocks
- Add error handling rows for agent deadlock scenarios
- Require user approval for restart/redeploy in escalation paths
- Bump version from 2.1.0 to 2.2.0

## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [x] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [x] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [x] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
