### PR TITLE
added stop condition for quality test so passing runs don't time out

### DIFF
--- a/tests/azure-enterprise-infra-planner/integration.test.ts
+++ b/tests/azure-enterprise-infra-planner/integration.test.ts
@@ -258,7 +258,13 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             testWorkspacePath = workspace;
             // Pre-create infra/ to guide IaC file placement per skill instructions
             fs.mkdirSync(path.join(workspace, "infra", "modules"), { recursive: true });
-          }
+          },
+          shouldEarlyTerminate: () => {
+            if (!testWorkspacePath) {
+              return false;
+            }
+            return fs.existsSync(path.join(testWorkspacePath, "infra", "main.bicep"));
+          },
         });
 
         softCheckSkill(agentMetadata, SKILL_NAME);


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR changes and why. -->
Now there's a stop condition on bicep creation so now it shouldn't timeout even though the task is completed
{
   "source_log": "C:\\Users\\JBROCK~1\\AppData\\Local\\Temp\\copilot-tool-output-1776879589343-118ycp.txt",
   "test_name": "azure-enterprise-infra-planner > response-quality > generates Bicep files from approved plan",
   "snippets": [
     {
       "line": 6955,
       "text": "📋 Found 4 total Bicep files:"
     },
     {
       "line": 6956,
       "text": "infra\\main.bicep"
     },
     {
       "line": 6969,
       "text": "infra\\modules\\backup.bicep"
     },
     {
       "line": 6982,
       "text": "infra\\modules\\monitoring.bicep"
     },
     {
       "line": 6995,
       "text": "infra\\modules\\security.bicep"
     },
     {
       "line": 7008,
       "text": "✅ 4 Bicep file(s) correctly under infra/"
     },
     {
       "line": 7020,
       "text": "main.bicep present: true"
     },
     {
       "line": 7037,
       "text": "PASS SKILLS azure-enterprise-infra-planner/integration.test.ts (498.31 s)"
     },
     {
       "line": 7113,
       "text": "√ generates Bicep files from approved plan (487809 ms)"
     }
   ],
   "bicep_files_detected": [
     "infra\\main.bicep",
     "infra\\modules\\backup.bicep",
     "infra\\modules\\monitoring.bicep",
     "infra\\modules\\security.bicep"
   ],
   "result": {
     "status": "PASS",
     "duration_ms": 487809
   }
 }


## Checklist

- [x ] Tests pass locally (`cd tests && npm test`)
- [x ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [x ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [x ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues


<!-- Link to related issues, e.g. Fixes #1234 -->
#1787 