### PR TITLE
Remove a problematic azure-deploy test

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -111,28 +111,6 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       });
     });
 
-    test("invokes azure-deploy skill for live RBAC role verification prompt", async () => {
-      await withTestResult(async ({ setSkillInvocationRate }) => {
-        let invocationCount = 0;
-        for (let i = 0; i < RUNS_PER_PROMPT; i++) {
-          const agentMetadata = await agent.run({
-            prompt: "Deploy my app to Azure and verify the live RBAC role assignments are correct after provisioning",
-            nonInteractive: true,
-            followUp,
-            shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
-          });
-
-          softCheckSkill(agentMetadata, SKILL_NAME);
-          if (isSkillInvoked(agentMetadata, SKILL_NAME)) {
-            invocationCount += 1;
-          }
-        }
-        const rate = invocationCount / RUNS_PER_PROMPT;
-        setSkillInvocationRate(rate);
-        expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-      });
-    });
-
     test("invokes azure-deploy skill for post-deployment role assignment check prompt", async () => {
       await withTestResult(async ({ setSkillInvocationRate }) => {
         let invocationCount = 0;


### PR DESCRIPTION
## Description

This PR removes a problematic skill invocation test that is consistently failing. When the agent runs the test case, it does the following things in order:

1. The agent reasons that it may need to use azure-deploy and azure-rbac skill
2. It scans the workspace, finds no file
3. Stop and yield control back to user

Example run of the problematic test case: https://agreeable-dune-0f718070f.1.azurestaticapps.net/nightly-runs.html?file=2026-04-28%2F25043236263%2Fazure-deploy%2Fskill-invocation%2Fazure-deploy_-_Integration_Tests_skill-invocation_invokes_azure-deploy_skill_for_live_RBAC_role_verification_prompt%2Fagent-metadata-2026-04-28T08-51-33-315Z.md

The agent behavior is reasonable. The fact that we ask it to deploy an app from an empty workspace is not reasonable.

Another skill invocation test has similar problem but has been passing. `Deploy my already-prepared Azure app and confirm the managed identity roles are properly assigned`. I believe it dodged problem by asserting that there is already a prepared app in the workspace, even though there isn't, which convinces the agent to not check the existing files and invoke the azure-deploy skill directly.

Example run for the other test case: https://agreeable-dune-0f718070f.1.azurestaticapps.net/nightly-runs.html?file=2026-04-28%2F25043236263%2Fazure-deploy%2Fskill-invocation%2Fazure-deploy_-_Integration_Tests_skill-invocation_invokes_azure-deploy_skill_for_post-deployment_role_assignment_check_prompt%2Fagent-metadata-2026-04-28T08-51-42-378Z.md

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills
- [ ] Version bumped in skill frontmatter (if skill files changed)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
