### PR TITLE
Add util function for extracting remote links in skills

### DIFF
--- a/scripts/src/references/__tests__/link-helpers.test.ts
+++ b/scripts/src/references/__tests__/link-helpers.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { extractRemoteLinks } from "../link-helpers.js";
+
+const tempDirs: string[] = [];
+
+function createMarkdown(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "remote-links-"));
+  tempDirs.push(dir);
+  const filePath = join(dir, "sample.md");
+  writeFileSync(filePath, content, "utf-8");
+  return filePath;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+describe("extractRemoteLinks", () => {
+  it("extracts plain URLs and markdown target URLs", () => {
+    const mdFile = createMarkdown(
+      [
+        "Plain URL: https://example.com/a/b?query=1#top",
+        "Markdown URL: [docs](http://docs.example.org/guide/intro)",
+      ].join("\n")
+    );
+
+    const links = extractRemoteLinks(mdFile, "");
+
+    expect(links).toEqual([
+      {
+        line: 1,
+        link: "https://example.com/a/b?query=1#top",
+        protocol: "https",
+        host: "example.com",
+        path: "/a/b",
+      },
+      {
+        line: 2,
+        link: "http://docs.example.org/guide/intro",
+        protocol: "http",
+        host: "docs.example.org",
+        path: "/guide/intro",
+      },
+    ]);
+  });
+
+  it("handles malformed placeholder URLs with fallback parsing", () => {
+    const mdFile = createMarkdown(
+      "Use placeholder URL: https://{tenant}.host.com/path/to/page?debug=true"
+    );
+
+    const links = extractRemoteLinks(mdFile, "");
+
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      protocol: "https",
+      host: "{tenant}.host.com",
+      path: "/path/to/page",
+    });
+  });
+
+  it("captures URLs from markdown labels and trims trailing punctuation", () => {
+    const mdFile = createMarkdown(
+      "See [https://label.example.com/reference](./local.md) and (https://api.example.com/v1/path)."
+    );
+
+    const links = extractRemoteLinks(mdFile, "");
+
+    expect(links).toHaveLength(2);
+    expect(links[0]).toMatchObject({
+      link: "https://label.example.com/reference",
+      host: "label.example.com",
+      path: "/reference",
+    });
+    expect(links[1]).toMatchObject({
+      link: "https://api.example.com/v1/path",
+      host: "api.example.com",
+      path: "/v1/path",
+    });
+  });
+
+  it("captures placeholder hosts that include indexed expressions", () => {
+    const mdFile = createMarkdown(
+      "Terraform output: https://${azurerm_container_app.api.ingress[0].fqdn}"
+    );
+
+    const links = extractRemoteLinks(mdFile, "");
+
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      link: "https://${azurerm_container_app.api.ingress[0].fqdn}",
+      protocol: "https",
+      host: "${azurerm_container_app.api.ingress[0].fqdn}",
+      path: "/",
+    });
+  });
+
+  it("trims a trailing backtick from extracted urls", () => {
+    const mdFile = createMarkdown(
+      "Key Vault endpoint: https://${vaultName}.vault.azure.net`"
+    );
+
+    const links = extractRemoteLinks(mdFile, "");
+
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      link: "https://${vaultName}.vault.azure.net",
+      protocol: "https",
+      host: "${vaultname}.vault.azure.net",
+      path: "/",
+    });
+  });
+
+  it("allows whitespace inside balanced shell substitutions", () => {
+    const mdFile = createMarkdown(
+      "Health check: https://$(terraform output -raw api_url)/health"
+    );
+
+    const links = extractRemoteLinks(mdFile, "");
+
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      link: "https://$(terraform output -raw api_url)/health",
+      protocol: "https",
+      host: "$(terraform output -raw api_url)",
+      path: "/health",
+    });
+  });
+
+  it("stops URL extraction at semicolons", () => {
+    const mdFile = createMarkdown(
+      "Connection string: http://localhost:8080;Authentication=None;TaskHub=default"
+    );
+
+    const links = extractRemoteLinks(mdFile, "");
+
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      link: "http://localhost:8080",
+      protocol: "http",
+      host: "localhost:8080",
+      path: "/",
+    });
+  });
+});

--- a/scripts/src/references/cli.ts
+++ b/scripts/src/references/cli.ts
@@ -17,7 +17,7 @@
 
 import { dirname, resolve, relative, normalize } from "node:path";
 import { existsSync, readdirSync, statSync } from "node:fs";
-import { extractLocalLinks } from "./link-helpers.js";
+import { extractLocalLinks, extractRemoteLinks } from "./link-helpers.js";
 import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
@@ -30,6 +30,20 @@ function getRepoRoot(): string {
 
 const REPO_ROOT = getRepoRoot();
 let SKILLS_DIR = resolve(REPO_ROOT, "plugin", "skills");
+
+const FILTERED_REMOTE_HOSTS = new Set<string>([]);
+const FILTERED_REMOTE_HOST_SUFFICES: string[] = [];
+
+function shouldPrintRemoteHost(host: string): boolean {
+  const normalizedHost = host.toLowerCase().replace(/:\d+$/, "");
+  if (FILTERED_REMOTE_HOSTS.has(normalizedHost)) {
+    return false;
+  }
+  if (FILTERED_REMOTE_HOST_SUFFICES.some(s => host.endsWith(s))) {
+    return false;
+  }
+  return true;
+}
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -45,10 +59,20 @@ interface OrphanedFile {
   reason: string;     // Human-readable explanation
 }
 
+interface RemoteLinkDetail {
+  file: string;
+  line: number;
+  link: string;
+  protocol: "http" | "https";
+  host: string;
+  path: string;
+}
+
 interface ValidationResult {
   skill: string;
   issues: LinkIssue[];
   orphanedFiles: OrphanedFile[];
+  remoteLinks: RemoteLinkDetail[];
 }
 
 // ── Markdown file discovery ──────────────────────────────────────────────────
@@ -122,8 +146,13 @@ function findReferenceFiles(skillDir: string): string[] {
 
 // ── Validation logic ─────────────────────────────────────────────────────────
 
-function validateFile(mdFile: string, skillDir: string): LinkIssue[] {
+function validateFile(mdFile: string, skillDir: string): {
+  issues: LinkIssue[];
+  remoteLinks: RemoteLinkDetail[];
+} {
+  // Local links
   const localLinks = extractLocalLinks(mdFile, skillDir);
+  const remoteLinks = extractRemoteLinks(mdFile, skillDir);
   const issues: LinkIssue[] = [];
 
   // Check 1: find all references that don't exist
@@ -172,17 +201,34 @@ function validateFile(mdFile: string, skillDir: string): LinkIssue[] {
     }
   }).filter((issue) => issue !== undefined));
 
-  return issues;
+  return {
+    issues,
+    remoteLinks: remoteLinks.filter((item) => {
+      return shouldPrintRemoteHost(item.host);
+    }).map((item) => {
+      return {
+        file: mdFile,
+        line: item.line,
+        link: item.link,
+        protocol: item.protocol,
+        host: item.host,
+        path: item.path,
+      };
+    })
+  };
 }
 
 function validateSkill(skillName: string): ValidationResult {
   const skillDir = resolve(SKILLS_DIR, skillName);
   const mdFiles = findMarkdownFiles(skillDir);
   const issues: LinkIssue[] = [];
+  const remoteLinks: RemoteLinkDetail[] = [];
 
   // Validate all markdown files for link issues
   for (const mdFile of mdFiles) {
-    issues.push(...validateFile(mdFile, skillDir));
+    const result = validateFile(mdFile, skillDir);
+    issues.push(...result.issues);
+    remoteLinks.push(...result.remoteLinks);
   }
 
   // Track visited files for orphan detection
@@ -230,7 +276,7 @@ function validateSkill(skillName: string): ValidationResult {
     }
   }
 
-  return { skill: skillName, issues, orphanedFiles };
+  return { skill: skillName, issues, orphanedFiles, remoteLinks };
 }
 
 // ── JSON output ──────────────────────────────────────────────────────────────
@@ -408,6 +454,18 @@ function main(): void {
       for (const orphan of result.orphanedFiles) {
         console.log(`     ${formatPath(orphan.file)}`);
         console.log(`       ${orphan.reason}`);
+      }
+    }
+
+    if (result.remoteLinks.length > 0) {
+      console.log(`     🌐 Remote links (${result.remoteLinks.length})`);
+      for (const remote of result.remoteLinks) {
+        const loc = `${formatPath(remote.file)}:${remote.line}`;
+        console.log(`       ${loc}`);
+        console.log(`         URL: ${remote.link}`);
+        console.log(`         Protocol: ${remote.protocol}`);
+        console.log(`         Host: ${remote.host}`);
+        console.log(`         Path: ${remote.path}`);
       }
     }
   }

--- a/scripts/src/references/link-helpers.ts
+++ b/scripts/src/references/link-helpers.ts
@@ -17,6 +17,163 @@ import { dirname, resolve } from "node:path";
  */
 export const MARKDOWN_LINK_RE = /\[(?:[^\]]*)\]\(([^)]+)\)/g;
 
+/**
+ * Regex that captures the http/https protocol prefix of remote link targets.
+ */
+export const REMOTE_URL_RE = /https?:\/\//gi;
+
+const TRAILING_PUNCTUATION = new Set([".", ",", ";", "!", "?", "`"]);
+
+function extractRemoteUrlCandidate(line: string, startIndex: number): string {
+  let endIndex = startIndex + line.slice(startIndex).match(/^https?:\/\//i)![0].length;
+  let parenDepth = 0;
+  let bracketDepth = 0;
+  let braceDepth = 0;
+
+  while (endIndex < line.length) {
+    const char = line[endIndex];
+    const nextChar = line[endIndex + 1];
+
+    if (char === "]" && nextChar === "(" && bracketDepth === 0) {
+      break;
+    }
+
+    if (char === "<" || char === ">" || char === '"' || char === "'") {
+      break;
+    }
+
+    if (/\s/.test(char) && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      break;
+    }
+
+    if (char === ";" && parenDepth === 0 && bracketDepth === 0 && braceDepth === 0) {
+      break;
+    }
+
+    if (char === "(") {
+      parenDepth++;
+    } else if (char === ")") {
+      if (parenDepth === 0) {
+        break;
+      }
+      parenDepth--;
+    } else if (char === "[") {
+      bracketDepth++;
+    } else if (char === "]") {
+      if (bracketDepth === 0) {
+        break;
+      }
+      bracketDepth--;
+    } else if (char === "{") {
+      braceDepth++;
+    } else if (char === "}") {
+      if (braceDepth === 0) {
+        break;
+      }
+      braceDepth--;
+    }
+
+    endIndex++;
+  }
+
+  return line.slice(startIndex, endIndex);
+}
+
+function trimTrailingUrlChars(url: string): string {
+  let output = url;
+
+  while (output.length > 0) {
+    const last = output.at(-1);
+    if (!last) {
+      break;
+    }
+
+    if (TRAILING_PUNCTUATION.has(last)) {
+      output = output.slice(0, -1);
+      continue;
+    }
+
+    if (last === ")") {
+      const opens = (output.match(/\(/g) ?? []).length;
+      const closes = (output.match(/\)/g) ?? []).length;
+      if (closes > opens) {
+        output = output.slice(0, -1);
+        continue;
+      }
+    }
+
+    if (last === "]") {
+      const opens = (output.match(/\[/g) ?? []).length;
+      const closes = (output.match(/\]/g) ?? []).length;
+      if (closes > opens) {
+        output = output.slice(0, -1);
+        continue;
+      }
+    }
+
+    if (last === "}") {
+      const opens = (output.match(/\{/g) ?? []).length;
+      const closes = (output.match(/\}/g) ?? []).length;
+      if (closes > opens) {
+        output = output.slice(0, -1);
+        continue;
+      }
+    }
+
+    break;
+  }
+
+  return output;
+}
+
+function parseRemoteLink(rawUrl: string): {
+  protocol: "http" | "https";
+  host: string;
+  path: string;
+} {
+  const lower = rawUrl.toLowerCase();
+  const protocol: "http" | "https" = lower.startsWith("https://") ? "https" : "http";
+
+  try {
+    const parsed = new URL(rawUrl);
+    return {
+      protocol,
+      host: parsed.host,
+      path: parsed.pathname || "/"
+    };
+  } catch {
+    const withoutScheme = rawUrl.replace(/^https?:\/\//i, "");
+    const firstPathChar = withoutScheme.search(/[/?#]/);
+    const authority = firstPathChar === -1
+      ? withoutScheme
+      : withoutScheme.slice(0, firstPathChar);
+    const remainder = firstPathChar === -1
+      ? ""
+      : withoutScheme.slice(firstPathChar);
+
+    const withoutCredentials = authority.includes("@")
+      ? authority.slice(authority.lastIndexOf("@") + 1)
+      : authority;
+
+    let host = withoutCredentials;
+    if (host.startsWith("[")) {
+      const end = host.indexOf("]");
+      host = end > 0 ? host.slice(0, end + 1) : host;
+    } else {
+      host = host.replace(/:\d+$/, "");
+    }
+
+    const pathMatch = remainder.match(/^([^?#]*)/);
+    const path = pathMatch && pathMatch[1] !== "" ? pathMatch[1] : "/";
+
+    return {
+      protocol,
+      host,
+      path: path.startsWith("/") ? path : `/${path}`,
+    };
+  }
+}
+
 function isIgnoredLink(rawTarget: string): boolean {
   const trimmed = rawTarget.trim();
   if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return true;
@@ -67,6 +224,34 @@ export type LocalLink = {
    * If the item doesn't exist, {@link LocalLink.isDirectory} is undefined.
    */
   isDirectory?: boolean;
+}
+
+export type RemoteLink = {
+  /**
+   * Line number at which the URL exists in the given file.
+   * The first line's line number is 1.
+   */
+  line: number;
+
+  /**
+   * The exact URL value extracted from markdown.
+   */
+  link: string;
+
+  /**
+   * The URL protocol.
+   */
+  protocol: "http" | "https";
+
+  /**
+   * URL host (hostname with optional port when parseable).
+   */
+  host: string;
+
+  /**
+   * URL path without query/fragment. Defaults to '/'.
+   */
+  path: string;
 }
 
 /**
@@ -129,6 +314,43 @@ export function extractLocalLinks(mdFile: string, _skillDir: string): LocalLink[
           exists: false
         });
       }
+    }
+  }
+
+  return links;
+}
+
+/**
+ * Extract all remote links from markdown content, including URLs that appear
+ * either in markdown link targets or as plain text.
+ */
+export function extractRemoteLinks(mdFile: string, _skillDir: string): RemoteLink[] {
+  const links: RemoteLink[] = [];
+  const content = readFileSync(mdFile, "utf-8");
+  const lines = content.split("\n");
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    let match: RegExpExecArray | null;
+    REMOTE_URL_RE.lastIndex = 0;
+
+    while ((match = REMOTE_URL_RE.exec(line)) !== null) {
+      const rawCandidate = extractRemoteUrlCandidate(line, match.index);
+      REMOTE_URL_RE.lastIndex = match.index + Math.max(rawCandidate.length, match[0].length);
+
+      const candidate = trimTrailingUrlChars(rawCandidate);
+      if (candidate === "") {
+        continue;
+      }
+
+      const parsed = parseRemoteLink(candidate);
+      links.push({
+        line: i + 1,
+        link: candidate,
+        protocol: parsed.protocol,
+        host: parsed.host,
+        path: parsed.path,
+      });
     }
   }
 


### PR DESCRIPTION
## Description

Add a function for extracting remote links with https/http protocol in skills and their references. Right now, the `references` commands prints formatted text to enumerate all of the discovered remote links. We can review them offline and decide what rules to apply to them. 

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

#1985