### PR TITLE
Take screenshot of deployed website for deploy integration tests

### DIFF
--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -158,6 +158,12 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Install Playwright browsers
+      - name: Install Playwright Browsers
+        run: |
+          npm install --no-save @playwright/mcp@latest
+          npx playwright install --with-deps chromium
+
       - name: Build plugin output
         run: |
           cd ..

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -161,7 +161,7 @@ jobs:
       # Install Playwright browsers
       - name: Install Playwright Browsers
         run: |
-          npm install --no-save @playwright/mcp@latest
+          npm install --no-save @playwright/mcp@0.0.71
           npx playwright install --with-deps chromium
 
       - name: Build plugin output

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -161,7 +161,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   const FOLLOW_UP_PROMPT = ["Go with recommended options and proceed with Azure deployment."];
   // Static Web Apps (SWA)
   describe("vanilla-static-web-apps-deploy", () => {
-    test("creates whiteboard application", async () => {
+    test("creates whiteboard application with bicep", async () => {
       await withTestResult(async () => {
         let workspacePath: string | undefined;
 
@@ -174,7 +174,10 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
+          takeScreenshot: {
+            predicate: (agentMetadata) => hasDeployLinks(agentMetadata)
+          }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -186,7 +189,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       });
     }, deployTestTimeoutMs);
 
-    test("creates static portfolio website", async () => {
+    test("creates static portfolio website with bicep", async () => {
       await withTestResult(async () => {
         let workspacePath: string | undefined;
 
@@ -199,7 +202,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -228,7 +232,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -253,7 +258,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -470,7 +476,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -495,7 +502,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -523,7 +531,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -548,7 +557,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
-          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment
+          shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -776,7 +786,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -811,7 +822,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -845,7 +857,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -879,7 +892,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -915,7 +929,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForAzdProvision,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -1064,7 +1079,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -1098,7 +1114,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -1132,7 +1149,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -1166,7 +1184,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);
@@ -1200,7 +1219,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          followUpTimeout: brownfieldTestTimeoutMs
+          followUpTimeout: brownfieldTestTimeoutMs,
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -175,9 +175,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           followUp: FOLLOW_UP_PROMPT,
           preserveWorkspace: true,
           shouldEarlyTerminate: shouldEarlyTerminateForCompletedDeployment,
-          takeScreenshot: {
-            predicate: (agentMetadata) => hasDeployLinks(agentMetadata)
-          }
+          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
         });
 
         softCheckDeploySkills(agentMetadata);

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -927,8 +927,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,
           shouldEarlyTerminate: shouldEarlyTerminateForAzdProvision,
-          followUpTimeout: brownfieldTestTimeoutMs,
-          takeScreenshot: { predicate: (agentMetadata) => hasDeployLinks(agentMetadata) }
+          followUpTimeout: brownfieldTestTimeoutMs
         });
 
         softCheckDeploySkills(agentMetadata);

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -665,7 +665,7 @@ export function useAgentRunner() {
       }
 
       if (config.takeScreenshot && config.takeScreenshot.predicate(agentMetadata)) {
-        // Resume the session so it can take a completely set of skills and mcp servers.
+        // Resume the session so it can take a different set of skills and mcp servers.
         // Use playwright mcp server to take a screenshot.
         const screenshotTimeout = 180000; // 3 minutes
         const screenshotPath = path.join(buildTestCaseDirPath(), "app-snapshot.jpg");
@@ -674,7 +674,7 @@ export function useAgentRunner() {
             playwright: {
               command: "npx",
               args: [
-                "@playwright/mcp@latest"
+                "@playwright/mcp@0.0.71"
               ],
               tools: ["*"]
             }

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -668,7 +668,7 @@ export function useAgentRunner() {
         // Resume the session so it can take a completely set of skills and mcp servers.
         // Use playwright mcp server to take a screenshot.
         const screenshotTimeout = 180000; // 3 minutes
-        const screenshotPath = path.join(buildTestCaseDirPath(), `app-snapshot.jpg`);
+        const screenshotPath = path.join(buildTestCaseDirPath(), "app-snapshot.jpg");
         const playwrightSession = await client.resumeSession(session.sessionId, {
           mcpServers: {
             playwright: {
@@ -814,7 +814,6 @@ function buildShareFilePath(): string {
   const testCaseArtifactsDir = buildTestCaseDirPath();
   return path.join(testCaseArtifactsDir, `agent-metadata-${new Date().toISOString().replace(/[:.]/g, "-")}.md`);
 }
-
 
 function isTest(): boolean {
   try {

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -118,6 +118,15 @@ export interface AgentRunConfig {
    * Number of milliseconds as timeout for follow ups.
    */
   followUpTimeout?: number;
+
+  /**
+   * Whether to take a screenshot of the application after the agent work.
+   * The predicate function will be called with the agentMetadata. If the return value is true, the agent runner will attempt to take a screenshot of the app. Otherwise, no screenshot will be taken.
+   * If undefined, the agent runner won't attempt to take a screenshot.
+   */
+  takeScreenshot?: {
+    predicate: (agentMetadata: AgentMetadata) => boolean
+  };
 }
 
 interface KeywordOptions {
@@ -517,7 +526,7 @@ export function useAgentRunner() {
       const cliArgs: string[] = config.nonInteractive ? ["--yolo"] : [];
       if (process.env.DEBUG && isTest()) {
         cliArgs.push("--log-dir");
-        cliArgs.push(buildLogFilePath());
+        cliArgs.push(buildTestCaseDirPath());
       }
 
       const client = new CopilotClient({
@@ -655,6 +664,34 @@ export function useAgentRunner() {
         await session.sendAndWait({ prompt: followUpPrompt }, FOLLOW_UP_TIMEOUT);
       }
 
+      if (config.takeScreenshot && config.takeScreenshot.predicate(agentMetadata)) {
+        // Resume the session so it can take a completely set of skills and mcp servers.
+        // Use playwright mcp server to take a screenshot.
+        const screenshotTimeout = 180000; // 3 minutes
+        const screenshotPath = path.join(buildTestCaseDirPath(), `app-snapshot.jpg`);
+        const playwrightSession = await client.resumeSession(session.sessionId, {
+          mcpServers: {
+            playwright: {
+              command: "npx",
+              args: [
+                "@playwright/mcp@latest"
+              ],
+              tools: ["*"]
+            }
+          },
+          onPermissionRequest: approveAll
+        });
+        await playwrightSession.sendAndWait({
+          prompt: `Use playwright mcp tools to take a screenshot of the deployed app. Save the screenshot to this directory at this file location ${screenshotPath}`
+        }, screenshotTimeout);
+
+        // Check if screenshot was successfully created
+        const screenshotExists = fs.existsSync(screenshotPath);
+        agentMetadata.testComments.push(
+          `Screenshot attempt: ${screenshotExists ? "✓ app-snapshot.jpg created successfully" : "✗ app-snapshot.jpg not found after screenshot attempt"}`
+        );
+      }
+
       return agentMetadata;
     } catch (error) {
       // Mark as complete to stop event processing
@@ -767,16 +804,17 @@ export function getIntegrationSkipReason(): string | undefined {
 
 const DEFAULT_REPORT_DIR = path.join(__dirname, "..", "reports");
 const TIME_STAMP = (process.env.START_TIMESTAMP || new Date().toISOString()).replace(/[:.]/g, "-");
+const testRunDirectoryName = `test-run-${testRunId || TIME_STAMP}`;
 
-function buildShareFilePath(): string {
-  const testRunDirectoryName = `test-run-${testRunId || TIME_STAMP}`;
-  return path.join(DEFAULT_REPORT_DIR, testRunDirectoryName, getTestName(), `agent-metadata-${new Date().toISOString().replace(/[:.]/g, "-")}.md`);
-}
-
-function buildLogFilePath(): string {
-  const testRunDirectoryName = `test-run-${testRunId || TIME_STAMP}`;
+function buildTestCaseDirPath(): string {
   return path.join(DEFAULT_REPORT_DIR, testRunDirectoryName, getTestName());
 }
+
+function buildShareFilePath(): string {
+  const testCaseArtifactsDir = buildTestCaseDirPath();
+  return path.join(testCaseArtifactsDir, `agent-metadata-${new Date().toISOString().replace(/[:.]/g, "-")}.md`);
+}
+
 
 function isTest(): boolean {
   try {


### PR DESCRIPTION
## Description

This PR adds an additional optional step to use a modified agent session with Playwright MCP tools to take a screenshot of the deployed website for deploy integration tests that deploy websites. The screenshots generated in the nightly runs will be uploaded as a part of the test results to the destination storage.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

resolves #1008
