### PR TITLE
Fix the problem of LinuxFxVersion set on a Windows App Service Plan

### DIFF
--- a/plugin/skills/azure-prepare/SKILL.md
+++ b/plugin/skills/azure-prepare/SKILL.md
@@ -4,7 +4,7 @@ description: "Prepare Azure apps for deployment (infra Bicep/Terraform, azure.ya
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.1.20"
+  version: "1.1.21"
 ---
 
 # Azure Prepare

--- a/plugin/skills/azure-prepare/references/services/app-service/README.md
+++ b/plugin/skills/azure-prepare/references/services/app-service/README.md
@@ -29,6 +29,10 @@ services:
 
 ## Runtime Stacks
 
+> 💡 **Tip:** Prefer Linux App Service Plans for Node.js, Python, and Java. Use Windows only when explicitly required (e.g. .NET Framework). See [Bicep Patterns](bicep.md) for Linux vs Windows configuration.
+
+### Linux (recommended)
+
 | Language | linuxFxVersion |
 |----------|----------------|
 | Node.js 18 | `NODE\|18-lts` |
@@ -36,6 +40,13 @@ services:
 | Python 3.11 | `PYTHON\|3.11` |
 | .NET 8 | `DOTNETCORE\|8.0` |
 | Java 17 | `JAVA\|17-java17` |
+
+### Windows
+
+| Language | Setting |
+|----------|---------|
+| Node.js | `WEBSITE_NODE_DEFAULT_VERSION: '~20'` (app setting) |
+| .NET 8 | Built-in (no extra config) |
 
 ## SKU Selection
 

--- a/plugin/skills/azure-prepare/references/services/app-service/bicep.md
+++ b/plugin/skills/azure-prepare/references/services/app-service/bicep.md
@@ -1,6 +1,19 @@
 # App Service Bicep Patterns
 
-## Basic Resource
+## Linux vs Windows
+
+> ⚠️ **Warning:** `linuxFxVersion` and `reserved: true` are **Linux-only** properties. Setting `linuxFxVersion` on a Windows App Service Plan causes a deployment error: `LinuxFxVersion cannot be set for non-Linux App Service plans`. Omit both for Windows plans.
+
+| Property | Linux | Windows |
+|----------|-------|---------|
+| Plan `reserved` | `true` | omit (defaults to `false`) |
+| Site `kind` | `'app,linux'` | `'app'` |
+| Site `linuxFxVersion` | e.g. `'NODE\|20-lts'` | omit |
+| Site `WEBSITE_NODE_DEFAULT_VERSION` | omit | e.g. `'~20'` |
+
+> 💡 **Tip:** When both frontend and API use Node.js, prefer a **single Linux App Service Plan** for both. This avoids mixed-platform complexity and keeps all services on one plan.
+
+## Linux App Service (Recommended for Node.js)
 
 > ⚠️ **REQUIRED: `azd-service-name` tag** — The `tags` property MUST include `union(tags, { 'azd-service-name': serviceName })` so that `azd deploy` can locate the resource. Without this tag, `azd deploy` fails with `resource not found: unable to find a resource tagged with 'azd-service-name: web'`.
 
@@ -8,26 +21,32 @@
 resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
   name: '${resourcePrefix}-plan-${uniqueHash}'
   location: location
+  kind: 'linux'
   sku: {
     name: 'B1'
     tier: 'Basic'
   }
   properties: {
-    reserved: true  // Linux
+    reserved: true  // Required for Linux
   }
 }
 
 resource webApp 'Microsoft.Web/sites@2022-09-01' = {
   name: '${resourcePrefix}-${serviceName}-${uniqueHash}'
   location: location
+  kind: 'app,linux'
   tags: union(tags, { 'azd-service-name': serviceName })  // REQUIRED for azd deploy
   properties: {
     serverFarmId: appServicePlan.id
     siteConfig: {
-      linuxFxVersion: 'NODE|18-lts'
+      linuxFxVersion: 'NODE|20-lts'
       alwaysOn: true
       healthCheckPath: '/health'
       appSettings: [
+        {
+          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
+          value: 'true'  // Required for source-based Node.js deploys (azd deploy)
+        }
         {
           name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
           value: applicationInsights.properties.ConnectionString
@@ -45,6 +64,61 @@ resource webApp 'Microsoft.Web/sites@2022-09-01' = {
   }
 }
 ```
+
+## Windows App Service
+
+Use when the runtime requires Windows (e.g. .NET Framework) or when explicitly requested.
+
+```bicep
+resource appServicePlan 'Microsoft.Web/serverfarms@2022-09-01' = {
+  name: '${resourcePrefix}-plan-${uniqueHash}'
+  location: location
+  sku: {
+    name: 'B1'
+    tier: 'Basic'
+  }
+  // Do NOT set reserved: true for Windows
+}
+
+resource webApp 'Microsoft.Web/sites@2022-09-01' = {
+  name: '${resourcePrefix}-${serviceName}-${uniqueHash}'
+  location: location
+  kind: 'app'
+  tags: union(tags, { 'azd-service-name': serviceName })  // REQUIRED for azd deploy
+  properties: {
+    serverFarmId: appServicePlan.id
+    siteConfig: {
+      // Do NOT set linuxFxVersion for Windows plans
+      alwaysOn: true
+      healthCheckPath: '/health'
+      appSettings: [
+        {
+          name: 'WEBSITE_NODE_DEFAULT_VERSION'
+          value: '~20'
+        }
+        {
+          name: 'APPLICATIONINSIGHTS_CONNECTION_STRING'
+          value: applicationInsights.properties.ConnectionString
+        }
+        {
+          name: 'ApplicationInsightsAgent_EXTENSION_VERSION'
+          value: '~3'
+        }
+      ]
+    }
+    httpsOnly: true
+  }
+  identity: {
+    type: 'SystemAssigned'
+  }
+}
+```
+
+## Node.js Build Configuration
+
+> ⚠️ **Warning:** For source-based Node.js deployments to App Service (e.g. `azd deploy`), you **must** set `SCM_DO_BUILD_DURING_DEPLOYMENT=true` so App Service runs `npm install` during deployment. Without this, the app fails at runtime with `Cannot find module` errors.
+
+This setting is already included in the Linux example above. For Windows, add it to `appSettings` alongside `WEBSITE_NODE_DEFAULT_VERSION`.
 
 ## Key Vault Integration
 

--- a/plugin/skills/azure-prepare/references/services/app-service/bicep.md
+++ b/plugin/skills/azure-prepare/references/services/app-service/bicep.md
@@ -93,6 +93,10 @@ resource webApp 'Microsoft.Web/sites@2022-09-01' = {
       healthCheckPath: '/health'
       appSettings: [
         {
+          name: 'SCM_DO_BUILD_DURING_DEPLOYMENT'
+          value: 'true'  // Required for source-based Node.js deploys (azd deploy)
+        }
+        {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
           value: '~20'
         }
@@ -118,7 +122,7 @@ resource webApp 'Microsoft.Web/sites@2022-09-01' = {
 
 > ⚠️ **Warning:** For source-based Node.js deployments to App Service (e.g. `azd deploy`), you **must** set `SCM_DO_BUILD_DURING_DEPLOYMENT=true` so App Service runs `npm install` during deployment. Without this, the app fails at runtime with `Cannot find module` errors.
 
-This setting is already included in the Linux example above. For Windows, add it to `appSettings` alongside `WEBSITE_NODE_DEFAULT_VERSION`.
+This setting is already included in both the Linux and Windows examples above.
 
 ## Key Vault Integration
 


### PR DESCRIPTION
## Description

This PR fixes the following two issues:

1. LinuxFxVersion on a Windows App Service Plan

The agent created a Windows plan for the frontend + Linux plan for the API. The Bicep template in plugin/skills/azure-prepare/references/services/app-service/bicep.md only shows Linux patterns (reserved: true,
 linuxFxVersion). There's no guidance for Windows plans, so the agent applied linuxFxVersion to both, causing a deployment error. It self-corrected, but this added an extra provisioning cycle (~5-10 min).

2. Missing SCM_DO_BUILD_DURING_DEPLOYMENT

After deployment, the API returned Cannot find module 'express' because App Service didn't run npm install. The Bicep template doesn't include SCM_DO_BUILD_DURING_DEPLOYMENT: 'true' in default appSettings. The
 agent had to diagnose and fix this post-deployment, adding more time.


## Related Issues

Fixes #1854
