### PR TITLE
fix: clarify output directory naming to use workspace root basename

### DIFF
--- a/plugin/skills/azure-cloud-migrate/SKILL.md
+++ b/plugin/skills/azure-cloud-migrate/SKILL.md
@@ -31,11 +31,11 @@ metadata:
 
 ## Output Directory
 
-All output goes to `<source-folder>-azure/` at workspace root. Never modify the source directory.
+All output goes to `<workspace-root-basename>-azure/` at workspace root, where `<workspace-root-basename>` is the name of the top-level workspace directory itself (NOT a subdirectory within it). Never modify the source directory.
 
 ## Steps
 
-1. **Create** `<source-folder>-azure/` at workspace root
+1. **Create** `<workspace-root-basename>-azure/` at workspace root
 2. **Assess** — Analyze source, map services, generate report using scenario-specific assessment guide
 3. **Migrate** — Convert code/config using scenario-specific migration guide
 4. **Ask User** — "Migration complete. Test locally or deploy to Azure?"

--- a/plugin/skills/azure-cloud-migrate/references/services/functions/assessment.md
+++ b/plugin/skills/azure-cloud-migrate/references/services/functions/assessment.md
@@ -35,7 +35,7 @@ Generate two diagrams:
 
 > ⚠️ **MANDATORY**: Use these exact section headings in every assessment report. Do NOT rename, reorder, or omit sections.
 
-The report MUST be saved as `migration-assessment-report.md` inside the output directory (`<aws-folder>-azure/`).
+The report MUST be saved as `migration-assessment-report.md` inside the output directory (`<workspace-root-basename>-azure/`).
 
 ```markdown
 # Migration Assessment Report

--- a/plugin/skills/azure-cloud-migrate/references/services/functions/code-migration.md
+++ b/plugin/skills/azure-cloud-migrate/references/services/functions/code-migration.md
@@ -21,7 +21,7 @@ Migrate AWS Lambda function code to Azure Functions.
 
 1. **Install Azure Functions Extension** — Ensure VS Code extension is installed
 2. **Load Best Practices** — Use `mcp_azure_mcp_get_azure_bestpractices` tool for code generation guidance
-3. **Create Project Structure** — Set up the Azure Functions project inside the output directory (`<aws-folder>-azure/`). Do NOT create files inside the original AWS directory
+3. **Create Project Structure** — Set up the Azure Functions project inside the output directory (`<workspace-root-basename>-azure/`). Do NOT create files inside the original AWS directory
 4. **Migrate Functions** — Convert each Lambda function to Azure Functions equivalent
 5. **Update Dependencies** — Replace AWS SDKs with Azure SDKs in package.json / requirements.txt
 6. **Configure Bindings** — Set up triggers and bindings inline (v4 JS / v2 Python)

--- a/plugin/skills/azure-cloud-migrate/references/workflow-details.md
+++ b/plugin/skills/azure-cloud-migrate/references/workflow-details.md
@@ -2,7 +2,7 @@
 
 ## Status Tracking
 
-Maintain a `migration-status.md` file in the output directory (`<source-folder>-azure/`):
+Maintain a `migration-status.md` file in the output directory (`<workspace-root-basename>-azure/`):
 
 ```markdown
 # Migration Status


### PR DESCRIPTION
Fixes #1927 - Agent was using subdirectory names (e.g. todo-src-azure) instead of workspace root name for the output directory.

- Replace ambiguous <source-folder> and <aws-folder> placeholders with explicit <workspace-root-basename> across all skill reference files
- Add clarification that it refers to the top-level workspace directory, NOT a subdirectory within it

## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
