### PR TITLE
Update integration tests which include container app deployment

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -670,7 +670,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: ACR resource
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_registry/i, tfPattern)).toBe(true);
         // Phase 1: Container App with placeholder image, system-assigned identity, and lifecycle ignore_changes
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com\//i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate file from the Container App

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -744,7 +744,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: ACR resource
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_registry/i, tfPattern)).toBe(true);
         // Phase 1: Container App with placeholder image, system-assigned identity, and lifecycle ignore_changes
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate file from the Container App

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -446,7 +446,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: ACR module
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.ContainerRegistry\/registries/i, bicepPattern)).toBe(true);
         // Phase 1: Container App with placeholder image and system-assigned managed identity
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com([^A-Za-z0-9.-]|$)/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate module file from the Container App
         expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -410,7 +410,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: ACR module
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.ContainerRegistry\/registries/i, bicepPattern)).toBe(true);
         // Phase 1: Container App with placeholder image and system-assigned managed identity
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate module file from the Container App
         expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -14,9 +14,9 @@ import {
   getIntegrationSkipReason,
   useAgentRunner,
 } from "../utils/agent-runner";
-import { hasDeployLinks, softCheckDeploySkills, softCheckContainerDeployEnvVars, shouldEarlyTerminateForCompletedDeployment } from "./utils";
+import { hasDeployLinks, softCheckDeploySkills, softCheckContainerDeployEnvVars, shouldEarlyTerminateForCompletedDeployment, shouldEarlyTerminateForAzdProvision } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
-import { expectFiles, softCheckSkill, doesWorkspaceFileIncludePattern, shouldEarlyTerminateForSkillInvocation, isSkillInvoked, withTestResult } from "../utils/evaluate";
+import { expectFiles, softCheckSkill, doesWorkspaceFileIncludePattern, arePatternsInSeparateFiles, shouldEarlyTerminateForSkillInvocation, isSkillInvoked, withTestResult } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-deploy";
 const RUNS_PER_PROMPT = 1;
@@ -394,15 +394,26 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForAzdProvision
         });
 
         softCheckDeploySkills(agentMetadata);
-        const containsDeployLinks = hasDeployLinks(agentMetadata);
-
         expect(workspacePath).toBeDefined();
-        expect(containsDeployLinks).toBe(true);
         expectFiles(workspacePath!, [/infra\/.*\.bicep$/], [/\.tf$/]);
+
+        // Verify Container Apps-specific Bicep content on disk
+        const bicepPattern = /\.bicep$/;
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.App\/containerApps/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.App\/managedEnvironments/i, bicepPattern)).toBe(true);
+
+        // Verify two-phase deployment pattern (three modules in main.bicep):
+        // Phase 1: ACR module
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.ContainerRegistry\/registries/i, bicepPattern)).toBe(true);
+        // Phase 1: Container App with placeholder image and system-assigned managed identity
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
+        // Phase 2: AcrPull role assignment in a separate module file from the Container App
+        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
 
@@ -419,15 +430,26 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForAzdProvision
         });
 
         softCheckDeploySkills(agentMetadata);
-        const containsDeployLinks = hasDeployLinks(agentMetadata);
-
         expect(workspacePath).toBeDefined();
-        expect(containsDeployLinks).toBe(true);
         expectFiles(workspacePath!, [/infra\/.*\.bicep$/], [/\.tf$/]);
+
+        // Verify Container Apps-specific Bicep content on disk
+        const bicepPattern = /\.bicep$/;
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.App\/containerApps/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.App\/managedEnvironments/i, bicepPattern)).toBe(true);
+
+        // Verify two-phase deployment pattern (three modules in main.bicep):
+        // Phase 1: ACR module
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.ContainerRegistry\/registries/i, bicepPattern)).toBe(true);
+        // Phase 1: Container App with placeholder image and system-assigned managed identity
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
+        // Phase 2: AcrPull role assignment in a separate module file from the Container App
+        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
 
@@ -632,15 +654,27 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForAzdProvision
         });
 
         softCheckDeploySkills(agentMetadata);
-        const containsDeployLinks = hasDeployLinks(agentMetadata);
-
         expect(workspacePath).toBeDefined();
-        expect(containsDeployLinks).toBe(true);
         expectFiles(workspacePath!, [/infra\/.*\.tf$/], [/\.bicep$/]);
+
+        // Verify Container Apps-specific Terraform content on disk
+        const tfPattern = /\.tf$/;
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_app[^_]/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_app_environment/i, tfPattern)).toBe(true);
+
+        // Verify two-phase deployment pattern (three resources):
+        // Phase 1: ACR resource
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_registry/i, tfPattern)).toBe(true);
+        // Phase 1: Container App with placeholder image, system-assigned identity, and lifecycle ignore_changes
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
+        // Phase 2: AcrPull role assignment in a separate file from the Container App
+        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
 
@@ -657,15 +691,27 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForAzdProvision
         });
 
         softCheckDeploySkills(agentMetadata);
-        const containsDeployLinks = hasDeployLinks(agentMetadata);
-
         expect(workspacePath).toBeDefined();
-        expect(containsDeployLinks).toBe(true);
         expectFiles(workspacePath!, [/infra\/.*\.tf$/], [/\.bicep$/]);
+
+        // Verify Container Apps-specific Terraform content on disk
+        const tfPattern = /\.tf$/;
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_app[^_]/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_app_environment/i, tfPattern)).toBe(true);
+
+        // Verify two-phase deployment pattern (three resources):
+        // Phase 1: ACR resource
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_registry/i, tfPattern)).toBe(true);
+        // Phase 1: Container App with placeholder image, system-assigned identity, and lifecycle ignore_changes
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
+        // Phase 2: AcrPull role assignment in a separate file from the Container App
+        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
 
@@ -682,15 +728,27 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForAzdProvision
         });
 
         softCheckDeploySkills(agentMetadata);
-        const containsDeployLinks = hasDeployLinks(agentMetadata);
-
         expect(workspacePath).toBeDefined();
-        expect(containsDeployLinks).toBe(true);
         expectFiles(workspacePath!, [/infra\/.*\.tf$/], [/\.bicep$/]);
+
+        // Verify Container Apps-specific Terraform content on disk
+        const tfPattern = /\.tf$/;
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_app[^_]/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_app_environment/i, tfPattern)).toBe(true);
+
+        // Verify two-phase deployment pattern (three resources):
+        // Phase 1: ACR resource
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_registry/i, tfPattern)).toBe(true);
+        // Phase 1: Container App with placeholder image, system-assigned identity, and lifecycle ignore_changes
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
+        // Phase 2: AcrPull role assignment in a separate file from the Container App
+        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
   });
@@ -834,9 +892,11 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     test("deploys aspire container build", async () => {
       await withTestResult(async () => {
         const CONTAINER_BUILD_SPARSE_PATH = "samples/container-build";
+        let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
           setup: async (workspace: string) => {
+            workspacePath = workspace;
             await cloneRepo({
               repoUrl: ASPIRE_SAMPLES_REPO,
               targetDir: workspace,
@@ -854,14 +914,26 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
+          shouldEarlyTerminate: shouldEarlyTerminateForAzdProvision,
           followUpTimeout: brownfieldTestTimeoutMs
         });
 
         softCheckDeploySkills(agentMetadata);
-        const containsDeployLinks = hasDeployLinks(agentMetadata);
+        expect(workspacePath).toBeDefined();
 
-        expect(containsDeployLinks).toBe(true);
+        // Verify Container Apps-specific Bicep content on disk
+        const bicepPattern = /\.bicep$/;
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.App\/containerApps/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.App\/managedEnvironments/i, bicepPattern)).toBe(true);
+
+        // Verify two-phase deployment pattern (three modules in main.bicep):
+        // Phase 1: ACR module
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.ContainerRegistry\/registries/i, bicepPattern)).toBe(true);
+        // Phase 1: Container App with placeholder image and system-assigned managed identity
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
+        // Phase 2: AcrPull role assignment in a separate module file from the Container App
+        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
       });
     }, brownfieldTestTimeoutMs);
 

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -413,7 +413,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate module file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
+        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toEqual({ isSeparate: true });
       });
     }, deployTestTimeoutMs);
 
@@ -449,7 +449,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com([^A-Za-z0-9.-]|$)/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate module file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
+        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toEqual({ isSeparate: true });
       });
     }, deployTestTimeoutMs);
 
@@ -674,7 +674,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toBe(true);
+        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toEqual({ isSeparate: true });
       });
     }, deployTestTimeoutMs);
 
@@ -711,7 +711,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toBe(true);
+        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toEqual({ isSeparate: true });
       });
     }, deployTestTimeoutMs);
 
@@ -748,7 +748,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toBe(true);
+        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toEqual({ isSeparate: true });
       });
     }, deployTestTimeoutMs);
   });
@@ -933,7 +933,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate module file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
+        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toEqual({ isSeparate: true });
       });
     }, brownfieldTestTimeoutMs);
 

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -707,7 +707,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: ACR resource
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_registry/i, tfPattern)).toBe(true);
         // Phase 1: Container App with placeholder image, system-assigned identity, and lifecycle ignore_changes
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate file from the Container App
@@ -930,7 +930,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: ACR module
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.ContainerRegistry\/registries/i, bicepPattern)).toBe(true);
         // Phase 1: Container App with placeholder image and system-assigned managed identity
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /mcr\.microsoft\.com/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
         // Phase 2: AcrPull role assignment in a separate module file from the Container App
         expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);

--- a/tests/azure-deploy/utils.ts
+++ b/tests/azure-deploy/utils.ts
@@ -65,9 +65,9 @@ export function shouldEarlyTerminateForCompletedDeployment(agentMetadata: AgentM
 }
 
 export function shouldEarlyTerminateForAzdProvision(agentMetadata: AgentMetadata): boolean {
-  const hasCalledProvision = matchesCommand(agentMetadata, /azd\s+provision/i);
+  const hasCalledProvision = matchesCommand(agentMetadata, /azd\s+(provision|up)\b/i);
   if (hasCalledProvision) {
-    const commentToAdd = "✅ azd provision was called. Terminating early — infrastructure provisioning has started.";
+    const commentToAdd = "✅ azd provision/up was called. Terminating early — infrastructure provisioning has started.";
     if (!agentMetadata.testComments.some((testComment) => testComment === commentToAdd)) {
       agentMetadata.testComments.push(commentToAdd);
     }

--- a/tests/azure-deploy/utils.ts
+++ b/tests/azure-deploy/utils.ts
@@ -63,3 +63,14 @@ export function shouldEarlyTerminateForCompletedDeployment(agentMetadata: AgentM
   }
   return containsDeployLinks;
 }
+
+export function shouldEarlyTerminateForAzdProvision(agentMetadata: AgentMetadata): boolean {
+  const hasCalledProvision = matchesCommand(agentMetadata, /azd\s+provision/i);
+  if (hasCalledProvision) {
+    const commentToAdd = "✅ azd provision was called. Terminating early — infrastructure provisioning has started.";
+    if (!agentMetadata.testComments.some((testComment) => testComment === commentToAdd)) {
+      agentMetadata.testComments.push(commentToAdd);
+    }
+  }
+  return hasCalledProvision;
+}

--- a/tests/azure-deploy/utils.ts
+++ b/tests/azure-deploy/utils.ts
@@ -65,12 +65,44 @@ export function shouldEarlyTerminateForCompletedDeployment(agentMetadata: AgentM
 }
 
 export function shouldEarlyTerminateForAzdProvision(agentMetadata: AgentMetadata): boolean {
-  const hasCalledProvision = matchesCommand(agentMetadata, /azd\s+(provision|up)\b/i);
-  if (hasCalledProvision) {
-    const commentToAdd = "✅ azd provision/up was called. Terminating early — infrastructure provisioning has started.";
+  const hasStartedAzdUp = matchesCommand(agentMetadata, /azd\s+up\b/i);
+  if (hasStartedAzdUp) {
+    const commentToAdd = "✅ azd up started running. Terminating early — end-to-end provisioning/deployment has started.";
+    if (!agentMetadata.testComments.some((testComment) => testComment === commentToAdd)) {
+      agentMetadata.testComments.push(commentToAdd);
+    }
+    return true;
+  }
+
+  // For azd provision, terminate only after at least one matching tool call completed.
+  const azdProvisionCallIds = new Set(
+    agentMetadata.events
+      .filter((event) => event.type === "tool.execution_start")
+      .filter((event) => {
+        if (event.data.toolName !== "bash" && event.data.toolName !== "powershell") {
+          return false;
+        }
+        const args = event.data.arguments as { command?: string } | undefined;
+        return /azd\s+provision\b/i.test(args?.command ?? "");
+      })
+      .map((event) => event.data.toolCallId)
+      .filter((toolCallId): toolCallId is string => typeof toolCallId === "string"),
+  );
+
+  const hasCompletedAzdProvision =
+    azdProvisionCallIds.size > 0
+    && agentMetadata.events.some((event) =>
+      event.type === "tool.execution_complete"
+      && typeof event.data.toolCallId === "string"
+      && azdProvisionCallIds.has(event.data.toolCallId)
+    );
+
+  if (hasCompletedAzdProvision) {
+    const commentToAdd = "✅ At least one azd provision command completed. Terminating early.";
     if (!agentMetadata.testComments.some((testComment) => testComment === commentToAdd)) {
       agentMetadata.testComments.push(commentToAdd);
     }
   }
-  return hasCalledProvision;
+
+  return hasCompletedAzdProvision;
 }

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -62,6 +62,48 @@ export function doesWorkspaceFileIncludePattern(workspace: string, valuePattern:
 }
 
 /**
+ * Checks that two value patterns exist in **different** files within the workspace.
+ * This verifies separation of concerns — e.g. the AcrPull role assignment is in a separate module from the Container App.
+ * @param workspace Path to a directory containing the files of interest.
+ * @param patternA First value pattern to match
+ * @param patternB Second value pattern — must be in a different file from patternA
+ * @param filePattern If provided, only files whose names match the pattern are considered
+ * @returns True if both patterns are found and they appear in different files
+ */
+export function arePatternsInSeparateFiles(workspace: string, patternA: RegExp, patternB: RegExp, filePattern?: RegExp): boolean {
+  const filesWithA: string[] = [];
+  const filesWithB: string[] = [];
+
+  const scanDirectory = (dir: string): void => {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory() && entry.name !== "node_modules") {
+        scanDirectory(fullPath);
+      } else if (entry.isFile()) {
+        if (filePattern && !entry.name.match(filePattern)) {
+          continue;
+        }
+        try {
+          const content = fs.readFileSync(fullPath, "utf-8");
+          if (content.match(patternA)) filesWithA.push(fullPath);
+          if (content.match(patternB)) filesWithB.push(fullPath);
+        } catch {
+          // Skip files that can't be read as text
+        }
+      }
+    }
+  };
+
+  scanDirectory(workspace);
+
+  if (filesWithA.length === 0 || filesWithB.length === 0) return false;
+
+  // Check that at least one file with patternB is different from all files with patternA
+  return filesWithB.some(f => !filesWithA.includes(f));
+}
+
+/**
  * Recursively list all files under a directory, returning paths relative to the root.
  * Paths are normalized to use forward slashes for cross-platform regex matching.
  */

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -71,36 +71,35 @@ export function doesWorkspaceFileIncludePattern(workspace: string, valuePattern:
  * @returns True if both patterns are found and they appear in different files
  */
 export function arePatternsInSeparateFiles(workspace: string, patternA: RegExp, patternB: RegExp, filePattern?: RegExp): boolean {
-  const filesWithA: string[] = [];
-  const filesWithB: string[] = [];
+  let hasA = false;
+  let hasBNotA = false;
 
-  const scanDirectory = (dir: string): void => {
+  const scanDirectory = (dir: string): boolean => {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory() && entry.name !== "node_modules") {
-        scanDirectory(fullPath);
+        if (scanDirectory(fullPath)) return true;
       } else if (entry.isFile()) {
         if (filePattern && !entry.name.match(filePattern)) {
           continue;
         }
         try {
           const content = fs.readFileSync(fullPath, "utf-8");
-          if (content.match(patternA)) filesWithA.push(fullPath);
-          if (content.match(patternB)) filesWithB.push(fullPath);
+          const matchesA = !!content.match(patternA);
+          const matchesB = !!content.match(patternB);
+          if (matchesA) hasA = true;
+          if (matchesB && !matchesA) hasBNotA = true;
+          if (hasA && hasBNotA) return true;
         } catch {
           // Skip files that can't be read as text
         }
       }
     }
+    return false;
   };
 
-  scanDirectory(workspace);
-
-  if (filesWithA.length === 0 || filesWithB.length === 0) return false;
-
-  // Check that at least one file with patternB is different from all files with patternA
-  return filesWithB.some(f => !filesWithA.includes(f));
+  return scanDirectory(workspace);
 }
 
 /**

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -61,6 +61,19 @@ export function doesWorkspaceFileIncludePattern(workspace: string, valuePattern:
   return scanDirectory(workspace);
 }
 
+export type SeparateFilesPatternResult =
+  | { isSeparate: true }
+  | {
+      isSeparate: false;
+      reason: "pattern-not-found";
+      missingPatterns: Array<"patternA" | "patternB">;
+    }
+  | {
+      isSeparate: false;
+      reason: "same-file";
+      filePaths: string[];
+    };
+
 /**
  * Checks that two value patterns exist in **different** files within the workspace.
  * This verifies patterns that must exist in different files — e.g. the AcrPull role assignment and the Container App must be in separate bicep modules so they can be provisioned separately to avoid cyclic dependency.
@@ -68,18 +81,28 @@ export function doesWorkspaceFileIncludePattern(workspace: string, valuePattern:
  * @param patternA First value pattern to match
  * @param patternB Second value pattern — must be in a different file from patternA
  * @param filePattern If provided, only files whose names match the pattern are considered
- * @returns True if both patterns are found and they appear in different files
+ * @returns Whether the patterns were found in separate files, or why they were not
  */
-export function arePatternsInSeparateFiles(workspace: string, patternA: RegExp, patternB: RegExp, filePattern?: RegExp): boolean {
+export function arePatternsInSeparateFiles(
+  workspace: string,
+  patternA: RegExp,
+  patternB: RegExp,
+  filePattern?: RegExp,
+): SeparateFilesPatternResult {
   let hasA = false;
-  let hasBNotA = false;
+  let hasB = false;
+  let hasBInDifferentFileFromA = false;
+  const sameFileMatches = new Set<string>();
 
-  const scanDirectory = (dir: string): boolean => {
+  const scanDirectory = (dir: string): SeparateFilesPatternResult | undefined => {
     const entries = fs.readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
       if (entry.isDirectory() && entry.name !== "node_modules") {
-        if (scanDirectory(fullPath)) return true;
+        const nestedResult = scanDirectory(fullPath);
+        if (nestedResult) {
+          return nestedResult;
+        }
       } else if (entry.isFile()) {
         if (filePattern && !entry.name.match(filePattern)) {
           continue;
@@ -88,18 +111,56 @@ export function arePatternsInSeparateFiles(workspace: string, patternA: RegExp, 
           const content = fs.readFileSync(fullPath, "utf-8");
           const matchesA = !!content.match(patternA);
           const matchesB = !!content.match(patternB);
-          if (matchesA) hasA = true;
-          if (matchesB && !matchesA) hasBNotA = true;
-          if (hasA && hasBNotA) return true;
+
+          if (matchesA) {
+            hasA = true;
+          }
+          if (matchesB) {
+            hasB = true;
+          }
+          if (matchesA && matchesB) {
+            sameFileMatches.add(fullPath);
+          }
+          if (matchesB && !matchesA) {
+            hasBInDifferentFileFromA = true;
+          }
+
+          if (hasA && hasBInDifferentFileFromA) {
+            return { isSeparate: true };
+          }
         } catch {
           // Skip files that can't be read as text
         }
       }
     }
-    return false;
+    return undefined;
   };
 
-  return scanDirectory(workspace);
+  const result = scanDirectory(workspace);
+  if (result) {
+    return result;
+  }
+
+  const missingPatterns: Array<"patternA" | "patternB"> = [];
+  if (!hasA) {
+    missingPatterns.push("patternA");
+  }
+  if (!hasB) {
+    missingPatterns.push("patternB");
+  }
+  if (missingPatterns.length > 0) {
+    return {
+      isSeparate: false,
+      reason: "pattern-not-found",
+      missingPatterns,
+    };
+  }
+
+  return {
+    isSeparate: false,
+    reason: "same-file",
+    filePaths: Array.from(sameFileMatches),
+  };
 }
 
 /**

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -63,7 +63,7 @@ export function doesWorkspaceFileIncludePattern(workspace: string, valuePattern:
 
 /**
  * Checks that two value patterns exist in **different** files within the workspace.
- * This verifies separation of concerns — e.g. the AcrPull role assignment is in a separate module from the Container App.
+ * This verifies patterns that must exist in different files — e.g. the AcrPull role assignment and the Container App must be in separate bicep modules so they can be provisioned separately to avoid cyclic dependency.
  * @param workspace Path to a directory containing the files of interest.
  * @param patternA First value pattern to match
  * @param patternB Second value pattern — must be in a different file from patternA


### PR DESCRIPTION
## Description

Container app deployment often fails with timeout due to the delay of AcrPull role assignment propagation. This PR update all of the 6 container app deployment tests to

1. Terminate tests after `azd provision` is completed
2. Verify two-phase IAC code pattern

Here is a detailed explain about two-phase container app deployment
###################################################
The "two-phase" terminology refers to **Bicep module dependency ordering**, not separate CLI invocations. Here's exactly what happens:

## How Many Commands?

- **`azd provision`**: **1 time** — deploys all Bicep (both "phases") in a single ARM deployment
- **`azd deploy`**: **1 time** — pushes your app image and configures the registry link
- Or just **`azd up`**: **1 time** — runs both provision + deploy sequentially

**No Bicep modifications between commands.**

## Step-by-Step

### 1. Write your Bicep (once)

Your `main.bicep` contains all three modules from the file:

| Module | "Phase" | What it does |
|--------|---------|-------------|
| `containerRegistry` | 1 | Creates ACR |
| `api` | 1 | Creates Container App with **placeholder image** (`mcr.microsoft.com/azuredocs/containerapps-helloworld:latest`), system-assigned managed identity, **no `registries` block** |
| `acrPullRole` | 2 | Assigns AcrPull role to the Container App's managed identity, using **outputs** from both Phase 1 modules |

The "phases" are just the dependency graph — ARM automatically deploys Phase 1 modules first, then Phase 2, because `acrPullRole` references outputs from the other two.

### 2. Run `azd up`

This executes two stages internally:

**Stage A — `azd provision`:**
- ARM deploys all three modules in dependency order
- Result: ACR exists, Container App exists (running placeholder image), role assignment exists

**Stage B — `azd deploy`:**
- `azd` automatically runs `az containerapp registry set --server <acr> --identity system` to link the registry to the app
- Builds and pushes your real app image to ACR
- Updates the Container App to use the real image

### 3. Done

No second provision, no Bicep edits.

## Why This Pattern Exists

Without the separate `acrPullRole` module, you'd get a **circular dependency**:
- ACR module needs to know the Container App's principal ID (for the role assignment)
- Container App module needs to reference ACR (if you put the `registries` block in Bicep)

By omitting the `registries` block from Bicep entirely and letting `azd deploy` handle it via the API, the circular dependency is broken. The role assignment module simply consumes outputs from both independent modules.
###################################################

## Related Issues

Fixes #1856
