### PR TITLE
Adjust azure-compute minimum tool call rate

### DIFF
--- a/tests/azure-compute/integration.test.ts
+++ b/tests/azure-compute/integration.test.ts
@@ -68,10 +68,11 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           RECOMMENDER_WORKFLOW_PATH,
         );
         if (!result) return;
-        const rate = result.skillInvocationCount / RUNS_PER_PROMPT;
-        setSkillInvocationRate(rate);
-        expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-        expect(result.toolCallCount).toBe(RUNS_PER_PROMPT);
+        const skillInvocationRate = result.skillInvocationCount / RUNS_PER_PROMPT;
+        setSkillInvocationRate(skillInvocationRate);
+        expect(skillInvocationRate).toBeGreaterThanOrEqual(invocationRateThreshold);
+        const referenceViewRate = result.toolCallCount / RUNS_PER_PROMPT;
+        expect(referenceViewRate).toBeGreaterThanOrEqual(invocationRateThreshold);
       });
     });
 
@@ -85,7 +86,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         const rate = result.skillInvocationCount / RUNS_PER_PROMPT;
         setSkillInvocationRate(rate);
         expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-        expect(result.toolCallCount).toBe(RUNS_PER_PROMPT);
+        const referenceViewRate = result.toolCallCount / RUNS_PER_PROMPT;
+        expect(referenceViewRate).toBeGreaterThanOrEqual(invocationRateThreshold);
       });
     });
 
@@ -99,7 +101,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         const rate = result.skillInvocationCount / RUNS_PER_PROMPT;
         setSkillInvocationRate(rate);
         expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-        expect(result.toolCallCount).toBe(RUNS_PER_PROMPT);
+        const referenceViewRate = result.toolCallCount / RUNS_PER_PROMPT;
+        expect(referenceViewRate).toBeGreaterThanOrEqual(invocationRateThreshold);
       });
     });
 
@@ -113,7 +116,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         const rate = result.skillInvocationCount / RUNS_PER_PROMPT;
         setSkillInvocationRate(rate);
         expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-        expect(result.toolCallCount).toBe(RUNS_PER_PROMPT);
+        const referenceViewRate = result.toolCallCount / RUNS_PER_PROMPT;
+        expect(referenceViewRate).toBeGreaterThanOrEqual(invocationRateThreshold);
       });
     });
 
@@ -127,7 +131,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         const rate = result.skillInvocationCount / RUNS_PER_PROMPT;
         setSkillInvocationRate(rate);
         expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-        expect(result.toolCallCount).toBe(RUNS_PER_PROMPT);
+        const referenceViewRate = result.toolCallCount / RUNS_PER_PROMPT;
+        expect(referenceViewRate).toBeGreaterThanOrEqual(invocationRateThreshold);
       });
     });
 
@@ -141,7 +146,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         const rate = result.skillInvocationCount / RUNS_PER_PROMPT;
         setSkillInvocationRate(rate);
         expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-        expect(result.toolCallCount).toBe(RUNS_PER_PROMPT);
+        const referenceViewRate = result.toolCallCount / RUNS_PER_PROMPT;
+        expect(referenceViewRate).toBeGreaterThanOrEqual(invocationRateThreshold);
       });
     });
 
@@ -155,7 +161,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         const rate = result.skillInvocationCount / RUNS_PER_PROMPT;
         setSkillInvocationRate(rate);
         expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-        expect(result.toolCallCount).toBe(RUNS_PER_PROMPT);
+        const referenceViewRate = result.toolCallCount / RUNS_PER_PROMPT;
+        expect(referenceViewRate).toBeGreaterThanOrEqual(invocationRateThreshold);
       });
     });
   });


### PR DESCRIPTION
## Description

Bring the required minimum reference file view rate to be the same as the required minimum skill invocation rate.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
