### PR TITLE
Add repo condition to workflows

### DIFF
--- a/.github/workflows/dashboard-collect.yml
+++ b/.github/workflows/dashboard-collect.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   collect-and-upload:
     name: Collect and upload dashboard data
+    if: github.repository == 'microsoft/GitHub-Copilot-for-Azure'
     runs-on: ubuntu-latest
     environment: cideploytest
 

--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   sync-to-microsoft-skills:
+    if: github.repository == 'microsoft/GitHub-Copilot-for-Azure'
     runs-on: ubuntu-latest
 
     steps:
@@ -163,6 +164,7 @@ jobs:
             --body "Automated sync of \`plugin/\` from [GitHub-Copilot-for-Azure](${{ github.server_url }}/${{ github.repository }}) at commit \`${{ github.sha }}\`."
 
   sync-to-microsoft-azure-skills:
+    if: github.repository == 'microsoft/GitHub-Copilot-for-Azure'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Description

This would prevent forked repos that have Action enabled to attempt to run these jobs. Those attempts are pointless since these jobs are only meant for the original repo and depend on its pre-configured secrets.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
