### PR TITLE
Fix false positive in deployment command detection for heredoc content

### DIFF
--- a/tests/utils/__tests__/evaluate.test.ts
+++ b/tests/utils/__tests__/evaluate.test.ts
@@ -191,4 +191,43 @@ azd provision --preview`;
     expect(result).not.toContain("azd deploy");
     expect(result).toContain("azd provision --preview");
   });
+
+  test("bash << heredoc does not match indented delimiter", () => {
+    // With plain <<, the closing delimiter must be at column 0
+    const command = `cat << EOF
+azd up
+  EOF
+azd deploy
+EOF
+azd provision`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).not.toContain("azd deploy");
+    // "  EOF" (indented) should NOT close the heredoc — only bare "EOF" does
+    expect(result).toContain("azd provision");
+  });
+
+  test("bash <<- heredoc strips only leading tabs from delimiter", () => {
+    const command = `cat <<-EOF
+\tazd up
+\tEOF
+azd provision`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).toContain("azd provision");
+  });
+
+  test("PS here-string closer must be at column 0", () => {
+    // Indented '@ should NOT close the here-string
+    const command = `$x = @'
+azd up
+  '@
+azd deploy
+'@
+azd provision`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).not.toContain("azd deploy");
+    expect(result).toContain("azd provision");
+  });
 });

--- a/tests/utils/__tests__/evaluate.test.ts
+++ b/tests/utils/__tests__/evaluate.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Tests for evaluate utility — specifically the stripNonExecutableContent function
+ * which filters out heredoc bodies, comments, and other non-command content
+ * before shell command pattern matching.
+ */
+
+import { stripNonExecutableContent } from "../evaluate";
+
+describe("stripNonExecutableContent", () => {
+  test("passes through simple commands unchanged", () => {
+    expect(stripNonExecutableContent("azd up")).toBe("azd up");
+    expect(stripNonExecutableContent("azd deploy --all")).toBe("azd deploy --all");
+    expect(stripNonExecutableContent("mkdir -p src && npm install")).toBe("mkdir -p src && npm install");
+  });
+
+  test("strips single-quoted heredoc body", () => {
+    const command = `cat > README.md << 'EOF'
+# My App
+Run: azd up
+Deploy: azd deploy
+EOF
+echo done`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).not.toContain("azd deploy");
+    expect(result).toContain("echo done");
+    expect(result).toContain("cat > README.md ");
+  });
+
+  test("strips double-quoted heredoc body", () => {
+    const command = `cat > file.txt << "MARKER"
+azd up --no-prompt
+MARKER`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+  });
+
+  test("strips unquoted heredoc body", () => {
+    const command = `cat > file.txt << EOF
+azd deploy
+EOF`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd deploy");
+  });
+
+  test("strips heredoc with dash (<<-) for tab stripping", () => {
+    const command = `cat > file.txt <<-END
+\tazd up
+\tEND`;
+    // Note: <<- strips leading tabs from content AND delimiter
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+  });
+
+  test("handles delimiter with hyphens", () => {
+    const command = `cat > file.txt << 'END-MARK'
+azd up
+END-MARK`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+  });
+
+  test("preserves commands after heredoc ends", () => {
+    const command = `cat > README.md << 'EOF'
+azd up
+EOF
+azd provision --preview`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).toContain("azd provision --preview");
+  });
+
+  test("handles multiple heredocs in sequence", () => {
+    const command = `cat > file1.txt << 'EOF1'
+azd up
+EOF1
+cat > file2.txt << 'EOF2'
+azd deploy
+EOF2
+azd provision`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).not.toContain("azd deploy");
+    expect(result).toContain("azd provision");
+  });
+
+  test("strips shell comment lines", () => {
+    const command = `# This runs azd up to deploy
+azd provision --preview`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).toContain("azd provision --preview");
+  });
+
+  test("preserves shebangs", () => {
+    const command = `#!/bin/bash
+azd provision`;
+    const result = stripNonExecutableContent(command);
+    expect(result).toContain("#!/bin/bash");
+    expect(result).toContain("azd provision");
+  });
+
+  test("handles the exact failing scenario from issue 1930", () => {
+    // This is the actual command that caused the false positive
+    const command = `cat > /tmp/skill-test-Fjv9Xq/README.md << 'EOF'
+# Containerized Web Application
+
+## Deployment to Azure
+
+### First Time Setup
+
+1. Login to Azure:
+\`\`\`bash
+azd auth login
+\`\`\`
+
+2. Provision infrastructure and deploy:
+\`\`\`bash
+azd up
+\`\`\`
+
+### Subsequent Deployments
+
+To deploy code changes:
+\`\`\`bash
+azd deploy
+\`\`\`
+EOF`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).not.toContain("azd deploy");
+    // The cat > file part before the heredoc is preserved
+    expect(result).toContain("cat > /tmp/skill-test-Fjv9Xq/README.md ");
+  });
+});

--- a/tests/utils/__tests__/evaluate.test.ts
+++ b/tests/utils/__tests__/evaluate.test.ts
@@ -132,4 +132,51 @@ EOF`;
     // The cat > file part before the heredoc is preserved
     expect(result).toContain("cat > /tmp/skill-test-Fjv9Xq/README.md ");
   });
+
+  test("comment with heredoc syntax does not enter heredoc mode", () => {
+    // A commented-out example must not swallow subsequent real commands
+    const command = `# example: cat <<EOF
+azd provision --preview
+echo done`;
+    const result = stripNonExecutableContent(command);
+    expect(result).toContain("azd provision --preview");
+    expect(result).toContain("echo done");
+    expect(result).not.toContain("example");
+  });
+
+  test("strips PowerShell single-quoted here-string", () => {
+    const command = `$readme = @'
+azd up
+azd deploy
+'@
+Write-Host "done"`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).not.toContain("azd deploy");
+    expect(result).toContain('Write-Host "done"');
+  });
+
+  test("strips PowerShell double-quoted here-string", () => {
+    const command = `$content = @"
+Run azd up to deploy
+Run azd deploy for updates
+"@
+Set-Content -Path README.md -Value $content`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).not.toContain("azd deploy");
+    expect(result).toContain("Set-Content");
+  });
+
+  test("preserves real PowerShell commands around here-strings", () => {
+    const command = `azd env set FOO bar
+$x = @'
+azd up
+'@
+azd provision --preview`;
+    const result = stripNonExecutableContent(command);
+    expect(result).toContain("azd env set FOO bar");
+    expect(result).not.toContain("azd up");
+    expect(result).toContain("azd provision --preview");
+  });
 });

--- a/tests/utils/__tests__/evaluate.test.ts
+++ b/tests/utils/__tests__/evaluate.test.ts
@@ -179,4 +179,16 @@ azd provision --preview`;
     expect(result).not.toContain("azd up");
     expect(result).toContain("azd provision --preview");
   });
+
+  test("handles PowerShell here-string closer with trailing content", () => {
+    const command = `$msg = @'
+azd up
+azd deploy
+'@ + " suffix"
+azd provision --preview`;
+    const result = stripNonExecutableContent(command);
+    expect(result).not.toContain("azd up");
+    expect(result).not.toContain("azd deploy");
+    expect(result).toContain("azd provision --preview");
+  });
 });

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -5,7 +5,49 @@ import { type AgentMetadata } from "./agent-runner";
 const SHELL_TOOL_NAMES = ["powershell", "bash"];
 
 /**
+ * Strip content that is not actually executed as shell commands.
+ * Removes heredoc bodies, shell comments, and PowerShell here-strings
+ * so that pattern matching only hits real commands.
+ */
+export function stripNonExecutableContent(command: string): string {
+  const lines = command.split("\n");
+  const result: string[] = [];
+  let heredocDelimiter: string | null = null;
+
+  for (const line of lines) {
+    if (heredocDelimiter !== null) {
+      // Inside a heredoc — check if this line is the closing delimiter
+      if (line.trim() === heredocDelimiter) {
+        heredocDelimiter = null;
+      }
+      continue;
+    }
+
+    // Detect heredoc opener: << or <<- followed by optional quotes around delimiter
+    const heredocMatch = line.match(/<<-?\s*['"]?([A-Za-z_][\w-]*)['"]?/);
+    if (heredocMatch) {
+      heredocDelimiter = heredocMatch[1];
+      // Keep the portion of the line before the heredoc (e.g., `cat > file`)
+      // but strip the heredoc body that follows on subsequent lines
+      result.push(line.substring(0, line.indexOf("<<")));
+      continue;
+    }
+
+    // Skip shell comment lines (but keep shebangs)
+    if (/^\s*#[^!]/.test(line) || /^\s*#$/.test(line)) {
+      continue;
+    }
+
+    result.push(line);
+  }
+
+  return result.join("\n");
+}
+
+/**
  * Extract all shell command strings (powershell and bash) from agent metadata.
+ * Non-executable content (heredoc bodies, comments) is stripped so that
+ * pattern matching via {@link matchesCommand} only matches real commands.
  */
 function getShellCommands(metadata: AgentMetadata): string[] {
   return getToolCalls(metadata)
@@ -13,7 +55,7 @@ function getShellCommands(metadata: AgentMetadata): string[] {
     .map(event => {
       const data = event.data as Record<string, unknown>;
       const args = data.arguments as { command?: string } | undefined;
-      return args?.command ?? "";
+      return stripNonExecutableContent(args?.command ?? "");
     });
 }
 

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -6,35 +6,53 @@ const SHELL_TOOL_NAMES = ["powershell", "bash"];
 
 /**
  * Strip content that is not actually executed as shell commands.
- * Removes heredoc bodies, shell comments, and PowerShell here-strings
+ * Removes bash heredoc bodies, shell comments, and PowerShell here-strings
  * so that pattern matching only hits real commands.
  */
 export function stripNonExecutableContent(command: string): string {
   const lines = command.split("\n");
   const result: string[] = [];
   let heredocDelimiter: string | null = null;
+  let psHereStringCloser: string | null = null;
 
   for (const line of lines) {
+    // Inside a bash heredoc — skip until closing delimiter
     if (heredocDelimiter !== null) {
-      // Inside a heredoc — check if this line is the closing delimiter
       if (line.trim() === heredocDelimiter) {
         heredocDelimiter = null;
       }
       continue;
     }
 
-    // Detect heredoc opener: << or <<- followed by optional quotes around delimiter
+    // Inside a PowerShell here-string — skip until closing marker
+    if (psHereStringCloser !== null) {
+      if (line.trim() === psHereStringCloser) {
+        psHereStringCloser = null;
+      }
+      continue;
+    }
+
+    // Skip shell comment lines before heredoc detection to prevent
+    // commented examples like `# cat <<EOF` from entering heredoc mode
+    if (/^\s*#[^!]/.test(line) || /^\s*#$/.test(line)) {
+      continue;
+    }
+
+    // Detect bash heredoc opener: << or <<- followed by optional quotes around delimiter
     const heredocMatch = line.match(/<<-?\s*['"]?([A-Za-z_][\w-]*)['"]?/);
     if (heredocMatch) {
       heredocDelimiter = heredocMatch[1];
       // Keep the portion of the line before the heredoc (e.g., `cat > file`)
-      // but strip the heredoc body that follows on subsequent lines
       result.push(line.substring(0, line.indexOf("<<")));
       continue;
     }
 
-    // Skip shell comment lines (but keep shebangs)
-    if (/^\s*#[^!]/.test(line) || /^\s*#$/.test(line)) {
+    // Detect PowerShell here-string openers: @' or @" (may appear mid-line after =)
+    const psMatch = line.match(/@(['"])\s*$/);
+    if (psMatch) {
+      psHereStringCloser = `${psMatch[1]}@`;
+      // Keep the portion before the here-string opener
+      result.push(line.substring(0, line.indexOf("@" + psMatch[1])));
       continue;
     }
 

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -28,7 +28,7 @@ export function stripNonExecutableContent(command: string): string {
     // The closer ('@ or "@) must be at the start of a line (possibly indented),
     // but may have trailing content (e.g., '@ + "extra").
     if (psHereStringCloser !== null) {
-      if (new RegExp(`^\\s*${psHereStringCloser.replace(/"/g, "\\\"")}`).test(line)) {
+      if (line.trimStart().startsWith(psHereStringCloser)) {
         psHereStringCloser = null;
       }
       continue;

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -13,22 +13,26 @@ export function stripNonExecutableContent(command: string): string {
   const lines = command.split("\n");
   const result: string[] = [];
   let heredocDelimiter: string | null = null;
+  let heredocAllowTabs = false;
   let psHereStringCloser: string | null = null;
 
   for (const line of lines) {
-    // Inside a bash heredoc — skip until closing delimiter
+    // Inside a bash heredoc — skip until closing delimiter.
+    // For `<<`, the delimiter must appear at column 0 with no surrounding whitespace.
+    // For `<<-`, only leading tabs are stripped before matching.
     if (heredocDelimiter !== null) {
-      if (line.trim() === heredocDelimiter) {
+      const closerLine = heredocAllowTabs ? line.replace(/^\t+/, "") : line;
+      if (closerLine === heredocDelimiter) {
         heredocDelimiter = null;
       }
       continue;
     }
 
     // Inside a PowerShell here-string — skip until closing marker.
-    // The closer ('@ or "@) must be at the start of a line (possibly indented),
-    // but may have trailing content (e.g., '@ + "extra").
+    // PowerShell requires the closer ('@ or "@) at column 0, but may have
+    // trailing content on the same line (e.g., '@ + "extra").
     if (psHereStringCloser !== null) {
-      if (line.trimStart().startsWith(psHereStringCloser)) {
+      if (line.startsWith(psHereStringCloser)) {
         psHereStringCloser = null;
       }
       continue;
@@ -41,9 +45,10 @@ export function stripNonExecutableContent(command: string): string {
     }
 
     // Detect bash heredoc opener: << or <<- followed by optional quotes around delimiter
-    const heredocMatch = line.match(/<<-?\s*['"]?([A-Za-z_][\w-]*)['"]?/);
+    const heredocMatch = line.match(/<<(-?)\s*['"]?([A-Za-z_][\w-]*)['"]?/);
     if (heredocMatch) {
-      heredocDelimiter = heredocMatch[1];
+      heredocAllowTabs = heredocMatch[1] === "-";
+      heredocDelimiter = heredocMatch[2];
       // Keep the portion of the line before the heredoc (e.g., `cat > file`)
       result.push(line.substring(0, line.indexOf("<<")));
       continue;

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -24,9 +24,11 @@ export function stripNonExecutableContent(command: string): string {
       continue;
     }
 
-    // Inside a PowerShell here-string — skip until closing marker
+    // Inside a PowerShell here-string — skip until closing marker.
+    // The closer ('@ or "@) must be at the start of a line (possibly indented),
+    // but may have trailing content (e.g., '@ + "extra").
     if (psHereStringCloser !== null) {
-      if (line.trim() === psHereStringCloser) {
+      if (new RegExp(`^\\s*${psHereStringCloser.replace(/"/g, "\\\"")}`).test(line)) {
         psHereStringCloser = null;
       }
       continue;


### PR DESCRIPTION
## Problem

The `deployment-validation` integration test "terminates at validation for containerized web app on Container Apps" fails with an assertion mismatch at line 214: `expect(deploymentCommandRan).toBe(false)`.

The agent correctly invoked `azure-prepare` and generated all files (including a README.md), but never ran an actual deployment command. The false positive occurs because `hasDeploymentCommand()` matches `azd up` and `azd deploy` inside a bash heredoc (`cat > README.md << 'EOF' ... EOF`) — the regex hits documentation text, not an executable command.

## Fix

Add `stripNonExecutableContent()` to `tests/utils/evaluate.ts` — a line-by-line scanner that removes heredoc bodies and shell comments from command strings before pattern matching. Applied in the shared `getShellCommands()` function so all callers of `matchesCommand()` benefit.

Handles:
- Heredoc variants: `<< 'EOF'`, `<< "EOF"`, `<< EOF`, `<<-EOF`
- Hyphenated delimiters (e.g., `END-MARK`)
- Multiple heredocs in sequence
- Shell comment lines (preserving shebangs)

Add 11 unit tests in `tests/utils/__tests__/evaluate.test.ts` covering all variants plus the exact failing scenario.

Fixes #1930