### PR TITLE
Add --no-prompt to azd env new commands to prevent interactive blocking

### DIFF
--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute Azure deployments for ALREADY-PREPARED applications that h
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.19"
+  version: "1.0.20"
 ---
 
 # Azure Deploy

--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute Azure deployments for ALREADY-PREPARED applications that h
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.20"
+  version: "1.0.21"
 ---
 
 # Azure Deploy

--- a/plugin/skills/azure-deploy/references/pre-deploy-checklist.md
+++ b/plugin/skills/azure-deploy/references/pre-deploy-checklist.md
@@ -47,12 +47,12 @@ ask_user(
 
 **For new projects (no azure.yaml):**
 ```bash
-azd init -e <environment-name>
+azd init -e <environment-name> --no-prompt
 ```
 
 **For existing projects (azure.yaml exists):**
 ```bash
-azd env new <environment-name>
+azd env new <environment-name> --no-prompt
 ```
 
 Both commands create:
@@ -97,7 +97,7 @@ az resource list --resource-group rg-<env-name> --tag azd-service-name=<service-
 
 Check for each service in `azure.yaml`. If duplicates exist **in the target RG**:
 
-1. **Preferred — Fresh environment**: Run `azd env new <new-name>` and restart from Step 4. Non-destructive, no user confirmation needed, avoids orphan risks.
+1. **Preferred — Fresh environment**: Run `azd env new <new-name> --no-prompt` and restart from Step 4. Non-destructive, no user confirmation needed, avoids orphan risks.
 2. **Alternative — Delete conflicts**: Use `ask_user` to confirm deletion of old resources (required by global rules).
 
 ## Step 5a: Check for Existing Container Apps Environments (Container Apps only)
@@ -155,14 +155,14 @@ ask_user(
      ```
    - **If the environment does NOT exist locally** (e.g., it was provisioned on a different machine or has been cleaned up), create it and configure it to target the existing resource group:
      ```bash
-     azd env new <matching-env-name>
+     azd env new <matching-env-name> --no-prompt
      azd env set AZURE_SUBSCRIPTION_ID <subscription-id>
      azd env set AZURE_LOCATION <location-of-existing-rg>
      ```
 
 2. **Choose a different name** — Create a new AZD environment:
    ```bash
-   azd env new <new-unique-env-name>
+   azd env new <new-unique-env-name> --no-prompt
    azd env set AZURE_SUBSCRIPTION_ID <subscription-id>
    # Then restart from Step 4 with the new environment name
    ```
@@ -241,7 +241,7 @@ fi
 
 ```bash
 # 1. Create environment FIRST
-azd env new myapp-dev
+azd env new myapp-dev --no-prompt
 
 # 2. Set subscription
 azd env set AZURE_SUBSCRIPTION_ID 25fd0362-...
@@ -261,7 +261,7 @@ azd up --no-prompt
 | ❌ Wrong | ✅ Correct |
 |----------|-----------|
 | `azd up --location eastus2` | `azd env set AZURE_LOCATION eastus2` then `azd up` |
-| Running `azd up` without environment | `azd env new <name>` first |
+| Running `azd up` without environment | `azd env new <name> --no-prompt` first |
 | Assuming location without checking RG | Check `az group show` before choosing |
 | Ignoring tag conflicts in target RG | Check `az resource list --resource-group rg-<env-name>` before deploy |
 | Skipping Container Apps environment check | Run `az containerapp env list --resource-group rg-<env-name>` before deploy (Step 5a) |

--- a/plugin/skills/azure-deploy/references/recipes/azd/README.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/README.md
@@ -35,7 +35,7 @@ Deploy to Azure using Azure Developer CLI (azd).
 |----------|-------------|
 | `azd up --location eastus2` | `--location` is not a valid flag for `azd up` |
 | `azd up` without `azd env new` | Prompts for input, fails with `--no-prompt` |
-| `mkdir .azure` then `azd env new` | Creates env folder structure incorrectly |
+| `mkdir .azure` then `azd env new --no-prompt` | Creates env folder structure incorrectly |
 | Setting AZURE_LOCATION without checking RG | "Invalid resource group location" if RG exists elsewhere |
 | Ignoring `azd-service-name` tag conflicts in same RG | "found '2' resources tagged with..." error |
 | `language: html` or `language: static` | Not valid - use `language: js` with `dist: .` for static sites |

--- a/plugin/skills/azure-deploy/references/recipes/azd/errors.md
+++ b/plugin/skills/azure-deploy/references/recipes/azd/errors.md
@@ -18,7 +18,7 @@ These errors occur **during** `azd up` execution:
 | `map has no entry for key "AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID"` | Missing managed identity env vars | See [Missing Container Registry Variables](#missing-container-registry-variables) |
 | `map has no entry for key "MANAGED_IDENTITY_CLIENT_ID"` | Missing managed identity client ID | See [Missing Container Registry Variables](#missing-container-registry-variables) |
 | `Operation expired` / revision creation timeout (900s) | RBAC propagation delay — Container App's managed identity doesn't have `AcrPull` on ACR yet | See [Container App Revision Timeout](#container-app-revision-timeout) |
-| `found '2' resources tagged with 'azd-service-name: <name>'` | Previous deployment left duplicate-tagged resources in same RG | **Preferred**: Create fresh env with `azd env new <new-name>`, set subscription/location, redeploy. **Alternative**: Delete conflicting resources (requires `ask_user`). |
+| `found '2' resources tagged with 'azd-service-name: <name>'` | Previous deployment left duplicate-tagged resources in same RG | **Preferred**: Create fresh env with `azd env new <new-name> --no-prompt`, set subscription/location, redeploy. **Alternative**: Delete conflicting resources (requires `ask_user`). |
 | Literal `{{ .Env.* }}` in Terraform errors | azd does not interpolate template variables in `.tfvars.json` | See [Unresolved Terraform Template Variables](#unresolved-terraform-template-variables) |
 
 > ℹ️ **Pre-flight validation**: Run `azure-validate` before deployment to catch configuration errors early. See [Pre-Deploy Checklist](../../pre-deploy-checklist.md).

--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -4,7 +4,7 @@ description: "Prepare Azure apps for deployment (infra Bicep/Terraform, azure.ya
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.1.16"
+  version: "1.1.17"
 ---
 
 # Azure Prepare

--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -4,7 +4,7 @@ description: "Prepare Azure apps for deployment (infra Bicep/Terraform, azure.ya
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.1.19"
+  version: "1.1.20"
 ---
 
 # Azure Prepare

--- a/plugin/skills/azure-prepare/references/azure-context.md
+++ b/plugin/skills/azure-prepare/references/azure-context.md
@@ -142,7 +142,7 @@ After confirmation, record in `.azure/deployment-plan.md`:
 
 ## Step 6: Apply to AZD Environment
 
-> **⛔ CRITICAL for Aspire and azd projects**: After user confirms subscription and location, you **MUST** set these values in the azd environment immediately after running `azd init` or `azd env new`.
+> **⛔ CRITICAL for Aspire and azd projects**: After user confirms subscription and location, you **MUST** set these values in the azd environment immediately after running `azd init` or `azd env new`. Always use `--no-prompt` with these commands to prevent interactive prompts from blocking execution.
 >
 > **DO NOT** wait until validation or deployment. The Azure CLI and azd maintain separate configuration contexts.
 
@@ -150,7 +150,7 @@ After confirmation, record in `.azure/deployment-plan.md`:
 
 ```bash
 # 1. Run azd init
-azd init --from-code -e <environment-name>
+azd init --from-code -e <environment-name> --no-prompt
 
 # 2. IMMEDIATELY set the user-confirmed subscription
 azd env set AZURE_SUBSCRIPTION_ID <subscription-id>
@@ -166,7 +166,7 @@ azd env get-values
 
 ```bash
 # 1. Create environment
-azd env new <environment-name>
+azd env new <environment-name> --no-prompt
 
 # 2. IMMEDIATELY set the user-confirmed subscription
 azd env set AZURE_SUBSCRIPTION_ID <subscription-id>

--- a/plugin/skills/azure-prepare/references/recipes/azd/terraform.md
+++ b/plugin/skills/azure-prepare/references/recipes/azd/terraform.md
@@ -230,7 +230,7 @@ resource "azurerm_resource_group" "main" {
 
 ```bash
 # 1. Create azd environment
-azd env new dev
+azd env new dev --no-prompt
 
 # 2. Set required variables
 azd env set AZURE_LOCATION eastus2

--- a/plugin/skills/azure-validate/SKILL.md
+++ b/plugin/skills/azure-validate/SKILL.md
@@ -4,7 +4,7 @@ description: "Pre-deployment validation for Azure readiness. Run deep checks on 
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.4"
+  version: "1.0.5"
 ---
 
 # Azure Validate

--- a/plugin/skills/azure-validate/references/recipes/azd/environment.md
+++ b/plugin/skills/azure-validate/references/recipes/azd/environment.md
@@ -70,7 +70,7 @@ Would you like to use this name or enter a custom one?
 
 After user confirms:
 ```bash
-azd env new <environment-name>
+azd env new <environment-name> --no-prompt
 ```
 
 ---

--- a/plugin/skills/azure-validate/references/recipes/azd/errors.md
+++ b/plugin/skills/azure-validate/references/recipes/azd/errors.md
@@ -7,8 +7,8 @@ These errors can be caught **before** running `azd up`:
 | Error | Cause | Resolution |
 |-------|-------|------------|
 | `Please run 'az login'` | Not authenticated | `az login` or `azd auth login` |
-| `No environment selected` | Missing azd environment | `azd env select <name>` or `azd env new <name>` |
-| `no default response for prompt 'Enter a unique environment name'` | No azd environment created, or missing `-e` flag | Run `azd env new <name>` OR use `azd init --from-code -e <name>` with the `-e` flag |
+| `No environment selected` | Missing azd environment | `azd env select <name>` or `azd env new <name> --no-prompt` |
+| `no default response for prompt 'Enter a unique environment name'` | No azd environment created, or missing `-e` flag | Run `azd env new <name> --no-prompt` OR use `azd init --from-code -e <name> --no-prompt` with the `-e` flag |
 | `no default response for prompt 'Enter a value for the 'environmentName'` | Environment variables not set | Run `azd env set AZURE_ENV_NAME <name>` |
 | `Service not found` | Service name mismatch | Check service name in azure.yaml |
 | `Invalid azure.yaml` | YAML syntax error | Fix YAML syntax |


### PR DESCRIPTION
Fixes #1884

## Problem

`azd env new` triggers an interactive prompt ("Set new environment as default? (y/N)") when an existing azd environment is present. During the flask calculator integration test, retry cycles created new environments which hit this prompt, blocking the session for 30+ minutes until timeout.

## Fix

Added `--no-prompt` flag to all `azd env new` and `azd init` commands across 3 skills:

- **azure-deploy** (v1.0.19 → v1.0.20): `pre-deploy-checklist.md` (7 instances), `recipes/azd/README.md`, `recipes/azd/errors.md`
- **azure-validate** (v1.0.4 → v1.0.5): `recipes/azd/environment.md`, `recipes/azd/errors.md`
- **azure-prepare** (v1.1.16 → v1.1.17): `azure-context.md`, `recipes/azd/terraform.md`

## Validation

- `npm run frontmatter` ✅
- `npm run references` ✅