### PR TITLE
Add directory creation guidance and Terraform cycle error handling

### DIFF
--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -4,7 +4,7 @@ description: "Prepare Azure apps for deployment (infra Bicep/Terraform, azure.ya
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.1.16"
+  version: "1.1.17"
 ---
 
 # Azure Prepare

--- a/plugin/skills/azure-prepare/references/generate.md
+++ b/plugin/skills/azure-prepare/references/generate.md
@@ -89,6 +89,20 @@ project-root/
 └── azure.yaml (AZD only)
 ```
 
+### Directory Creation
+
+> ⚠️ **Warning:** The `create` tool fails with `Parent directory does not exist` when intermediate directories are missing. Always create the full directory tree before writing files.
+
+**Before creating nested files** (e.g., `src/frontend/src/App.jsx`), create all parent directories first:
+
+```bash
+mkdir -p src/frontend/src src/api
+```
+
+- Use **absolute paths** in `mkdir -p` when the working directory may differ from the project root
+- Create directories for **all components** in a single command before writing any files
+- Do **not** rely on the `create` tool to create parent directories — it will not
+
 ### Security Requirements
 
 - No hardcoded secrets

--- a/plugin/skills/azure-validate/SKILL.md
+++ b/plugin/skills/azure-validate/SKILL.md
@@ -4,7 +4,7 @@ description: "Pre-deployment validation for Azure readiness. Run deep checks on 
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.4"
+  version: "1.0.5"
 ---
 
 # Azure Validate

--- a/plugin/skills/azure-validate/references/recipes/terraform/errors.md
+++ b/plugin/skills/azure-validate/references/recipes/terraform/errors.md
@@ -6,7 +6,7 @@
 | `Provider version conflict` | Update required_providers |
 | `State lock failed` | Wait or force unlock |
 | `Validation failed` | Check terraform validate output |
-| `Error: Cycle` | See [Cycle Errors](#cycle-errors) below |
+| `Error: Cycle:` | See [Cycle Errors](#cycle-errors) below |
 
 ## Cycle Errors
 
@@ -42,18 +42,26 @@ resource "azurerm_linux_web_app" "frontend" {
 
 ### Fix Strategies
 
-**Option A (recommended):** Break the cycle by using a wildcard or removing one side of the cross-reference. Set CORS to allow all origins and configure the specific origin post-deployment:
+**Option A (recommended):** Use a Terraform variable for the frontend origin so CORS is restrictive by default and the cycle is broken. Define the variable with a sensible default and pass the real frontend URL after the first deployment:
 
 ```hcl
+variable "frontend_origin" {
+  type        = string
+  description = "Frontend origin for API CORS. Set after first deployment."
+  default     = ""
+}
+
 resource "azurerm_linux_web_app" "api" {
   site_config {
     cors {
-      allowed_origins     = ["*"]
-      support_credentials = false
+      allowed_origins     = var.frontend_origin != "" ? [var.frontend_origin] : ["*"]
+      support_credentials = var.frontend_origin != "" ? true : false
     }
   }
 }
 ```
+
+> ⚠️ **Warning:** If using `["*"]` as a temporary bootstrap value, you **must** set `frontend_origin` to the actual URL (e.g., `https://app-web-*.azurewebsites.net`) and re-run `terraform apply` in the same deployment session before reporting success. Do not leave wildcard CORS in a completed deployment.
 
 **Option B:** Use `azurerm_app_service_custom_hostname_binding` or a `null_resource` with a `local-exec` provisioner to configure CORS after both resources are created, breaking the dependency chain.
 

--- a/plugin/skills/azure-validate/references/recipes/terraform/errors.md
+++ b/plugin/skills/azure-validate/references/recipes/terraform/errors.md
@@ -6,6 +6,64 @@
 | `Provider version conflict` | Update required_providers |
 | `State lock failed` | Wait or force unlock |
 | `Validation failed` | Check terraform validate output |
+| `Error: Cycle` | See [Cycle Errors](#cycle-errors) below |
+
+## Cycle Errors
+
+`terraform validate` reports a cycle when two or more resources reference each other's attributes, creating a circular dependency.
+
+### Common Pattern: CORS Cross-Reference
+
+Multi-service App Service deployments often introduce a cycle when the API's CORS configuration references the frontend hostname and the frontend's app settings reference the API hostname:
+
+```
+Error: Cycle: azurerm_linux_web_app.frontend, azurerm_linux_web_app.api
+```
+
+**Cause — circular attribute references:**
+
+```hcl
+# API references frontend.default_hostname in CORS
+resource "azurerm_linux_web_app" "api" {
+  site_config {
+    cors {
+      allowed_origins = ["https://${azurerm_linux_web_app.frontend.default_hostname}"]
+    }
+  }
+}
+
+# Frontend references api.default_hostname in app_settings
+resource "azurerm_linux_web_app" "frontend" {
+  app_settings = {
+    API_URL = "https://${azurerm_linux_web_app.api.default_hostname}"
+  }
+}
+```
+
+### Fix Strategies
+
+**Option A (recommended):** Break the cycle by using a wildcard or removing one side of the cross-reference. Set CORS to allow all origins and configure the specific origin post-deployment:
+
+```hcl
+resource "azurerm_linux_web_app" "api" {
+  site_config {
+    cors {
+      allowed_origins     = ["*"]
+      support_credentials = false
+    }
+  }
+}
+```
+
+**Option B:** Use `azurerm_app_service_custom_hostname_binding` or a `null_resource` with a `local-exec` provisioner to configure CORS after both resources are created, breaking the dependency chain.
+
+**Option C:** Use `lifecycle { ignore_changes = [site_config[0].cors] }` on the API resource and configure CORS via a separate `azurerm_web_app_active_slot` or post-deployment script.
+
+### After Fixing
+
+1. Run `terraform fmt -recursive` to fix formatting
+2. Re-run `terraform validate` to confirm the cycle is resolved
+3. Run `terraform plan` to verify the configuration is correct
 
 ## Debug
 


### PR DESCRIPTION
Addresses two root causes from integration test failure #1886 (azure-deploy todo list Terraform App Service timeout).

## Fix 1: Directory creation guidance (azure-prepare)
The agent repeatedly failed to create frontend files because the create tool does not create parent directories. After 8 failed attempts it fell back to bash heredocs, wasting time.

Added a Directory Creation section to references/generate.md warning agents to mkdir -p all component directories before writing nested files.

## Fix 2: Terraform cycle error handling (azure-validate)
terraform validate caught a cycle error caused by CORS cross-references, but the agent made 3 broken edit attempts before fixing it because errors.md had no guidance for cycle errors.

Expanded references/recipes/terraform/errors.md with the common CORS cross-reference cycle pattern, three fix strategies, and post-fix verification steps.

## Version bumps
- azure-prepare: 1.1.16 -> 1.1.17
- azure-validate: 1.0.4 -> 1.0.5

## Validation
- npm run frontmatter: All 33 skills passed
- npm run references: All 24 skills passed

Fixes #1886