### PR TITLE
Initialize test result entry

### DIFF
--- a/tests/globals.d.ts
+++ b/tests/globals.d.ts
@@ -9,7 +9,7 @@ declare global {
   var TESTS_PATH: string;
   function getSkillPath(skillName: string): string;
   function getFixturesPath(skillName: string): string;
-  function addTestResult(data: { isPass: boolean, message?: string, skillInvocationRate?: number }): void;
+  function setTestResult(data: { isPass: boolean, message?: string, skillInvocationRate?: number }): void;
 
   namespace jest {
     interface Matchers<R> {

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -72,7 +72,7 @@ global.getFixturesPath = (skillName: string): string => {
 // per-worker JSON file in afterAll so globalTeardown can merge them.
 const testResults: Record<string, { isPass: boolean; message?: string; skillInvocationRate?: number }> = {};
 
-global.addTestResult = (data) => {
+global.setTestResult = (data) => {
   try {
     const state = expect.getState();
     const testName = state.currentTestName ?? "unknown";

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -297,8 +297,8 @@ export async function withTestResult(fn: (ctx: WithTestResultContext) => Promise
 
   try {
     // Before agent run starts, initialize the test result as if it failed.
-    // This ensures every test case has a result even when their agent run time out.
-    global.setTestResult({ isPass: false, message: "waiting for agent run to finish" });
+    // This ensures every test case has a result even when the agent run times out.
+    global.setTestResult({ isPass: false, message: "agent run did not finish; test likely timed out or was terminated before completion" });
     await fn(ctx);
     global.setTestResult({ isPass: true, skillInvocationRate });
   } catch (e) {

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -296,8 +296,11 @@ export async function withTestResult(fn: (ctx: WithTestResultContext) => Promise
   };
 
   try {
+    // Before agent run starts, initialize the test result as if it failed.
+    // This ensures every test case has a result even when their agent run time out.
+    global.setTestResult({ isPass: false, message: "waiting for agent run to finish" });
     await fn(ctx);
-    global.addTestResult({ isPass: true, skillInvocationRate });
+    global.setTestResult({ isPass: true, skillInvocationRate });
   } catch (e) {
     let message: string | undefined;
     if (e instanceof Error) {
@@ -306,7 +309,7 @@ export async function withTestResult(fn: (ctx: WithTestResultContext) => Promise
     } else {
       message = String(e).slice(0, 4096);
     }
-    global.addTestResult({ isPass: false, message, skillInvocationRate });
+    global.setTestResult({ isPass: false, message, skillInvocationRate });
     throw e;
   }
 }


### PR DESCRIPTION
## Description

If a test case times out, a test case may be missing in the aggregated test result since it didn't have a chance to add its entry. This PR ensures every test case has an entry for its test result that explains its outcome, even if it times out.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
