### PR TITLE
Fix early termination targeting router instead of sub-skill in AKS Automatic readiness test

### DIFF
--- a/tests/azure-kubernetes/azure-kubernetes-automatic-readiness/integration.test.ts
+++ b/tests/azure-kubernetes/azure-kubernetes-automatic-readiness/integration.test.ts
@@ -24,7 +24,6 @@ import {
 } from "../../utils/evaluate";
 
 const SKILL_NAME = "azure-kubernetes-automatic-readiness";
-const ROUTER_SKILL_NAME = "azure-kubernetes";
 const RUNS_PER_PROMPT = 5;
 const invocationRateThreshold = 0.8;
 
@@ -73,10 +72,10 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         for (let i = 0; i < RUNS_PER_PROMPT; i++) {
           const agentMetadata = await agent.run({
             prompt: "Can I migrate my AKS cluster to AKS Automatic? Check if my workloads are compatible.",
-            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, ROUTER_SKILL_NAME)
+            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
           });
 
-          softCheckSkill(agentMetadata, ROUTER_SKILL_NAME);
+          softCheckSkill(agentMetadata, SKILL_NAME);
           if (isReadinessWorkflowInvoked(agentMetadata)) {
             invocationCount += 1;
           }


### PR DESCRIPTION
## Description

Fixes the `azure-kubernetes-automatic-readiness` integration test that was failing with a 0% invocation rate (threshold ≥ 80%).

Fixes #1979

## Problem

The skill-invocation test used `shouldEarlyTerminateForSkillInvocation(metadata, ROUTER_SKILL_NAME)` which terminated the agent run as soon as the **router** skill (`azure-kubernetes`) was invoked — before the **sub-skill** (`azure-kubernetes-automatic-readiness`) ever had a chance to execute. The test then checked `isReadinessWorkflowInvoked()` against the truncated run and found no evidence of the sub-skill, scoring 0/5 every time.

## Fix

- Changed `shouldEarlyTerminateForSkillInvocation` and `softCheckSkill` to use `SKILL_NAME` (`azure-kubernetes-automatic-readiness`) instead of `ROUTER_SKILL_NAME` (`azure-kubernetes`)
- Removed the now-unused `ROUTER_SKILL_NAME` constant

This allows the agent run to continue past the router invocation until the actual readiness sub-skill is invoked, which is what the test is measuring.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

Fixes #1979 
