### PR TITLE
azure-deploy: make azd show mandatory after deployment

### DIFF
--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute Azure deployments for ALREADY-PREPARED applications that h
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.19"
+  version: "1.0.20"
 ---
 
 # Azure Deploy

--- a/plugin/skills/azure-deploy/references/recipes/azd/verify.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/verify.md
@@ -42,18 +42,20 @@ Expected: HTTP 200 response.
 
 > ⛔ **MANDATORY** — You **MUST** present the deployed endpoint URLs to the user in your response. A deployment is not considered complete until the user has received the URLs.
 
-Extract all endpoints from the `azd up` / `azd deploy` output or by running:
+> ⛔ **ALWAYS run `azd show`** after deployment to extract endpoint URLs. Do NOT rely on the `azd deploy` output alone — it is frequently truncated before endpoint URLs appear.
 
 ```bash
 azd show
 ```
 
+Parse the `Endpoint:` lines from the `azd show` output to collect all deployed service URLs.
+
 **Present a summary to the user that includes:**
 
 | Item | Source |
 |------|--------|
-| Deployed service endpoint(s) | `Endpoint:` lines from `azd` output or `azd show` |
-| Aspire Dashboard URL (if applicable) | `Aspire Dashboard:` line from `azd` output |
+| Deployed service endpoint(s) | `Endpoint:` lines from `azd show` |
+| Aspire Dashboard URL (if applicable) | `Aspire Dashboard:` line from `azd show` |
 | Azure Portal deployment link (if available) | Portal URL from provisioning output |
 
 Example response format:
@@ -67,8 +69,6 @@ Example response format:
 
 Aspire Dashboard: https://aspire-dashboard.xxx.azurecontainerapps.io
 ```
-
-> ⚠️ If output was truncated, run `azd show` to retrieve endpoint URLs.
 
 > ⚠️ **Always use fully-qualified URLs with the `https://` scheme.** If a command returns a bare hostname (e.g. `myapp.azurestaticapps.net`), prepend `https://` before presenting it to the user.
 


### PR DESCRIPTION
## Summary

The `azd deploy` output is frequently truncated before endpoint URLs appear, causing integration tests to fail (`hasDeployLinks` returns false). This was the root cause of both #1881 and #1882.

## Changes

In `verify.md`, changed `azd show` from a conditional fallback ("if output was truncated") to a **mandatory** post-deploy step with a `⛔` callout. This ensures endpoint URLs are always reliably captured regardless of `azd deploy` output truncation.

## Files changed

- `plugin/skills/azure-deploy/references/recipes/azd/verify.md` — mandatory `azd show` step
- `plugin/skills/azure-deploy/SKILL.md` — version bump to 1.0.20

## Validation

- `npm run frontmatter` ✅
- `npm run references` ✅