### PR TITLE
fix: strengthen azure-resource-lookup routing for web app/website prompts

### DIFF
--- a/plugin/skills/azure-resource-lookup/SKILL.md
+++ b/plugin/skills/azure-resource-lookup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-resource-lookup
-description: "List, find, and show Azure resources across subscriptions or resource groups. Handles prompts like \"list websites\", \"list virtual machines\", \"list my VMs\", \"show storage accounts\", \"find container apps\", and \"what resources do I have\". USE FOR: resource inventory, find resources by tag, tag analysis, orphaned resource discovery (not for cost analysis), unattached disks, count resources by type, cross-subscription lookup, and Azure Resource Graph queries. DO NOT USE FOR: deploying/changing resources (use azure-deploy), cost optimization (use azure-cost), or non-Azure clouds."
+description: "List, find, and show Azure resources across subscriptions or resource groups. Handles prompts like \"list the websites in my subscription\", \"list my web apps\", \"show my app services\", \"list virtual machines\", \"list my VMs\", \"show storage accounts\", \"find container apps\", and \"what resources do I have\". USE FOR: list websites, list web apps, list app services, show websites in subscription, resource inventory, find resources by tag, tag analysis, orphaned resource discovery (not for cost analysis), unattached disks, count resources by type, cross-subscription lookup, and Azure Resource Graph queries. DO NOT USE FOR: deploying/changing resources (use azure-deploy), cost optimization (use azure-cost), or non-Azure clouds."
 license: MIT
 metadata:
   author: Microsoft
@@ -22,6 +22,9 @@ Use this skill when the user wants to:
 - Get a **resource inventory** spanning multiple types
 - Find resources in a **specific state** (unhealthy, failed provisioning, stopped)
 - Answer "**what resources do I have?**" or "**show me my Azure resources**"
+- **List web apps, websites, or App Services**
+
+> ⚠️ **Warning:** App Service / Web Apps have no dedicated MCP `list` command. Prompts like "list websites", "list web apps", or "list app services" **must** route through this skill to use Azure Resource Graph.
 
 > 💡 **Tip:** For single-resource-type queries, first check if a dedicated MCP tool can handle it (see routing table below). If none exists, use Azure Resource Graph.
 

--- a/tests/azure-resource-lookup/__snapshots__/triggers.test.ts.snap
+++ b/tests/azure-resource-lookup/__snapshots__/triggers.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`azure-resource-lookup - Trigger Tests Trigger Keywords Snapshot skill description triggers match snapshot 1`] = `
 {
-  "description": "List, find, and show Azure resources across subscriptions or resource groups. Handles prompts like "list websites", "list virtual machines", "list my VMs", "show storage accounts", "find container apps", and "what resources do I have". USE FOR: resource inventory, find resources by tag, tag analysis, orphaned resource discovery (not for cost analysis), unattached disks, count resources by type, cross-subscription lookup, and Azure Resource Graph queries. DO NOT USE FOR: deploying/changing resources (use azure-deploy), cost optimization (use azure-cost), or non-Azure clouds.",
+  "description": "List, find, and show Azure resources across subscriptions or resource groups. Handles prompts like "list the websites in my subscription", "list my web apps", "show my app services", "list virtual machines", "list my VMs", "show storage accounts", "find container apps", and "what resources do I have". USE FOR: list websites, list web apps, list app services, show websites in subscription, resource inventory, find resources by tag, tag analysis, orphaned resource discovery (not for cost analysis), unattached disks, count resources by type, cross-subscription lookup, and Azure Resource Graph queries. DO NOT USE FOR: deploying/changing resources (use azure-deploy), cost optimization (use azure-cost), or non-Azure clouds.",
   "extractedKeywords": [
     "accounts",
     "across",
@@ -47,9 +47,11 @@ exports[`azure-resource-lookup - Trigger Tests Trigger Keywords Snapshot skill d
     "rbac",
     "resource",
     "resources",
+    "services",
     "show",
     "sql",
     "storage",
+    "subscription",
     "subscriptions",
     "type",
     "unattached",
@@ -106,9 +108,11 @@ exports[`azure-resource-lookup - Trigger Tests Trigger Keywords Snapshot skill k
   "rbac",
   "resource",
   "resources",
+  "services",
   "show",
   "sql",
   "storage",
+  "subscription",
   "subscriptions",
   "type",
   "unattached",


### PR DESCRIPTION
## Summary

Fixes #1982 - the azure-resource-lookup skill was not being invoked for prompts like "List the websites in my subscription". The agent routed directly to MCP appservice tools, completing the task but bypassing the skill wrapper.

## Changes (2 files)

**plugin/skills/azure-resource-lookup/SKILL.md**
- Added web app/website/App Service triggers to front of prompt examples in description
- Added "list websites, list web apps, list app services, show websites in subscription" to USE FOR triggers
- Added bullet in "When to Use" section for web app/website listing
- Added warning callout that App Service has no dedicated MCP list command

**tests/azure-resource-lookup/__snapshots__/triggers.test.ts.snap**
- Updated keyword snapshots to match new description (adds "services", "subscription")

## Validation

- Skill Structure, Markdown References, ESLint, Token Analysis, Skill Structure all pass
- Description length: 743/1024 chars
- Version left as 0.0.0-placeholder (build stamps real version)
