### PR TITLE
Increase toolCallBudget of some hosted-copilot-sdk invocation tests

### DIFF
--- a/tests/azure-hosted-copilot-sdk/integration.test.ts
+++ b/tests/azure-hosted-copilot-sdk/integration.test.ts
@@ -97,7 +97,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         const rate = await measureInvocationRate(agent, SKILL_NAME, {
           setup: setupCopilotSdkApp,
           prompt: "Deploy this app to Azure",
-          shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME),
+          shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME, 10),
         }, "existing-sdk-deploy", RUNS_PER_PROMPT);
         if (rate >= 0) {
           setSkillInvocationRate(rate);
@@ -112,7 +112,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         const rate = await measureInvocationRate(agent, SKILL_NAME, {
           setup: setupCopilotSdkApp,
           prompt: "Add a new feature to this app that summarizes pull requests",
-          shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME),
+          shouldEarlyTerminate: (agentMetadata) => shouldEarlyTerminateForSkillInvocation(agentMetadata, SKILL_NAME, 10),
         }, "existing-sdk-modify", RUNS_PER_PROMPT);
         if (rate >= 0) {
           setSkillInvocationRate(rate);

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -311,7 +311,7 @@ export async function withTestResult(fn: (ctx: WithTestResultContext) => Promise
   }
 }
 
-export function shouldEarlyTerminateForSkillInvocation(agentMetadata: AgentMetadata, skillName: string): boolean {
+export function shouldEarlyTerminateForSkillInvocation(agentMetadata: AgentMetadata, skillName: string, toolCallBudget?: number): boolean {
   const shouldEarlyTerminateForInvokedSkill = isSkillInvoked(agentMetadata, skillName);
   if (shouldEarlyTerminateForInvokedSkill) {
     const earlyTerminateComment = `✅ ${skillName} is invoked as expected. Terminating the agent run early.`;
@@ -323,7 +323,7 @@ export function shouldEarlyTerminateForSkillInvocation(agentMetadata: AgentMetad
     return true;
   }
 
-  const shouldEarlyTerminateForTooLate = getToolCalls(agentMetadata).length > maxToolCallBeforeSkillInvocationTerminate;
+  const shouldEarlyTerminateForTooLate = getToolCalls(agentMetadata).length > (toolCallBudget ?? maxToolCallBeforeSkillInvocationTerminate);
   if (shouldEarlyTerminateForTooLate) {
     agentMetadata.testComments.push(`⚠️ ${skillName} is not invoked within early tool calls. Terminating the agent run early.`);
     return true;


### PR DESCRIPTION
## Description

The modified tests expect the agent to view the codebase to find out it needs to invoke the azure-hosted-copilot-sdk skill. Reading files in the workspace uses tool calls. The default 3 tool call budget is not enough for the agent to read the files and invoke the skill. Extending it to 10.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
