### PR TITLE
Log estimated tool response token count

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -263,6 +263,9 @@ function generateMarkdownReport(config: AgentRunConfig, agentMetadata: AgentMeta
           if (result) {
             const durationSec = (new Date(result.timestamp).getTime() - new Date(event.timestamp).getTime()) / 1000;
             lines.push(`duration: ${durationSec.toFixed(3)} sec`);
+            // Copilot SDK truncates the tool response if it's too long
+            // Record the estimated token count for what it sends to the LLM
+            lines.push(`estimated llm token count: ${((result?.content ?? result?.error)?.length ?? 0) / 4}`);
             if (result.success && result.content) {
               let content = result.content;
               if (content.length > 500) {


### PR DESCRIPTION
## Description

Log estimated tool response token count to find opportunities for token usage optimization.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
