### PR TITLE
chore: support hosted agent v2 in code gen and deploy skill

### DIFF
--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -11,6 +11,10 @@ metadata:
 
 This skill helps developers work with Microsoft Foundry resources, covering model discovery and deployment, complete dev lifecycle of AI agent, evaluation workflows, and troubleshooting.
 
+## Pre-Execution Requirements
+
+> **MANDATORY: Before executing ANY workflow, you MUST first call the Azure MCP `foundry` tool and inspect the Foundry operations and parameters it exposes.** For this skill, treat Azure MCP `foundry` as the required entry point for Foundry-related MCP operations.
+
 ## Sub-Skills
 
 > **MANDATORY: Before executing ANY workflow, you MUST read the corresponding sub-skill document.** Do not call MCP tools for a workflow without reading its skill document. This applies even if you already know the MCP tool parameters — the skill document contains required workflow steps, pre-checks, and validation logic that must be followed. This rule applies on every new user message that triggers a different workflow, even if the skill is already loaded.

--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -13,11 +13,11 @@ This skill helps developers work with Microsoft Foundry resources, covering mode
 
 ## Pre-Execution Requirements
 
-> **MANDATORY: Before executing ANY workflow, you MUST first call the Azure MCP `foundry` tool and inspect the Foundry operations and parameters it exposes.** For this skill, treat Azure MCP `foundry` as the required entry point for Foundry-related MCP operations.
+> **MANDATORY: Before executing ANY workflow, you MUST first call the Azure MCP `foundry` tool and inspect the available Foundry MCP tools and related parameters.** Treat this initial `foundry` call as a discovery/help step. For this skill, Azure MCP `foundry` is the required entry point for Foundry-related MCP operations.
 
 ## Sub-Skills
 
-> **MANDATORY: Before executing ANY workflow, you MUST read the corresponding sub-skill document.** Do not call MCP tools for a workflow without reading its skill document. This applies even if you already know the MCP tool parameters — the skill document contains required workflow steps, pre-checks, and validation logic that must be followed. This rule applies on every new user message that triggers a different workflow, even if the skill is already loaded.
+> **MANDATORY: Before executing ANY workflow-specific steps, you MUST read the corresponding sub-skill document.** Do not call workflow-specific MCP tools for a workflow without reading its skill document. This applies even if you already know the MCP tool parameters — the skill document contains required workflow steps, pre-checks, and validation logic that must be followed. This rule applies on every new user message that triggers a different workflow, even if the skill is already loaded.
 
 This skill includes specialized sub-skills for specific workflows. **Use these instead of the main skill when they match your task:**
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
@@ -179,7 +179,7 @@ Modify the project's main entrypoint to wrap the existing agent with the adapter
 ### Step B4: Configure Environment
 
 1. Create or update a `.env` file with required environment variables (project endpoint, model deployment name, etc.)
-2. For Python: ensure the code uses `load_dotenv(override=False)` so Foundry-injected environment variables is available at runtime.
+2. For Python: ensure the code uses `load_dotenv(override=False)` so Foundry-injected environment variables are available at runtime.
 3. If the project uses Azure credentials: ensure Python uses `azure.identity.DefaultAzureCredential` for **local development**. In production, use `ManagedIdentityCredential`. See [auth-best-practices.md](../../references/auth-best-practices.md)
 
 ### Step B5: Create agent.yaml

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
@@ -135,7 +135,7 @@ Add the correct adapter package based on framework and language. Get the latest 
 
 | Framework | Package |
 |-----------|---------|
-| Microsoft Agent Framework | `agent_framework_foundry_hosting ` |
+| Microsoft Agent Framework | `agent_framework_foundry_hosting` |
 | LangGraph | `azure-ai-agentserver-langgraph` |
 | Custom | `azure-ai-agentserver-core` |
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
@@ -6,9 +6,9 @@ Create new hosted agent applications for Microsoft Foundry, or convert existing 
 
 | Property | Value |
 |----------|-------|
-| **Samples Repo** | `microsoft-foundry/foundry-samples` |
-| **Python Samples** | `samples/python/hosted-agents/{framework}/` |
-| **C# Samples** | `samples/csharp/hosted-agents/{framework}/` |
+| **Samples Repo** | `microsoft-foundry/foundry-samples` #todo |
+| **Python Samples** | `samples/python/hosted-agents/{framework}/` #todo |
+| **C# Samples** | `samples/csharp/hosted-agents/{framework}/` #todo |
 | **Hosted Agents Docs** | https://learn.microsoft.com/azure/ai-foundry/agents/concepts/hosted-agents |
 | **Best For** | Creating new or converting existing agent projects for Foundry |
 
@@ -51,7 +51,7 @@ If user has no specific preference, suggest Microsoft Agent Framework + Python a
 List available samples using the GitHub API:
 
 ```
-GET https://api.github.com/repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}
+GET https://api.github.com/repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework} #todo
 ```
 
 If the user has specified any information on what they want their agent to do, just choose the most relevant or most simple sample to start with. Only if user has not given any preferences, present the sample directories to the user and help them choose based on their requirements (e.g., RAG, tools, multi-agent workflows, HITL).
@@ -62,7 +62,7 @@ Download only the selected sample directory — do NOT clone the entire repo. Pr
 
 **Using `gh` CLI (preferred if available):**
 ```bash
-gh api repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}/{sample} \
+gh api repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}/{sample} \ #todo
   --jq '.[] | select(.type=="file") | .download_url' | while read url; do
   filepath="${url##*/samples/{language}/hosted-agents/{framework}/{sample}/}"
   mkdir -p "$(dirname "$filepath")"
@@ -72,7 +72,7 @@ done
 
 **Using curl (fallback):**
 ```bash
-curl -s "https://api.github.com/repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}/{sample}" | \
+curl -s "https://api.github.com/repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}/{sample}" | \ #todo
   jq -r '.[] | select(.type=="file") | .path + "\t" + .download_url' | while IFS=$'\t' read path url; do
     relpath="${path#samples/{language}/hosted-agents/{framework}/{sample}/}"
     mkdir -p "$(dirname "$relpath")"
@@ -120,7 +120,7 @@ Scan the project to determine:
 
 | Indicator | Framework |
 |-----------|-----------|
-| Imports from `agent_framework` or `Microsoft.Agents.AI` | Microsoft Agent Framework |
+| Imports from `agent_framework` or `Microsoft.Agents.AI` | Microsoft Agent Framework | #todo
 | Imports from `langgraph`, `langchain` | LangGraph |
 | No recognized framework imports, or other frameworks (e.g., Semantic Kernel, AutoGen) | Custom |
 
@@ -135,7 +135,7 @@ Add the correct adapter package based on framework and language. Get the latest 
 
 | Framework | Package |
 |-----------|---------|
-| Microsoft Agent Framework | `azure-ai-agentserver-agentframework` |
+| Microsoft Agent Framework | `azure-ai-agentserver-agentframework` | #todo
 | LangGraph | `azure-ai-agentserver-langgraph` |
 | Custom | `azure-ai-agentserver-core` |
 
@@ -143,7 +143,7 @@ Add the correct adapter package based on framework and language. Get the latest 
 
 | Framework | Package |
 |-----------|---------|
-| Microsoft Agent Framework | `Azure.AI.AgentServer.AgentFramework` |
+| Microsoft Agent Framework | `Azure.AI.AgentServer.AgentFramework` | #todo
 | Custom | `Azure.AI.AgentServer.Core` |
 
 Add the package to the project's dependency file (`requirements.txt`, `pyproject.toml`, or `.csproj`). For Python, also add `python-dotenv` if not present.
@@ -152,7 +152,7 @@ Add the package to the project's dependency file (`requirements.txt`, `pyproject
 
 Modify the project's main entrypoint to wrap the existing agent with the adapter. The approach differs by framework:
 
-**Microsoft Agent Framework (Python):**
+**Microsoft Agent Framework (Python):** #todo
 - Import `from_agent_framework` from the adapter package
 - Pass the agent instance (a `BaseAgent` subclass) to the adapter
 - Call `.run()` on the adapter as the default entrypoint
@@ -163,14 +163,14 @@ Modify the project's main entrypoint to wrap the existing agent with the adapter
 - Pass the compiled `StateGraph` to the adapter
 - Call `.run()` on the adapter as the default entrypoint
 
-**Custom code (Python):**
+**Custom code (Python):** #todo
 - Import `FoundryCBAgent` from the core adapter package
 - Create a class that extends `FoundryCBAgent`
 - Implement the `agent_run()` method which receives an `AgentRunContext` and returns either an `OpenAIResponse` (non-streaming) or `AsyncGenerator[ResponseStreamEvent]` (streaming)
 - The agent must handle the Foundry request/response protocol manually — refer to the [custom sample](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/custom) for the exact interface
 - Instantiate and call `.run()` as the default entrypoint
 
-**Custom code (C#):**
+**Custom code (C#):** #todo
 - Use `AgentServerApplication.RunAsync()` with dependency injection to register an `IAgentInvocation` implementation
 - Refer to the [C# custom sample](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/csharp/hosted-agents/AgentWithCustomFramework) for the exact interface
 
@@ -179,8 +179,8 @@ Modify the project's main entrypoint to wrap the existing agent with the adapter
 ### Step B4: Configure Environment
 
 1. Create or update a `.env` file with required environment variables (project endpoint, model deployment name, etc.)
-2. For Python: ensure the code uses `load_dotenv()` so Foundry-injected environment variables is available at runtime.
-3. If the project uses Azure credentials: ensure Python uses `azure.identity.aio.DefaultAzureCredential` (async version) for **local development**, not `azure.identity.DefaultAzureCredential`. In production, use `ManagedIdentityCredential`. See [auth-best-practices.md](../../references/auth-best-practices.md)
+2. For Python: ensure the code uses `load_dotenv(override=False)` so Foundry-injected environment variables is available at runtime.
+3. If the project uses Azure credentials: ensure Python uses #todo `azure.identity.aio.DefaultAzureCredential` (async version) for **local development**, not `azure.identity.DefaultAzureCredential`. In production, use `ManagedIdentityCredential`. See [auth-best-practices.md](../../references/auth-best-practices.md)
 
 ### Step B5: Create agent.yaml
 
@@ -192,7 +192,7 @@ Create an `agent.yaml` file in the project root. This file defines the agent's m
 - `template.protocols` — Must include `responses` protocol v1
 - `template.environment_variables` — List all environment variables the agent needs at runtime
 
-Refer to any sample's `agent.yaml` in the [foundry-samples repo](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents) for the exact schema.
+Refer to any sample's `agent.yaml` in the [foundry-samples repo](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents) #todo for the exact schema.
 
 ### Step B6: Create Dockerfile
 
@@ -206,7 +206,7 @@ Create a `Dockerfile` if one doesn't exist. Requirements:
 
 > ⚠️ **Warning:** When building, MUST use `--platform linux/amd64`. Hosted agents run on Linux AMD64 infrastructure. Images built for other architectures (e.g., ARM64 on Apple Silicon) will fail.
 
-Refer to any sample's `Dockerfile` in the [foundry-samples repo](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents) for the exact pattern.
+Refer to any sample's `Dockerfile` in the [foundry-samples repo](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents) #todo for the exact pattern.
 
 ### Step B7: Test Locally
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create.md
@@ -6,9 +6,9 @@ Create new hosted agent applications for Microsoft Foundry, or convert existing 
 
 | Property | Value |
 |----------|-------|
-| **Samples Repo** | `microsoft-foundry/foundry-samples` #todo |
-| **Python Samples** | `samples/python/hosted-agents/{framework}/` #todo |
-| **C# Samples** | `samples/csharp/hosted-agents/{framework}/` #todo |
+| **Samples Repo** | `microsoft-foundry/foundry-samples` |
+| **Python Samples** | `samples/python/hosted-agents/{framework}/` |
+| **C# Samples** | `samples/csharp/hosted-agents/{framework}/` |
 | **Hosted Agents Docs** | https://learn.microsoft.com/azure/ai-foundry/agents/concepts/hosted-agents |
 | **Best For** | Creating new or converting existing agent projects for Foundry |
 
@@ -51,7 +51,7 @@ If user has no specific preference, suggest Microsoft Agent Framework + Python a
 List available samples using the GitHub API:
 
 ```
-GET https://api.github.com/repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework} #todo
+GET https://api.github.com/repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}
 ```
 
 If the user has specified any information on what they want their agent to do, just choose the most relevant or most simple sample to start with. Only if user has not given any preferences, present the sample directories to the user and help them choose based on their requirements (e.g., RAG, tools, multi-agent workflows, HITL).
@@ -62,7 +62,7 @@ Download only the selected sample directory — do NOT clone the entire repo. Pr
 
 **Using `gh` CLI (preferred if available):**
 ```bash
-gh api repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}/{sample} \ #todo
+gh api repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}/{sample} \
   --jq '.[] | select(.type=="file") | .download_url' | while read url; do
   filepath="${url##*/samples/{language}/hosted-agents/{framework}/{sample}/}"
   mkdir -p "$(dirname "$filepath")"
@@ -72,7 +72,7 @@ done
 
 **Using curl (fallback):**
 ```bash
-curl -s "https://api.github.com/repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}/{sample}" | \ #todo
+curl -s "https://api.github.com/repos/microsoft-foundry/foundry-samples/contents/samples/{language}/hosted-agents/{framework}/{sample}" | \
   jq -r '.[] | select(.type=="file") | .path + "\t" + .download_url' | while IFS=$'\t' read path url; do
     relpath="${path#samples/{language}/hosted-agents/{framework}/{sample}/}"
     mkdir -p "$(dirname "$relpath")"
@@ -120,7 +120,7 @@ Scan the project to determine:
 
 | Indicator | Framework |
 |-----------|-----------|
-| Imports from `agent_framework` or `Microsoft.Agents.AI` | Microsoft Agent Framework | #todo
+| Imports from `agent_framework` or `Microsoft.Agents.AI` | Microsoft Agent Framework |
 | Imports from `langgraph`, `langchain` | LangGraph |
 | No recognized framework imports, or other frameworks (e.g., Semantic Kernel, AutoGen) | Custom |
 
@@ -135,7 +135,7 @@ Add the correct adapter package based on framework and language. Get the latest 
 
 | Framework | Package |
 |-----------|---------|
-| Microsoft Agent Framework | `azure-ai-agentserver-agentframework` | #todo
+| Microsoft Agent Framework | `agent_framework_foundry_hosting ` |
 | LangGraph | `azure-ai-agentserver-langgraph` |
 | Custom | `azure-ai-agentserver-core` |
 
@@ -143,7 +143,7 @@ Add the correct adapter package based on framework and language. Get the latest 
 
 | Framework | Package |
 |-----------|---------|
-| Microsoft Agent Framework | `Azure.AI.AgentServer.AgentFramework` | #todo
+| Microsoft Agent Framework | `Microsoft.Agents.AI.Foundry.Hosting` |
 | Custom | `Azure.AI.AgentServer.Core` |
 
 Add the package to the project's dependency file (`requirements.txt`, `pyproject.toml`, or `.csproj`). For Python, also add `python-dotenv` if not present.
@@ -152,25 +152,25 @@ Add the package to the project's dependency file (`requirements.txt`, `pyproject
 
 Modify the project's main entrypoint to wrap the existing agent with the adapter. The approach differs by framework:
 
-**Microsoft Agent Framework (Python):** #todo
-- Import `from_agent_framework` from the adapter package
-- Pass the agent instance (a `BaseAgent` subclass) to the adapter
+**Microsoft Agent Framework (Python):**
+- Import `ResponsesHostServer` from the adapter package
+- Pass the agent instance (from `agent_framework` package) to the adapter
 - Call `.run()` on the adapter as the default entrypoint
-- The agent must implement both `run()` and `run_stream()` methods
+- The agent must implement the `run()` method
 
 **LangGraph (Python):**
 - Import `from_langgraph` from the adapter package
 - Pass the compiled `StateGraph` to the adapter
 - Call `.run()` on the adapter as the default entrypoint
 
-**Custom code (Python):** #todo
+**Custom code (Python):**
 - Import `FoundryCBAgent` from the core adapter package
 - Create a class that extends `FoundryCBAgent`
 - Implement the `agent_run()` method which receives an `AgentRunContext` and returns either an `OpenAIResponse` (non-streaming) or `AsyncGenerator[ResponseStreamEvent]` (streaming)
 - The agent must handle the Foundry request/response protocol manually — refer to the [custom sample](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/custom) for the exact interface
 - Instantiate and call `.run()` as the default entrypoint
 
-**Custom code (C#):** #todo
+**Custom code (C#):**
 - Use `AgentServerApplication.RunAsync()` with dependency injection to register an `IAgentInvocation` implementation
 - Refer to the [C# custom sample](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/csharp/hosted-agents/AgentWithCustomFramework) for the exact interface
 
@@ -180,7 +180,7 @@ Modify the project's main entrypoint to wrap the existing agent with the adapter
 
 1. Create or update a `.env` file with required environment variables (project endpoint, model deployment name, etc.)
 2. For Python: ensure the code uses `load_dotenv(override=False)` so Foundry-injected environment variables is available at runtime.
-3. If the project uses Azure credentials: ensure Python uses #todo `azure.identity.aio.DefaultAzureCredential` (async version) for **local development**, not `azure.identity.DefaultAzureCredential`. In production, use `ManagedIdentityCredential`. See [auth-best-practices.md](../../references/auth-best-practices.md)
+3. If the project uses Azure credentials: ensure Python uses `azure.identity.DefaultAzureCredential` for **local development**. In production, use `ManagedIdentityCredential`. See [auth-best-practices.md](../../references/auth-best-practices.md)
 
 ### Step B5: Create agent.yaml
 
@@ -192,7 +192,7 @@ Create an `agent.yaml` file in the project root. This file defines the agent's m
 - `template.protocols` — Must include `responses` protocol v1
 - `template.environment_variables` — List all environment variables the agent needs at runtime
 
-Refer to any sample's `agent.yaml` in the [foundry-samples repo](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents) #todo for the exact schema.
+Refer to any sample's `agent.yaml` in the [foundry-samples repo](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents) for the exact schema.
 
 ### Step B6: Create Dockerfile
 
@@ -206,7 +206,7 @@ Create a `Dockerfile` if one doesn't exist. Requirements:
 
 > ⚠️ **Warning:** When building, MUST use `--platform linux/amd64`. Hosted agents run on Linux AMD64 infrastructure. Images built for other architectures (e.g., ARM64 on Apple Silicon) will fail.
 
-Refer to any sample's `Dockerfile` in the [foundry-samples repo](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents) #todo for the exact pattern.
+Refer to any sample's `Dockerfile` in the [foundry-samples repo](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents) for the exact pattern.
 
 ### Step B7: Test Locally
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
@@ -18,19 +18,17 @@ Best practices when building hosted agents with Microsoft Agent Framework for de
 
 ## Installation
 
-**Python:** `pip install agent-framework --pre` (installs all sub-packages) #todo
+**Python:** `pip install agent-framework agent-framework-foundry-hosting ` (installs all sub-packages)
 
 **.NET:** `dotnet add package Microsoft.Agents.AI`
-
-> ⚠️ **Warning:** Always pin specific pre-release versions. Use `--pre` to get the latest. Check the [PyPI page](https://pypi.org/project/agent-framework/) or [NuGet profile](https://www.nuget.org/profiles/MicrosoftAgentFramework/) for current stable versions. #todo
 
 ## Hosting Adapter
 
 Hosted agents must expose an HTTP server using the hosting adapter. This enables local testing and Foundry deployment with the same code.
 
-**Python adapter packages:** `azure-ai-agentserver-core`, `azure-ai-agentserver-agentframework` #todo
+**Python adapter packages:** `agent_framework_foundry_hosting`
 
-**.NET adapter packages:** `Azure.AI.AgentServer.Core`, `Azure.AI.AgentServer.AgentFramework` #todo
+**.NET adapter packages:** `Azure.AI.AgentServer.Core`, `Microsoft.Agents.AI.Foundry.Hosting`
 
 The adapter handles protocol translation between Foundry request/response formats and your framework's native data structures, including conversation management, message serialization, and streaming.
 
@@ -40,7 +38,7 @@ The adapter handles protocol translation between Foundry request/response format
 
 ### Python: Async Credentials
 
-For **local development**, use `DefaultAzureCredential` from `azure.identity.aio` (not `azure.identity`) — `AzureAIClient` requires async credentials. In production, use `ManagedIdentityCredential` from `azure.identity.aio`. See [auth-best-practices.md](../../../references/auth-best-practices.md). #todo
+For **local development**, use `DefaultAzureCredential` from `azure.identity`. In production, use `ManagedIdentityCredential`. See [auth-best-practices.md](../../../references/auth-best-practices.md).
 
 ### Python: Environment Variables
 
@@ -74,7 +72,7 @@ For workflow samples and advanced patterns, search the [Agent Framework GitHub r
 
 ## Debugging
 
-Use [AI Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) with the `agentdev` CLI tool for interactive debugging: #todo
+Use [AI Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) with the `agentdev` CLI tool for interactive debugging:
 
 1. Install `debugpy` for VS Code Python Debugger support
 2. Install `agent-dev-cli` (pre-release) for the `agentdev` command

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
@@ -18,19 +18,19 @@ Best practices when building hosted agents with Microsoft Agent Framework for de
 
 ## Installation
 
-**Python:** `pip install agent-framework --pre` (installs all sub-packages)
+**Python:** `pip install agent-framework --pre` (installs all sub-packages) #todo
 
 **.NET:** `dotnet add package Microsoft.Agents.AI`
 
-> ⚠️ **Warning:** Always pin specific pre-release versions. Use `--pre` to get the latest. Check the [PyPI page](https://pypi.org/project/agent-framework/) or [NuGet profile](https://www.nuget.org/profiles/MicrosoftAgentFramework/) for current stable versions.
+> ⚠️ **Warning:** Always pin specific pre-release versions. Use `--pre` to get the latest. Check the [PyPI page](https://pypi.org/project/agent-framework/) or [NuGet profile](https://www.nuget.org/profiles/MicrosoftAgentFramework/) for current stable versions. #todo
 
 ## Hosting Adapter
 
 Hosted agents must expose an HTTP server using the hosting adapter. This enables local testing and Foundry deployment with the same code.
 
-**Python adapter packages:** `azure-ai-agentserver-core`, `azure-ai-agentserver-agentframework`
+**Python adapter packages:** `azure-ai-agentserver-core`, `azure-ai-agentserver-agentframework` #todo
 
-**.NET adapter packages:** `Azure.AI.AgentServer.Core`, `Azure.AI.AgentServer.AgentFramework`
+**.NET adapter packages:** `Azure.AI.AgentServer.Core`, `Azure.AI.AgentServer.AgentFramework` #todo
 
 The adapter handles protocol translation between Foundry request/response formats and your framework's native data structures, including conversation management, message serialization, and streaming.
 
@@ -40,7 +40,7 @@ The adapter handles protocol translation between Foundry request/response format
 
 ### Python: Async Credentials
 
-For **local development**, use `DefaultAzureCredential` from `azure.identity.aio` (not `azure.identity`) — `AzureAIClient` requires async credentials. In production, use `ManagedIdentityCredential` from `azure.identity.aio`. See [auth-best-practices.md](../../../references/auth-best-practices.md).
+For **local development**, use `DefaultAzureCredential` from `azure.identity.aio` (not `azure.identity`) — `AzureAIClient` requires async credentials. In production, use `ManagedIdentityCredential` from `azure.identity.aio`. See [auth-best-practices.md](../../../references/auth-best-practices.md). #todo
 
 ### Python: Environment Variables
 
@@ -74,7 +74,7 @@ For workflow samples and advanced patterns, search the [Agent Framework GitHub r
 
 ## Debugging
 
-Use [AI Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) with the `agentdev` CLI tool for interactive debugging:
+Use [AI Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) with the `agentdev` CLI tool for interactive debugging: #todo
 
 1. Install `debugpy` for VS Code Python Debugger support
 2. Install `agent-dev-cli` (pre-release) for the `agentdev` command

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
@@ -18,7 +18,7 @@ Best practices when building hosted agents with Microsoft Agent Framework for de
 
 ## Installation
 
-**Python:** `pip install agent-framework agent-framework-foundry-hosting ` (installs all sub-packages)
+**Python:** `pip install agent-framework agent-framework-foundry-hosting` (installs all sub-packages)
 
 **.NET:** `dotnet add package Microsoft.Agents.AI`
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
@@ -36,7 +36,7 @@ The adapter handles protocol translation between Foundry request/response format
 
 ## Key Patterns
 
-### Python: Async Credentials
+### Python: Credentials
 
 For **local development**, use `DefaultAzureCredential` from `azure.identity`. In production, use `ManagedIdentityCredential`. See [auth-best-practices.md](../../../references/auth-best-practices.md).
 
@@ -84,7 +84,7 @@ For VS Code `launch.json` and `tasks.json` configuration templates, see [AI Tool
 
 | Error | Cause | Fix |
 |-------|-------|-----|
-| `ModuleNotFoundError` | Missing SDK | `pip install agent-framework --pre` in venv |
-| Async credential error | Wrong import | Use `azure.identity.aio.DefaultAzureCredential` (local dev) or `azure.identity.aio.ManagedIdentityCredential` (production) |
+| `ModuleNotFoundError` | Missing SDK | `pip install agent-framework agent-framework-foundry-hosting` in venv |
+| Credential error | Wrong import | Use `azure.identity.DefaultAzureCredential` (local dev) or `ManagedIdentityCredential` (production) |
 | Agent name validation error | Invalid characters | Use alphanumeric + hyphens, start/end alphanumeric, max 63 chars |
-| Hosting adapter not found | Missing package | Install `azure-ai-agentserver-agentframework` |
+| Hosting adapter not found | Missing package | Install `agent-framework-foundry-hosting` |

--- a/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
@@ -123,26 +123,30 @@ Use `agent_definition_schema_get` with `schemaType: hosted` to retrieve the curr
 
 > **VNext Experience:** You MUST pass `enableVnextExperience = true` in the `metadata` field of `creationOptions`. This is required for vNext deployments.
 
-Use `agent_update` with the agent definition:
+Use `agent_update` with this schema: `agent_update projectEndpoint=<project-endpoint> agentName=<agent-name> payload={...}`. Put the full agent request body inside `payload`.
+
+> ⚠️ **Protocol version source of truth:** Do NOT copy the protocol version from `agent_definition_schema_get` examples. Use the protocol version declared by the agent source itself (for example, `agent.yaml` or `agent.manifest.yaml`).
 
 For ACA one:
-```json
-{
-  "kind": "hosted",
-  "image": "<acr-name>.azurecr.io/<repository>:<tag>",
-  "cpu": "<cpu-cores>",
-  "memory": "<memory>",
-  "container_protocol_versions": [
-    { "protocol": "<protocol>", "version": "<version>" }
-  ],
-  "environment_variables": { "<var>": "<value>" }
+```text
+agent_update projectEndpoint=<project-endpoint> agentName=<agent-name> payload={
+  "agentDefinition": {
+    "kind": "hosted",
+    "image": "<acr-name>.azurecr.io/<repository>:<tag>",
+    "cpu": "<cpu-cores>",
+    "memory": "<memory>",
+    "container_protocol_versions": [
+      { "protocol": "<protocol>", "version": "<version>" }
+    ],
+    "environment_variables": { "<var>": "<value>" }
+  }
 }
 ```
 
 For vNext one:
-```json
-{
-   "agentDefinition": {
+```text
+agent_update projectEndpoint=<project-endpoint> agentName=<agent-name> payload={
+  "agentDefinition": {
     "kind": "hosted",
     "image": "<acr-name>.azurecr.io/<repository>:<tag>",
     "cpu": "<cpu-cores>",

--- a/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
@@ -123,13 +123,15 @@ Use `agent_definition_schema_get` with `schemaType: hosted` to retrieve the curr
 
 > **VNext Experience:** You MUST pass `enableVnextExperience = true` in the `metadata` field of `creationOptions`. This is required for vNext deployments.
 
-Use `agent_update` with this schema: `agent_update projectEndpoint=<project-endpoint> agentName=<agent-name> payload={...}`. Put the full agent request body inside `payload`.
+Use `agent_update` with the agent definition:
 
 > ⚠️ **Protocol version source of truth:** Do NOT copy the protocol version from `agent_definition_schema_get` examples. Use the protocol version declared by the agent source itself (for example, `agent.yaml` or `agent.manifest.yaml`).
 
 For ACA one:
-```text
-agent_update projectEndpoint=<project-endpoint> agentName=<agent-name> payload={
+```json
+{
+  "command": "agent_update",
+  "intent": "Update a hosted agent with a new docker image",
   "agentDefinition": {
     "kind": "hosted",
     "image": "<acr-name>.azurecr.io/<repository>:<tag>",
@@ -144,8 +146,10 @@ agent_update projectEndpoint=<project-endpoint> agentName=<agent-name> payload={
 ```
 
 For vNext one:
-```text
-agent_update projectEndpoint=<project-endpoint> agentName=<agent-name> payload={
+```json
+{
+  "command": "agent_update",
+  "intent": "Update a hosted agent with a new docker image",
   "agentDefinition": {
     "kind": "hosted",
     "image": "<acr-name>.azurecr.io/<repository>:<tag>",

--- a/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
@@ -132,15 +132,19 @@ For ACA one:
 {
   "command": "agent_update",
   "intent": "Update a hosted agent with a new docker image",
-  "agentDefinition": {
-    "kind": "hosted",
-    "image": "<acr-name>.azurecr.io/<repository>:<tag>",
-    "cpu": "<cpu-cores>",
-    "memory": "<memory>",
-    "container_protocol_versions": [
-      { "protocol": "<protocol>", "version": "<version>" }
-    ],
-    "environment_variables": { "<var>": "<value>" }
+  "parameters": {
+    "projectEndpoint": "<project-endpoint>",
+    "agentName": "<agent-name>",
+    "agentDefinition": {
+      "kind": "hosted",
+      "image": "<acr-name>.azurecr.io/<repository>:<tag>",
+      "cpu": "<cpu-cores>",
+      "memory": "<memory>",
+      "container_protocol_versions": [
+        { "protocol": "<protocol>", "version": "<version>" }
+      ],
+      "environment_variables": { "<var>": "<value>" }
+    }
   }
 }
 ```
@@ -150,19 +154,23 @@ For vNext one:
 {
   "command": "agent_update",
   "intent": "Update a hosted agent with a new docker image",
-  "agentDefinition": {
-    "kind": "hosted",
-    "image": "<acr-name>.azurecr.io/<repository>:<tag>",
-    "cpu": "<cpu-cores>",
-    "memory": "<memory>",
-    "container_protocol_versions": [
-      { "protocol": "<protocol>", "version": "<version>" }
-    ],
-    "environment_variables": { "<var>": "<value>" }
-  },
-  "creationOptions": {
-    "metadata": {
-      "enableVnextExperience": "true"
+  "parameters": {
+    "projectEndpoint": "<project-endpoint>",
+    "agentName": "<agent-name>",
+    "agentDefinition": {
+      "kind": "hosted",
+      "image": "<acr-name>.azurecr.io/<repository>:<tag>",
+      "cpu": "<cpu-cores>",
+      "memory": "<memory>",
+      "container_protocol_versions": [
+        { "protocol": "<protocol>", "version": "<version>" }
+      ],
+      "environment_variables": { "<var>": "<value>" }
+    },
+    "creationOptions": {
+      "metadata": {
+        "enableVnextExperience": "true"
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Support hosted agent v2 in code gen and deploy skill

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [x] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [x] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [x] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
