### PR TITLE
Update .gitignore to ignore *.lscache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -352,4 +352,4 @@ dashboard/dist/
 dashboard/**/dist/
 
 # C# DevKit (VS Code extension) language server cache files
-.lscache
+*.lscache


### PR DESCRIPTION
Change `.lscache` to `*.lscache` so that any file ending in `.lscache` is ignored regardless of directory depth (e.g., C# DevKit language server cache files).