### PR TITLE
refactor: deploy to VNext by default

### DIFF
--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -4,7 +4,7 @@ description: "Deploy, evaluate, and manage Foundry agents end-to-end: Docker bui
 license: MIT
 metadata:
   author: Microsoft
-  version: "1.0.11"
+  version: "1.0.12"
 ---
 
 # Microsoft Foundry Skill

--- a/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
@@ -31,7 +31,7 @@ USE FOR: deploy agent to foundry, push agent to foundry, ship my agent, build an
 | `agent_container_status_get` | Check container running status | `projectEndpoint`, `agentName` (required); `agentVersion` |
 
 ## Workflow: Hosted Agent Deployment
-There are two types of hosted agent - ACA based and vNext. There is only one change in the deployment flow for vNext which is indicated in the steps below. You must use vNext experience only when user explicitly asks you to deploy the agent to vNext (or v2, or v-next, or similar words). For all other cases, use the ACA based deployment flow.
+There are two types of hosted agent - ACA based and vNext. There is only one change in the deployment flow for vNext which is indicated in the steps below. You must use the ACA based deployment flow only when user explicitly asks you to deploy the agent to ACA (or Azure Container Apps, or similar words). For all other cases, use the vNext deployment flow.
 
 
 ### Step 1: Detect and Scan Project


### PR DESCRIPTION
## Description

Deploy agents to VNext by default.

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [x] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [x] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [x] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
