### PR TITLE
azure-deploy: add non-user principal RBAC pre-deploy check

### DIFF
--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute Azure deployments for ALREADY-PREPARED applications that h
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.19"
+  version: "1.0.20"
 ---
 
 # Azure Deploy

--- a/plugin/skills/azure-deploy/SKILL.md
+++ b/plugin/skills/azure-deploy/SKILL.md
@@ -4,7 +4,7 @@ description: "Execute Azure deployments for ALREADY-PREPARED applications that h
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.20"
+  version: "1.0.21"
 ---
 
 # Azure Deploy

--- a/plugin/skills/azure-deploy/references/pre-deploy-checklist.md
+++ b/plugin/skills/azure-deploy/references/pre-deploy-checklist.md
@@ -374,6 +374,63 @@ Only after this check confirms `AcrPull` has propagated should you run `azd depl
 
 ---
 
+### AZD/Bicep — Non-User Principal RBAC Fix
+
+> **⛔ MANDATORY**: If the deploying identity is NOT an interactive user (e.g., service principal in CI/CD), you **MUST** check and patch Bicep templates that hardcode user-type RBAC role assignments. Skipping this causes `PrincipalType` mismatch errors during provisioning, leading to costly retry loops and potential test timeouts.
+
+This check is **required** when ALL of the following are true:
+- The deployment uses AZD with Bicep infrastructure
+- The deploying identity is not an interactive user (service principal, managed identity, etc.)
+- The Bicep templates contain `allowUserIdentityPrincipal` set to `true` or role assignments with `principalType: 'User'`
+
+> ⚠️ **Known affected templates:** `functions-quickstart-python-http-azd` and other AZD quickstart templates that include optional user-identity RBAC. See [Principal Type Mismatch](recipes/azd/errors.md#principal-type-mismatch) for details.
+
+**Step A — Detect the deploying identity type:**
+
+```bash
+AUTH_TYPE=$(az account show --query user.type -o tsv)
+echo "Auth type: $AUTH_TYPE"
+```
+
+**PowerShell:**
+```powershell
+$AuthType = az account show --query user.type -o tsv
+Write-Output "Auth type: $AuthType"
+```
+
+If `AUTH_TYPE` is `user`, skip to the next section — no fix needed.
+
+**Step B — Search for user-type RBAC in Bicep templates:**
+
+```bash
+grep -rn "allowUserIdentityPrincipal" infra/ --include='*.bicep'
+```
+
+**PowerShell:**
+```powershell
+Select-String -Path infra\*.bicep -Pattern 'allowUserIdentityPrincipal' -Recurse
+```
+
+If no matches are found, skip to the next section.
+
+**Step C — Patch `allowUserIdentityPrincipal` to `false`:**
+
+For each match where `allowUserIdentityPrincipal` is set to `true`, change it to `false`:
+
+```bicep
+// Before (fails with service principal deployments):
+allowUserIdentityPrincipal: true
+
+// After (CI/CD compatible):
+allowUserIdentityPrincipal: false
+```
+
+> ⚠️ **This is a CI/CD compatibility patch.** Setting this to `false` disables optional interactive-user RBAC role assignments. The application's managed identity roles are unaffected. If the user later needs local interactive access, they can re-enable this flag or assign roles manually.
+
+> ⚠️ **Do NOT** attempt to fix this by clearing `AZURE_PRINCIPAL_ID`. The `azd` CLI repopulates this value from the current auth context on every run.
+
+---
+
 ### Durable Functions — Verify DTS Backend
 
 > **⛔ MANDATORY**: If the plan includes Durable Functions, verify infrastructure uses **Durable Task Scheduler** (DTS), NOT Azure Storage.


### PR DESCRIPTION
Add a mandatory pre-deploy checklist section that detects when the deploying identity is not an interactive user (e.g., service principal in CI/CD) and patches Bicep templates that hardcode `allowUserIdentityPrincipal: true`. This prevents `PrincipalType` mismatch errors during provisioning that caused the `vanilla-azure-functions-deploy` integration test to timeout.

## Changes

- **`pre-deploy-checklist.md`**: New "AZD/Bicep — Non-User Principal RBAC Fix" section with 3-step detection and patching flow (detect identity type → search Bicep templates → patch `allowUserIdentityPrincipal`)
- **`SKILL.md`**: Version bump 1.0.19 → 1.0.20

Fixes #1906