### PR TITLE
Fix tool, skill, and token counts

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -775,6 +775,13 @@ export function useAgentRunner() {
       await session.send({ prompt: config.prompt });
       await done;
 
+      // Send follow-up prompts before aggregating stats so tool/skill/token
+      // counts include events emitted during follow-up turns.
+      for (const followUpPrompt of config.followUp ?? []) {
+        isComplete = false;
+        await session.sendAndWait({ prompt: followUpPrompt }, FOLLOW_UP_TIMEOUT);
+      }
+
       // Extract token usage from assistant.usage events
       const tokenUsage: TokenUsage = {
         inputTokens: 0,
@@ -834,12 +841,6 @@ export function useAgentRunner() {
           `${tokenUsage.apiCallCount} API calls | ` +
           `Duration: ${(tokenUsage.totalApiDurationMs / 1000).toFixed(1)}s\n`
         );
-      }
-
-      // Send follow-up prompts
-      for (const followUpPrompt of config.followUp ?? []) {
-        isComplete = false;
-        await session.sendAndWait({ prompt: followUpPrompt }, FOLLOW_UP_TIMEOUT);
       }
 
       if (config.takeScreenshot && config.takeScreenshot.predicate(agentMetadata)) {


### PR DESCRIPTION
It turns out we were only counting the tools, skills, and tokens used after submitting the initial prompt, but _before_ submitting any follow-up prompts. This would generally lead us to undercount all of these things.

Here we fix the issue by sending the follow-up prompts before performing the counts.

## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
