### PR TITLE
Add Deploy Scenario Retry Table to Dashboard

### DIFF
--- a/dashboard/api/src/functions/getTestResults.ts
+++ b/dashboard/api/src/functions/getTestResults.ts
@@ -135,16 +135,18 @@ function collectAgentMetadataPaths(
  * Counts tool.execution_start events for powershell/bash tools whose command
  * matches azd up, azd deploy, or terraform apply.
  *
- * @returns max(0, deployInvocations - 1)
+ * Returns null when the input cannot be parsed or contains no events array,
+ * so callers can distinguish invalid/unreadable files from a genuine 0-retry run.
+ * @returns max(0, deployInvocations - 1), or null for invalid input
  */
-function countDeployRetries(raw: string): number {
+function countDeployRetries(raw: string): number | null {
     let parsed: { events?: Array<{ type: string; data?: { toolName?: string; arguments?: { command?: string } } }> };
     try {
         parsed = JSON.parse(raw);
     } catch {
-        return 0;
+        return null;
     }
-    if (!Array.isArray(parsed.events)) return 0;
+    if (!Array.isArray(parsed.events)) return null;
 
     let deployCount = 0;
     for (const event of parsed.events) {
@@ -321,6 +323,7 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
             retryFetchTasks.push(
                 getBlobContent(blobPath).then((raw) => {
                     const retries = countDeployRetries(raw);
+                    if (retries === null) return; // invalid/unreadable — don't skew the average
                     deployRetryTotals.set(
                         testCaseName,
                         (deployRetryTotals.get(testCaseName) ?? 0) + retries,

--- a/dashboard/api/src/functions/getTestResults.ts
+++ b/dashboard/api/src/functions/getTestResults.ts
@@ -313,22 +313,34 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
     await Promise.all(reportFetchTasks);
 
     // Fetch agent-metadata.json files for azure-deploy scenario retry counts
-    const deployRetryCounts = new Map<string, number>();
+    const deployRetryTotals = new Map<string, number>();
+    const deployRetryRunCounts = new Map<string, number>();
     const retryFetchTasks: Promise<void>[] = [];
     for (const [testCaseName, paths] of agentMetadataPathsByTestCase) {
         for (const blobPath of paths) {
             retryFetchTasks.push(
                 getBlobContent(blobPath).then((raw) => {
                     const retries = countDeployRetries(raw);
-                    deployRetryCounts.set(
+                    deployRetryTotals.set(
                         testCaseName,
-                        (deployRetryCounts.get(testCaseName) ?? 0) + retries,
+                        (deployRetryTotals.get(testCaseName) ?? 0) + retries,
+                    );
+                    deployRetryRunCounts.set(
+                        testCaseName,
+                        (deployRetryRunCounts.get(testCaseName) ?? 0) + 1,
                     );
                 }).catch(() => { /* skip unreadable files */ }),
             );
         }
     }
     await Promise.all(retryFetchTasks);
+
+    // Average retries per run to avoid inflating counts when a scenario fires across multiple runs
+    const deployRetryCounts = new Map<string, number>();
+    for (const [testCaseName, total] of deployRetryTotals) {
+        const runCount = deployRetryRunCounts.get(testCaseName) ?? 1;
+        deployRetryCounts.set(testCaseName, total / runCount);
+    }
 
     // Compute statistics per skill
     const skillTestResults: SkillTestResults = {};

--- a/dashboard/api/src/functions/getTestResults.ts
+++ b/dashboard/api/src/functions/getTestResults.ts
@@ -32,6 +32,13 @@ export interface SkillStats {
     passedTests: TestCase[];
     /** Average Confidence extracted from SKILL-REPORT.md files (0–100), or null if not available. */
     averageConfidence: number | null;
+    /**
+     * Maps sanitised test-case directory names to the number of agent runs recorded
+     * for that test case (i.e. the number of agent-metadata-*.md files found).
+     * Populated only for the azure-deploy skill; skill-invocation tests are excluded.
+     * A value greater than 1 means the test case required retries.
+     */
+    scenarioAgentRunCounts?: Record<string, number>;
 }
 
 export type SkillTestResults = Record<string, SkillStats>;
@@ -77,6 +84,48 @@ function collectSkillReportPaths(
     for (const child of Object.values(node.children)) {
         collectSkillReportPaths(child, skillName, results);
     }
+}
+
+/**
+ * Count agent-metadata markdown files (agent-metadata-*.md) per leaf test-case
+ * directory for any skill node that has scenario test groups.
+ *
+ * Traverses two levels deep:
+ *  Level 1 – testGroup directory (e.g. "vanilla-static-web-apps-deploy")
+ *  Level 2 – testCase directory  (e.g. "azure-deploy_-_Integration_Tests_...")
+ *
+ * The "skill-invocation" test group is excluded because only scenario tests
+ * are relevant for retry tracking.
+ *
+ * @param skillNode  The BlobTreeNode for the skill (e.g. azure-deploy)
+ * @returns Map of testCaseDirName → agent run count
+ */
+function collectScenarioAgentRunCounts(skillNode: BlobTreeNode): Map<string, number> {
+    const counts = new Map<string, number>();
+
+    for (const [groupName, groupNode] of Object.entries(skillNode.children)) {
+        if (groupName === "skill-invocation") continue;
+
+        // Level 2: test-case directories under a test-group directory
+        for (const [testCaseName, testCaseNode] of Object.entries(groupNode.children)) {
+            const metaCount = testCaseNode.files.filter(
+                f => /^agent-metadata-.*\.md$/i.test(f.name),
+            ).length;
+            if (metaCount > 0) {
+                counts.set(testCaseName, (counts.get(testCaseName) ?? 0) + metaCount);
+            }
+        }
+
+        // Level 1 fallback: some skills store agent-metadata directly under the group
+        const directMeta = groupNode.files.filter(
+            f => /^agent-metadata-.*\.md$/i.test(f.name),
+        ).length;
+        if (directMeta > 0) {
+            counts.set(groupName, (counts.get(groupName) ?? 0) + directMeta);
+        }
+    }
+
+    return counts;
 }
 
 /**
@@ -178,11 +227,27 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
     // Structure: date -> runId -> skillName -> (files | children with testResults.json)
     const pathsBySkill = new Map<string, string[]>();
     const reportPathsBySkill = new Map<string, string[]>();
+    // Accumulate agent-run counts for deploy scenario tests across all runs
+    const agentRunCountsBySkill = new Map<string, Map<string, number>>();
 
     for (const runNode of Object.values(dateNode.children)) {
         for (const [skillName, skillNode] of Object.entries(runNode.children)) {
             collectTestResultPaths(skillNode, skillName, pathsBySkill);
             collectSkillReportPaths(skillNode, skillName, reportPathsBySkill);
+
+            // Collect scenario agent-run counts for the azure-deploy skill
+            if (skillName === "azure-deploy") {
+                const runCounts = collectScenarioAgentRunCounts(skillNode);
+                if (runCounts.size > 0) {
+                    if (!agentRunCountsBySkill.has(skillName)) {
+                        agentRunCountsBySkill.set(skillName, new Map());
+                    }
+                    const existing = agentRunCountsBySkill.get(skillName)!;
+                    for (const [testCase, count] of runCounts) {
+                        existing.set(testCase, (existing.get(testCase) ?? 0) + count);
+                    }
+                }
+            }
         }
     }
 
@@ -233,6 +298,10 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
         const confValues = confidenceBySkill.get(skillName);
         if (confValues && confValues.length > 0) {
             stats.averageConfidence = confValues.reduce((a, b) => a + b, 0) / confValues.length;
+        }
+        const runCounts = agentRunCountsBySkill.get(skillName);
+        if (runCounts && runCounts.size > 0) {
+            stats.scenarioAgentRunCounts = Object.fromEntries(runCounts);
         }
         skillTestResults[skillName] = stats;
     }

--- a/dashboard/api/src/functions/getTestResults.ts
+++ b/dashboard/api/src/functions/getTestResults.ts
@@ -33,12 +33,13 @@ export interface SkillStats {
     /** Average Confidence extracted from SKILL-REPORT.md files (0–100), or null if not available. */
     averageConfidence: number | null;
     /**
-     * Maps sanitised test-case directory names to the number of agent runs recorded
-     * for that test case (i.e. the number of agent-metadata-*.md files found).
+     * Maps sanitised test-case directory names to the number of deployment retries
+     * recorded for that test case within a single agent run.
+     * A retry is counted each time a deploy command (azd up, azd deploy, terraform apply)
+     * is invoked after the first attempt within the same agent session.
      * Populated only for the azure-deploy skill; skill-invocation tests are excluded.
-     * A value greater than 1 means the test case required retries.
      */
-    scenarioAgentRunCounts?: Record<string, number>;
+    scenarioDeployRetryCounts?: Record<string, number>;
 }
 
 export type SkillTestResults = Record<string, SkillStats>;
@@ -86,46 +87,76 @@ function collectSkillReportPaths(
     }
 }
 
-/**
- * Count agent-metadata markdown files (agent-metadata-*.md) per leaf test-case
- * directory for any skill node that has scenario test groups.
- *
- * Traverses two levels deep:
- *  Level 1 – testGroup directory (e.g. "vanilla-static-web-apps-deploy")
- *  Level 2 – testCase directory  (e.g. "azure-deploy_-_Integration_Tests_...")
- *
- * The "skill-invocation" test group is excluded because only scenario tests
- * are relevant for retry tracking.
- *
- * @param skillNode  The BlobTreeNode for the skill (e.g. azure-deploy)
- * @returns Map of testCaseDirName → agent run count
- */
-function collectScenarioAgentRunCounts(skillNode: BlobTreeNode): Map<string, number> {
-    const counts = new Map<string, number>();
+const AGENT_METADATA_JSON = "agent-metadata.json";
 
+/**
+ * Regex matching deploy commands that constitute a deployment attempt:
+ * azd up, azd deploy, terraform apply.
+ */
+const DEPLOY_COMMAND_PATTERN = /\bazd\s+(?:up|deploy)\b|\bterraform\s+apply\b/i;
+
+/**
+ * Collect agent-metadata.json blob paths for each scenario test case directory
+ * under the given skill node.
+ *
+ * The agent-metadata.json file is excluded from blob enumeration, so its path
+ * is derived from any other file present in the same directory.
+ *
+ * The "skill-invocation" group is excluded.
+ *
+ * @param skillNode  BlobTreeNode for the skill (e.g. azure-deploy)
+ * @param results    Accumulates testCaseDirName → list of agent-metadata.json blob paths
+ */
+function collectAgentMetadataPaths(
+    skillNode: BlobTreeNode,
+    results: Map<string, string[]>,
+): void {
     for (const [groupName, groupNode] of Object.entries(skillNode.children)) {
         if (groupName === "skill-invocation") continue;
 
         // Level 2: test-case directories under a test-group directory
         for (const [testCaseName, testCaseNode] of Object.entries(groupNode.children)) {
-            const metaCount = testCaseNode.files.filter(
-                f => /^agent-metadata-.*\.md$/i.test(f.name),
-            ).length;
-            if (metaCount > 0) {
-                counts.set(testCaseName, (counts.get(testCaseName) ?? 0) + metaCount);
+            // Derive the agent-metadata.json path from any sibling file in the directory
+            const anchor = testCaseNode.files[0];
+            if (!anchor) continue;
+            const jsonPath = anchor.blobName.replace(/\/[^/]+$/, `/${AGENT_METADATA_JSON}`);
+            if (!results.has(testCaseName)) {
+                results.set(testCaseName, []);
             }
-        }
-
-        // Level 1 fallback: some skills store agent-metadata directly under the group
-        const directMeta = groupNode.files.filter(
-            f => /^agent-metadata-.*\.md$/i.test(f.name),
-        ).length;
-        if (directMeta > 0) {
-            counts.set(groupName, (counts.get(groupName) ?? 0) + directMeta);
+            results.get(testCaseName)!.push(jsonPath);
         }
     }
+}
 
-    return counts;
+/**
+ * Parse an agent-metadata.json string and count deployment retries.
+ *
+ * A retry is any deploy command invocation after the first within the session.
+ * Counts tool.execution_start events for powershell/bash tools whose command
+ * matches azd up, azd deploy, or terraform apply.
+ *
+ * @returns max(0, deployInvocations - 1)
+ */
+function countDeployRetries(raw: string): number {
+    let parsed: { events?: Array<{ type: string; data?: { toolName?: string; arguments?: { command?: string } } }> };
+    try {
+        parsed = JSON.parse(raw);
+    } catch {
+        return 0;
+    }
+    if (!Array.isArray(parsed.events)) return 0;
+
+    let deployCount = 0;
+    for (const event of parsed.events) {
+        if (event.type !== "tool.execution_start") continue;
+        const toolName = event.data?.toolName;
+        if (toolName !== "powershell" && toolName !== "bash") continue;
+        const command = event.data?.arguments?.command ?? "";
+        if (DEPLOY_COMMAND_PATTERN.test(command)) {
+            deployCount++;
+        }
+    }
+    return Math.max(0, deployCount - 1);
 }
 
 /**
@@ -227,26 +258,16 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
     // Structure: date -> runId -> skillName -> (files | children with testResults.json)
     const pathsBySkill = new Map<string, string[]>();
     const reportPathsBySkill = new Map<string, string[]>();
-    // Accumulate agent-run counts for deploy scenario tests across all runs
-    const agentRunCountsBySkill = new Map<string, Map<string, number>>();
+    // Collect agent-metadata.json paths for deploy scenario retry counting
+    const agentMetadataPathsByTestCase = new Map<string, string[]>();
 
     for (const runNode of Object.values(dateNode.children)) {
         for (const [skillName, skillNode] of Object.entries(runNode.children)) {
             collectTestResultPaths(skillNode, skillName, pathsBySkill);
             collectSkillReportPaths(skillNode, skillName, reportPathsBySkill);
 
-            // Collect scenario agent-run counts for the azure-deploy skill
             if (skillName === "azure-deploy") {
-                const runCounts = collectScenarioAgentRunCounts(skillNode);
-                if (runCounts.size > 0) {
-                    if (!agentRunCountsBySkill.has(skillName)) {
-                        agentRunCountsBySkill.set(skillName, new Map());
-                    }
-                    const existing = agentRunCountsBySkill.get(skillName)!;
-                    for (const [testCase, count] of runCounts) {
-                        existing.set(testCase, (existing.get(testCase) ?? 0) + count);
-                    }
-                }
+                collectAgentMetadataPaths(skillNode, agentMetadataPathsByTestCase);
             }
         }
     }
@@ -291,6 +312,24 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
     }
     await Promise.all(reportFetchTasks);
 
+    // Fetch agent-metadata.json files for azure-deploy scenario retry counts
+    const deployRetryCounts = new Map<string, number>();
+    const retryFetchTasks: Promise<void>[] = [];
+    for (const [testCaseName, paths] of agentMetadataPathsByTestCase) {
+        for (const blobPath of paths) {
+            retryFetchTasks.push(
+                getBlobContent(blobPath).then((raw) => {
+                    const retries = countDeployRetries(raw);
+                    deployRetryCounts.set(
+                        testCaseName,
+                        (deployRetryCounts.get(testCaseName) ?? 0) + retries,
+                    );
+                }).catch(() => { /* skip unreadable files */ }),
+            );
+        }
+    }
+    await Promise.all(retryFetchTasks);
+
     // Compute statistics per skill
     const skillTestResults: SkillTestResults = {};
     for (const [skillName, results] of rawBySkill) {
@@ -299,9 +338,8 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
         if (confValues && confValues.length > 0) {
             stats.averageConfidence = confValues.reduce((a, b) => a + b, 0) / confValues.length;
         }
-        const runCounts = agentRunCountsBySkill.get(skillName);
-        if (runCounts && runCounts.size > 0) {
-            stats.scenarioAgentRunCounts = Object.fromEntries(runCounts);
+        if (skillName === "azure-deploy" && deployRetryCounts.size > 0) {
+            stats.scenarioDeployRetryCounts = Object.fromEntries(deployRetryCounts);
         }
         skillTestResults[skillName] = stats;
     }

--- a/dashboard/assets/dashboard.js
+++ b/dashboard/assets/dashboard.js
@@ -1653,12 +1653,11 @@ async function loadDeployScenarioRetries() {
     }
 
     const deployStats = skillResults["azure-deploy"];
-    const counts = (deployStats && deployStats.scenarioAgentRunCounts) || {};
+    const counts = (deployStats && deployStats.scenarioDeployRetryCounts) || {};
 
-    const rows = Object.entries(counts).map(function ([name, runs]) {
-      // Strip the leading "…_-_Integration_Tests_" prefix and replace underscores
+    const rows = Object.entries(counts).map(function ([name, retries]) {
       const label = name.replace(/^.*?_-_Integration_Tests_/i, "").replace(/_/g, " ");
-      return { label, runs: /** @type {number} */ (runs), retries: /** @type {number} */ (runs) - 1 };
+      return { label, retries: /** @type {number} */ (retries) };
     });
 
     rows.sort(function (a, b) {
@@ -1678,8 +1677,8 @@ async function loadDeployScenarioRetries() {
 /**
  * Populate and finalise the deploy scenario retries panel.
  * @param {HTMLElement} section
- * @param {Array<{label:string, runs:number, retries:number}>} rows
- * @param {string} overallStatus - pass | warn | skip
+ * @param {Array<{label:string, retries:number}>} rows
+ * @param {string} overallStatus - pass | warn | fail | skip
  * @param {string|null} dateLabel
  */
 function renderDeployRetriesPanel(section, rows, overallStatus, dateLabel) {
@@ -1716,12 +1715,9 @@ function renderDeployRetriesPanel(section, rows, overallStatus, dateLabel) {
     const headerRow = el("tr");
     const thScenario = el("th", undefined, "Test Scenario");
     thScenario.setAttribute("scope", "col");
-    const thRuns = el("th", "deploy-retries-num-col", "Agent Runs");
-    thRuns.setAttribute("scope", "col");
     const thRetries = el("th", "deploy-retries-num-col", "Retries");
     thRetries.setAttribute("scope", "col");
     headerRow.appendChild(thScenario);
-    headerRow.appendChild(thRuns);
     headerRow.appendChild(thRetries);
     thead.appendChild(headerRow);
     table.appendChild(thead);
@@ -1735,7 +1731,6 @@ function renderDeployRetriesPanel(section, rows, overallStatus, dateLabel) {
       else if (row.retries > 0) tr.className = "deploy-retries-row-warn";
 
       const tdName = el("td", "deploy-retries-name", row.label);
-      const tdRuns = el("td", "deploy-retries-num-col", String(row.runs));
       const tdRetries = el("td", "deploy-retries-num-col deploy-retries-count");
       tdRetries.textContent = String(row.retries);
       if (row.retries >= 3) {
@@ -1747,7 +1742,6 @@ function renderDeployRetriesPanel(section, rows, overallStatus, dateLabel) {
       }
 
       tr.appendChild(tdName);
-      tr.appendChild(tdRuns);
       tr.appendChild(tdRetries);
       tbody.appendChild(tr);
     }

--- a/dashboard/assets/dashboard.js
+++ b/dashboard/assets/dashboard.js
@@ -1634,6 +1634,153 @@ function renderConfidenceLevelPanel(
   createItemFilter(section);
 }
 
+// ── Deploy Scenario Retries Panel ───────────────────────────────────────────
+
+/**
+ * Fetch the latest integration test results and render the retry count for
+ * each azure-deploy scenario test case on the main dashboard.
+ */
+async function loadDeployScenarioRetries() {
+  const section = document.getElementById("panel-deploy-retries");
+  if (!section) return;
+
+  try {
+    const { latestDate, skillResults } = await fetchLatestTestResults();
+
+    if (!latestDate) {
+      renderDeployRetriesPanel(section, [], "skip", null);
+      return;
+    }
+
+    const deployStats = skillResults["azure-deploy"];
+    const counts = (deployStats && deployStats.scenarioAgentRunCounts) || {};
+
+    const rows = Object.entries(counts).map(function ([name, runs]) {
+      // Strip the leading "…_-_Integration_Tests_" prefix and replace underscores
+      const label = name.replace(/^.*?_-_Integration_Tests_/i, "").replace(/_/g, " ");
+      return { label, runs: /** @type {number} */ (runs), retries: /** @type {number} */ (runs) - 1 };
+    });
+
+    rows.sort(function (a, b) {
+      return b.retries - a.retries || a.label.localeCompare(b.label);
+    });
+
+    const hasFailing = rows.some(function (r) { return r.retries >= 3; });
+    const hasWarning = rows.some(function (r) { return r.retries > 0 && r.retries < 3; });
+    const overallStatus = rows.length === 0 ? "skip" : hasFailing ? "fail" : hasWarning ? "warn" : "pass";
+
+    renderDeployRetriesPanel(section, rows, overallStatus, latestDate);
+  } catch {
+    renderDeployRetriesPanel(section, [], "skip", null);
+  }
+}
+
+/**
+ * Populate and finalise the deploy scenario retries panel.
+ * @param {HTMLElement} section
+ * @param {Array<{label:string, runs:number, retries:number}>} rows
+ * @param {string} overallStatus - pass | warn | skip
+ * @param {string|null} dateLabel
+ */
+function renderDeployRetriesPanel(section, rows, overallStatus, dateLabel) {
+  const summaryEl = section.querySelector(".panel-summary");
+  const itemsEl = section.querySelector(".panel-items");
+  if (!summaryEl || !itemsEl) return;
+
+  summaryEl.textContent = "";
+  itemsEl.textContent = "";
+
+  const total = rows.length;
+  const failing = rows.filter(function (r) { return r.retries >= 3; }).length;
+  const warning = rows.filter(function (r) { return r.retries > 0 && r.retries < 3; }).length;
+  const withRetries = failing + warning;
+  const noRetries = total - withRetries;
+
+  if (total === 0) {
+    itemsEl.appendChild(el("p", "no-data-message", "No deploy scenario data available."));
+  } else {
+    // Summary stat boxes
+    const statsRow = el("div", "stats-row");
+    statsRow.appendChild(statBox(total, "Scenarios"));
+    if (withRetries > 0) {
+      statsRow.appendChild(statBox(withRetries, "With retries"));
+    }
+    statsRow.appendChild(statBox(noRetries, "No retries"));
+    summaryEl.appendChild(statsRow);
+
+    // Table
+    const table = el("table", "deploy-retries-table");
+    table.setAttribute("aria-label", "Deploy scenario retry counts");
+
+    const thead = el("thead");
+    const headerRow = el("tr");
+    const thScenario = el("th", undefined, "Test Scenario");
+    thScenario.setAttribute("scope", "col");
+    const thRuns = el("th", "deploy-retries-num-col", "Agent Runs");
+    thRuns.setAttribute("scope", "col");
+    const thRetries = el("th", "deploy-retries-num-col", "Retries");
+    thRetries.setAttribute("scope", "col");
+    headerRow.appendChild(thScenario);
+    headerRow.appendChild(thRuns);
+    headerRow.appendChild(thRetries);
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+
+    const tbody = el("tbody");
+    for (const row of rows) {
+      const rowStatus = row.retries >= 3 ? "fail" : row.retries > 0 ? "warn" : "pass";
+      const tr = el("tr");
+      tr.setAttribute("data-item-status", rowStatus);
+      if (row.retries >= 3) tr.className = "deploy-retries-row-fail";
+      else if (row.retries > 0) tr.className = "deploy-retries-row-warn";
+
+      const tdName = el("td", "deploy-retries-name", row.label);
+      const tdRuns = el("td", "deploy-retries-num-col", String(row.runs));
+      const tdRetries = el("td", "deploy-retries-num-col deploy-retries-count");
+      tdRetries.textContent = String(row.retries);
+      if (row.retries >= 3) {
+        tdRetries.classList.add("deploy-retries-fail");
+      } else if (row.retries > 0) {
+        tdRetries.classList.add("deploy-retries-nonzero");
+      } else {
+        tdRetries.classList.add("deploy-retries-zero");
+      }
+
+      tr.appendChild(tdName);
+      tr.appendChild(tdRuns);
+      tr.appendChild(tdRetries);
+      tbody.appendChild(tr);
+    }
+    table.appendChild(tbody);
+    itemsEl.appendChild(table);
+  }
+
+  section.classList.add("loaded");
+  section.setAttribute("data-category-status", overallStatus);
+
+  var summaryText = total === 0
+    ? "No data"
+    : failing > 0
+      ? failing + " scenario" + (failing !== 1 ? "s" : "") + " failed (\u22653 retries)"
+        + (warning > 0 ? ", " + warning + " warned" : "")
+      : withRetries > 0
+        ? withRetries + " scenario" + (withRetries !== 1 ? "s" : "") + " needed retries"
+        : "No retries \u2014 all scenarios passed first try";
+  if (dateLabel) summaryText += " \u2014 " + dateLabel;
+  section.setAttribute("data-summary-text", summaryText);
+
+  var fakeCategory = {
+    status: overallStatus,
+    summary: { total: total, passed: noRetries, failed: failing, warnings: warning, skipped: 0 },
+    items: rows.map(function (r) {
+      return { name: r.label, status: r.retries >= 3 ? "fail" : r.retries > 0 ? "warn" : "pass" };
+    }),
+  };
+
+  setupCollapsible(section, fakeCategory, "deploy-retries");
+  createItemFilter(section);
+}
+
 // ── Initialization ──────────────────────────────────────────────────────────
 
 async function init() {
@@ -1680,4 +1827,5 @@ document.addEventListener("DOMContentLoaded", function () {
   loadSkillInvocationRates();
   loadE2EPassRates();
   loadConfidenceLevelPerSkill();
+  loadDeployScenarioRetries();
 });

--- a/dashboard/assets/style.css
+++ b/dashboard/assets/style.css
@@ -901,6 +901,71 @@ button.header-status-pill {
   color: var(--color-fail);
 }
 
+/* === Deploy Scenario Retries Table === */
+
+.deploy-retries-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+  margin-top: 4px;
+}
+
+.deploy-retries-table th {
+  text-align: left;
+  padding: 4px 8px;
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--color-text-muted);
+  font-weight: 600;
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+}
+
+.deploy-retries-table td {
+  padding: 5px 8px;
+  border-bottom: 1px solid var(--color-border);
+  vertical-align: middle;
+}
+
+.deploy-retries-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.deploy-retries-row-warn {
+  background: color-mix(in srgb, var(--color-warn) 10%, transparent);
+}
+
+.deploy-retries-row-fail {
+  background: color-mix(in srgb, var(--color-fail) 10%, transparent);
+}
+
+.deploy-retries-name {
+  color: var(--color-text);
+  word-break: break-word;
+}
+
+.deploy-retries-num-col {
+  font-family: ui-monospace, "SF Mono", "Fira Code", "Cascadia Code", monospace;
+  text-align: right;
+  white-space: nowrap;
+  padding-left: 1.5rem !important;
+}
+
+.deploy-retries-nonzero {
+  color: var(--color-warn);
+  font-weight: 700;
+}
+
+.deploy-retries-fail {
+  color: var(--color-fail);
+  font-weight: 700;
+}
+
+.deploy-retries-zero {
+  color: var(--color-text-muted);
+}
+
 /* === Responsive === */
 @media (max-width: 480px) {
   .panel-grid {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -100,6 +100,14 @@
         <div class="panel-items"></div>
         <p class="loading-text">Loading...</p>
       </section>
+
+      <section class="panel" id="panel-deploy-retries" role="region" aria-label="Deploy Scenario Retries">
+        <h2>Deploy Scenario Retries</h2>
+        <div class="panel-status"></div>
+        <div class="panel-summary"></div>
+        <div class="panel-items"></div>
+        <p class="loading-text">Loading...</p>
+      </section>
     </div>
 
     <div class="sr-only" aria-live="polite" id="live-region"></div>


### PR DESCRIPTION
## Description

Added a table to the Dashboard that shows the number of retries per scenario, and flags cases where retries is >= 3
<img width="500" height="987" alt="image" src="https://github.com/user-attachments/assets/f84feda6-aa6e-40db-8581-087e45849653" />

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
