### PR TITLE
test: Emit correct tool and skill counts

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -88,9 +88,11 @@ export interface AgentMetadata {
   toolCounts: Record<string, number>;
 
   /**
-   * Map from skill name to the sorted, deduped list of files read from that skill's
-   * directory (i.e., paths under `output/skills/<skillName>/`) during the run.
-   * Populated from observed `read_file` tool invocations.
+   * Map from skill name to the sorted, deduped list of files under that skill's
+   * directory (i.e., paths under `output/skills/<skillName>/`) that were referenced
+   * by tool invocations during the run.
+   * Populated from tool arguments that reference files in a skill directory, and may
+   * also include a synthesized `SKILL.md` entry for `skill` tool calls.
    */
   skillFiles: Record<string, string[]>;
 }
@@ -184,7 +186,16 @@ function extractSkillDirPaths(args: unknown, skillDirectory: string): string[] {
   }
 
   // Fallback: scan serialized args for any occurrence of the skill directory
-  const serialized = typeof args === "string" ? args : JSON.stringify(args ?? "");
+  let serialized: string;
+  if (typeof args === "string") {
+    serialized = args;
+  } else {
+    try {
+      serialized = JSON.stringify(args ?? "");
+    } catch {
+      serialized = String(args ?? "");
+    }
+  }
   const normalizedSerialized = serialized.replace(/\\\\/g, "/").replace(/\\/g, "/");
   const needle = normalizedDir + "/";
   let searchFrom = 0;
@@ -234,8 +245,13 @@ function computeToolAndSkillStats(
         const v = (args as Record<string, unknown>).skill;
         if (typeof v === "string") skillName = v;
       } else if (typeof args === "string") {
-        const m = (args as string).match(/"skill"\s*:\s*"([^"]+)"/);
-        if (m) skillName = m[1];
+        const stringArgs = args.trim();
+        const m = stringArgs.match(/"skill"\s*:\s*"([^"]+)"/);
+        if (m) {
+          skillName = m[1];
+        } else if (stringArgs) {
+          skillName = stringArgs;
+        }
       }
       if (skillName) {
         (skillFilesSet[skillName] ??= new Set()).add(`${normalizedSkillDir}/${skillName}/SKILL.md`);

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -79,6 +79,20 @@ export interface AgentMetadata {
    * Token usage and cost data extracted from assistant.usage and session.shutdown events.
    */
   tokenUsage?: TokenUsage;
+
+  /**
+   * Map from tool name to the number of times that tool was invoked during the run.
+   * Excludes the `skill` pseudo-tool; all other tools (including MCP tools) are included,
+   * keyed by the raw `event.data.toolName`.
+   */
+  toolCounts: Record<string, number>;
+
+  /**
+   * Map from skill name to the sorted, deduped list of files read from that skill's
+   * directory (i.e., paths under `output/skills/<skillName>/`) during the run.
+   * Populated from observed `read_file` tool invocations.
+   */
+  skillFiles: Record<string, string[]>;
 }
 
 /**
@@ -135,6 +149,117 @@ interface RunnerCleanup {
 }
 
 /**
+ * Extract file-system paths from the serialized arguments of a tool call that
+ * reference the given `skillDirectory`. Checks common argument keys
+ * (`filePath`, `path`, `file`, `uri`) and also scans the full serialized args
+ * for any substring rooted at the skill directory. Returned paths are
+ * normalized to forward slashes.
+ */
+function extractSkillDirPaths(args: unknown, skillDirectory: string): string[] {
+  const normalizedDir = skillDirectory.replace(/\\/g, "/").replace(/\/+$/, "");
+  const found = new Set<string>();
+
+  let obj: Record<string, unknown> | undefined;
+  if (args && typeof args === "object") {
+    obj = args as Record<string, unknown>;
+  } else if (typeof args === "string") {
+    try {
+      const parsed: unknown = JSON.parse(args);
+      if (parsed && typeof parsed === "object") {
+        obj = parsed as Record<string, unknown>;
+      }
+    } catch { /* ignore */ }
+  }
+
+  if (obj) {
+    for (const key of ["filePath", "path", "file", "uri"]) {
+      const v = obj[key];
+      if (typeof v === "string" && v.length > 0) {
+        const normalized = v.replace(/\\/g, "/");
+        if (normalized.startsWith(normalizedDir + "/")) {
+          found.add(normalized);
+        }
+      }
+    }
+  }
+
+  // Fallback: scan serialized args for any occurrence of the skill directory
+  const serialized = typeof args === "string" ? args : JSON.stringify(args ?? "");
+  const normalizedSerialized = serialized.replace(/\\\\/g, "/").replace(/\\/g, "/");
+  const needle = normalizedDir + "/";
+  let searchFrom = 0;
+  while (true) {
+    const idx = normalizedSerialized.indexOf(needle, searchFrom);
+    if (idx < 0) break;
+    const tail = normalizedSerialized.slice(idx);
+    const endMatch = tail.match(/^[^"',\s\\]+/);
+    if (endMatch) found.add(endMatch[0]);
+    searchFrom = idx + needle.length;
+  }
+
+  return Array.from(found);
+}
+
+/**
+ * Compute aggregate tool invocation counts and per-skill file-read listings
+ * from the ordered list of session events.
+ *
+ * - `toolCounts` keys are raw `event.data.toolName`, excluding the `skill` pseudo-tool.
+ * - `skillFiles` is populated from any tool invocation whose arguments reference
+ *   a path under the given skill directory (`output/skills/<skill>/...`).
+ */
+function computeToolAndSkillStats(
+  events: SessionEvent[],
+  skillDirectory: string
+): { toolCounts: Record<string, number>; skillFiles: Record<string, string[]> } {
+  const toolCounts: Record<string, number> = {};
+  const skillFilesSet: Record<string, Set<string>> = {};
+
+  const normalizedSkillDir = skillDirectory.replace(/\\/g, "/").replace(/\/+$/, "");
+
+  for (const event of events) {
+    if (event.type !== "tool.execution_start") continue;
+    const toolName = event.data.toolName as string | undefined;
+    if (!toolName) continue;
+
+    if (toolName !== "skill") {
+      toolCounts[toolName] = (toolCounts[toolName] ?? 0) + 1;
+    } else {
+      // The `skill` tool loads <skillDirectory>/<skillName>/SKILL.md internally
+      // via the SDK; no path appears in tool arguments. Synthesize the entry so
+      // SKILL.md is reflected in `skillFiles` for every invoked skill.
+      const args: unknown = event.data.arguments;
+      let skillName: string | undefined;
+      if (args && typeof args === "object") {
+        const v = (args as Record<string, unknown>).skill;
+        if (typeof v === "string") skillName = v;
+      } else if (typeof args === "string") {
+        const m = (args as string).match(/"skill"\s*:\s*"([^"]+)"/);
+        if (m) skillName = m[1];
+      }
+      if (skillName) {
+        (skillFilesSet[skillName] ??= new Set()).add(`${normalizedSkillDir}/${skillName}/SKILL.md`);
+      }
+    }
+
+    for (const filePath of extractSkillDirPaths(event.data.arguments, skillDirectory)) {
+      const relative = filePath.slice(normalizedSkillDir.length + 1);
+      const slashIdx = relative.indexOf("/");
+      if (slashIdx <= 0) continue;
+      const skillName = relative.slice(0, slashIdx);
+      (skillFilesSet[skillName] ??= new Set()).add(filePath);
+    }
+  }
+
+  const skillFiles: Record<string, string[]> = {};
+  for (const skillName of Object.keys(skillFilesSet).sort()) {
+    skillFiles[skillName] = Array.from(skillFilesSet[skillName]).sort();
+  }
+
+  return { toolCounts, skillFiles };
+}
+
+/**
  * Generate a markdown report from agent metadata
  */
 function generateMarkdownReport(config: AgentRunConfig, agentMetadata: AgentMetadata): string {
@@ -168,6 +293,36 @@ function generateMarkdownReport(config: AgentRunConfig, agentMetadata: AgentMeta
     lines.push(`| Cache Write | ${t.cacheWriteTokens.toLocaleString()} |`);
     lines.push(`| API Calls | ${t.apiCallCount} |`);
     lines.push(`| API Duration | ${(t.totalApiDurationMs / 1000).toFixed(1)}s |`);
+    lines.push("");
+  }
+
+  // Tool invocation counts (excludes the `skill` pseudo-tool)
+  const toolCountEntries = Object.entries(agentMetadata.toolCounts ?? {});
+  if (toolCountEntries.length > 0) {
+    toolCountEntries.sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+    lines.push("# Tool Counts");
+    lines.push("");
+    lines.push("| Tool | Count |");
+    lines.push("|------|-------|");
+    for (const [tool, count] of toolCountEntries) {
+      lines.push(`| ${tool} | ${count} |`);
+    }
+    lines.push("");
+  }
+
+  // Files read from each invoked skill's directory
+  const skillFileEntries = Object.entries(agentMetadata.skillFiles ?? {});
+  if (skillFileEntries.length > 0) {
+    skillFileEntries.sort((a, b) => a[0].localeCompare(b[0]));
+    lines.push("# Skill Files Read");
+    lines.push("");
+    lines.push("| Skill | File |");
+    lines.push("|-------|------|");
+    for (const [skillName, files] of skillFileEntries) {
+      for (const file of files) {
+        lines.push(`| ${skillName} | ${file} |`);
+      }
+    }
     lines.push("");
   }
 
@@ -380,6 +535,8 @@ function writeMarkdownReport(config: AgentRunConfig, agentMetadata: AgentMetadat
       events: agentMetadata.events,
       testComments: agentMetadata.testComments,
       tokenUsage: agentMetadata.tokenUsage,
+      toolCounts: agentMetadata.toolCounts,
+      skillFiles: agentMetadata.skillFiles,
     };
     fs.writeFileSync(jsonPath, redactSecrets(JSON.stringify(jsonData, null, 2)), "utf-8");
 
@@ -562,7 +719,7 @@ export function useAgentRunner() {
       });
       entry.session = session;
 
-      const agentMetadata: AgentMetadata = { events: [], testComments: [] };
+      const agentMetadata: AgentMetadata = { events: [], testComments: [], toolCounts: {}, skillFiles: {} };
       entry.agentMetadata = agentMetadata;
 
       const done = new Promise<void>((resolve) => {
@@ -639,6 +796,11 @@ export function useAgentRunner() {
       }
 
       agentMetadata.tokenUsage = tokenUsage;
+
+      // Aggregate tool invocation counts and skill-file reads
+      const { toolCounts, skillFiles } = computeToolAndSkillStats(agentMetadata.events, skillDirectory);
+      agentMetadata.toolCounts = toolCounts;
+      agentMetadata.skillFiles = skillFiles;
 
       // Log token usage summary
       if (tokenUsage.apiCallCount > 0) {


### PR DESCRIPTION
Currently the tests/scripts/generate-test-reports.ts generates a report (using report-template.md) that lists the skills and tools used during a test run. However, it depends on Copilot identifying and counting the skills/tools itself, which means it is subject to hallucinations. I have definitely seen it assert a skill was used when it was not, and even make up tool names.

Here we updated agent-runner.ts to dig through the actual event log to positively identify tool and skill usage, and this data is output to the agent-metadata-*.md file generated for a particular test run. We still depend on the LM to read this information and copy it to the final report, but the chances of things being entirely made up will be significantly reduced.

## Example

This is the additional information written to the agent-metadata-*.md file;

# Tool Counts

| Tool | Count |
|------|-------|
| powershell | 2 |
| azure-subscription_list | 1 |
| report_intent | 1 |
| view | 1 |

# Skill Files Read

| Skill | File |
|-------|------|
| azure-cost | D:/repos/ghcfa/output/skills/azure-cost/SKILL.md |
| azure-cost | D:/repos/ghcfa/output/skills/azure-cost/cost-query/workflow.md |
