### PR TITLE
Add shortcut button for viewing agent metadata

### DIFF
--- a/dashboard/Readme.md
+++ b/dashboard/Readme.md
@@ -51,8 +51,7 @@ From the `dashboard/api/` directory:
 
 ```bash
 npm install
-npm run build
-func start --port 7071
+npm run dev
 ```
 
 The default configuration points the frontend at `http://localhost:7071` for API requests. To use a different port, update the proxy setting in `vite.config.ts` as well.

--- a/dashboard/api/package.json
+++ b/dashboard/api/package.json
@@ -9,7 +9,7 @@
         "watch": "tsc -w",
         "prestart": "npm run build",
         "start": "func start",
-        "dev": "npm run build; func start --port 7071",
+        "dev": "npm run build && func start --port 7071",
         "test": "echo \"No tests yet\""
     },
     "dependencies": {

--- a/dashboard/api/package.json
+++ b/dashboard/api/package.json
@@ -9,6 +9,7 @@
         "watch": "tsc -w",
         "prestart": "npm run build",
         "start": "func start",
+        "dev": "npm run build; func start --port 7071",
         "test": "echo \"No tests yet\""
     },
     "dependencies": {

--- a/dashboard/api/src/blobEnumerator.ts
+++ b/dashboard/api/src/blobEnumerator.ts
@@ -1,36 +1,10 @@
 import { BlobServiceClient, ContainerClient } from "@azure/storage-blob";
 import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
+import type { BlobEntry, BlobTree, BlobTreeNode } from "../../shared/blobTree";
 
 const INTEGRATION_REPORTS_CONTAINER_NAME = "integration-reports";
 
 const EXCLUDED_FILENAMES = new Set(["token-usage.json", "agent-metadata.json"]);
-
-export interface BlobEntry {
-    /**
-     * Name of the last segment in the blob path
-     */
-    name: string;
-    /**
-     * Full blob path
-     */
-    blobName: string
-};
-
-/**
- * A nested tree node representing a segment of a blob path.
- * Directories have children; leaf nodes have a `blobName` pointing to the full blob path.
- */
-export interface BlobTreeNode {
-    /** Files directly in this path segment (leaf blobs). */
-    files: BlobEntry[];
-    /** Child path segments, keyed by segment name. */
-    children: Record<string, BlobTreeNode>;
-}
-
-/**
- * Top-level structure: date string (yyyy-mm-dd) → nested tree of path segments.
- */
-export type BlobTree = Record<string, BlobTreeNode>;
 
 function createNode(): BlobTreeNode {
     return { files: [], children: {} };

--- a/dashboard/api/src/functions/getReports.ts
+++ b/dashboard/api/src/functions/getReports.ts
@@ -1,7 +1,8 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
-import { enumerateBlobs, getBlobContent, BlobTree, BlobTreeNode } from "../blobEnumerator";
+import { enumerateBlobs, getBlobContent, } from "../blobEnumerator";
 import { logRequestIdentity } from "../requestIdentity";
 import { SKILL_REPORT_PATTERN } from "../skillReport";
+import type { BlobTree, BlobTreeNode } from "../../../shared/blobTree";
 
 /**
  * Recursively collect all blob paths matching the SKILL-REPORT pattern from a tree node.

--- a/dashboard/api/src/functions/getTestResults.ts
+++ b/dashboard/api/src/functions/getTestResults.ts
@@ -1,7 +1,8 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
-import { enumerateBlobs, getBlobContent, BlobTree, BlobTreeNode } from "../blobEnumerator";
+import { enumerateBlobs, getBlobContent } from "../blobEnumerator";
 import { logRequestIdentity } from "../requestIdentity";
 import { SKILL_REPORT_PATTERN } from "../skillReport";
+import type { BlobTree, BlobTreeNode } from "../../../shared/blobTree";
 
 const TEST_RESULTS_FILENAME = "testResults.json";
 

--- a/dashboard/api/src/msbenchBlobEnumerator.ts
+++ b/dashboard/api/src/msbenchBlobEnumerator.ts
@@ -1,5 +1,6 @@
 import { BlobServiceClient, ContainerClient } from "@azure/storage-blob";
-import { BlobTree, listDatePrefixes, enumerateBlobTree, downloadBlobContent, getCredential } from "./blobEnumerator";
+import { listDatePrefixes, enumerateBlobTree, downloadBlobContent, getCredential } from "./blobEnumerator";
+import type { BlobTree } from "../../shared/blobTree";
 
 const MSBENCH_STORAGE_ACCOUNT = process.env.MSBENCH_STORAGE_ACCOUNT;
 const MSBENCH_REPORTS_CONTAINER_NAME = process.env.MSBENCH_REPORTS_CONTAINER;

--- a/dashboard/shared/blobTree.d.ts
+++ b/dashboard/shared/blobTree.d.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared blob-tree types used across the dashboard frontend (Vite/React),
+ * the SWA API (`dashboard/api`), and the sync function app (`dashboard/sync`).
+ *
+ * Declared as `.d.ts` so the file emits no JS and does not participate in
+ * the per-project `rootDir` restriction. Consumers import via relative path.
+ */
+
+export interface BlobEntry {
+    /** Name of the last segment in the blob path. */
+    name: string;
+    /** Full blob path. */
+    blobName: string;
+}
+
+/**
+ * A nested tree node representing a segment of a blob path.
+ * Directories have children; leaf entries live in `files`.
+ */
+export interface BlobTreeNode {
+    /** Files directly in this path segment (leaf blobs). */
+    files: BlobEntry[];
+    /** Child path segments, keyed by segment name. */
+    children: Record<string, BlobTreeNode>;
+}
+
+/**
+ * Top-level structure: date string (yyyy-mm-dd) -> nested tree of path segments.
+ */
+export type BlobTree = Record<string, BlobTreeNode>;

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -1,9 +1,49 @@
 import { useEffect, useState } from "react";
+import type { BlobTree, BlobTreeNode } from "../../api/src/blobEnumerator";
 
 interface TestCase {
     testName: string;
     message?: string;
     skillInvocationRate?: number;
+}
+
+async function openAgentMetadataLinks(date: string, testName: string): Promise<void> {
+    const res = await fetch(`/api/data/${encodeURIComponent(date)}`);
+    if (!res.ok) throw new Error(`API error: ${res.status}`);
+    const tree = (await res.json()) as BlobTree;
+    const dateNode = tree[date];
+    if (!dateNode) throw new Error("No data for this date.");
+
+    const targetFolder = `/${formatTestName(testName)}/`;
+    const matches: string[] = [];
+    const walk = (node: BlobTreeNode): void => {
+        for (const file of node.files) {
+            if (
+                file.blobName.includes(targetFolder) &&
+                /\/agent-metadata-[^/]+\.md$/.test(file.blobName)
+            ) {
+                matches.push(file.blobName);
+            }
+        }
+        for (const child of Object.values(node.children)) {
+            walk(child);
+        }
+    };
+    walk(dateNode);
+
+    if (matches.length === 0) {
+        throw new Error("No agentMetadata files found for this test case.");
+    }
+    for (const blobName of matches) {
+        // Note: when there are multiple matches, the browser may block attempts
+        // to open the new page after the first one.
+        // The user may unblock pop ups from this website or open them individually.
+        window.open(
+            `/nightly-runs.html?file=${encodeURIComponent(blobName)}`,
+            "_blank",
+            "noopener,noreferrer",
+        );
+    }
 }
 
 interface SkillStats {
@@ -209,6 +249,10 @@ function App() {
                                         {ft.message && (
                                             <span className="it-failed-message">{ft.message}</span>
                                         )}
+                                        <ViewAgentMetadataButton
+                                            date={selectedDate!}
+                                            testName={ft.testName}
+                                        />
                                     </li>
                                 ))}
                             </ul>
@@ -235,6 +279,10 @@ function App() {
                                                 rate: {formatRate(pt.skillInvocationRate)}
                                             </span>
                                         )}
+                                        <ViewAgentMetadataButton
+                                            date={selectedDate!}
+                                            testName={pt.testName}
+                                        />
                                     </li>
                                 ))}
                             </ul>
@@ -243,6 +291,36 @@ function App() {
                 )}
             </div>
         </div>
+    );
+}
+
+function ViewAgentMetadataButton({ date, testName }: { date: string; testName: string }) {
+    const [busy, setBusy] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+
+    const onClick = async () => {
+        setBusy(true);
+        setErr(null);
+        try {
+            await openAgentMetadataLinks(date, testName);
+        } catch (e) {
+            setErr((e as Error).message);
+        } finally {
+            setBusy(false);
+        }
+    };
+
+    return (
+        <span className="it-view-agent-metadata">
+            <button
+                className="it-view-agent-metadata-btn"
+                onClick={onClick}
+                disabled={busy}
+            >
+                {busy ? "Loading\u2026" : "view agentMetadata"}
+            </button>
+            {err && <span className="it-view-agent-metadata-error">{err}</span>}
+        </span>
     );
 }
 

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -304,7 +304,7 @@ function ViewAgentMetadataButton({ date, testName }: { date: string; testName: s
         try {
             await openAgentMetadataLinks(date, testName);
         } catch (e) {
-            setErr((e as Error).message);
+            setErr(e instanceof Error ? e.message : String(e));
         } finally {
             setBusy(false);
         }

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { BlobTree, BlobTreeNode } from "../../api/src/blobEnumerator";
+import type { BlobTree, BlobTreeNode } from "../../shared/blobTree";
 
 interface TestCase {
     testName: string;

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -7,10 +7,31 @@ interface TestCase {
     skillInvocationRate?: number;
 }
 
+// Cache /api/data/{date} responses keyed by encoded date so repeated lookups
+// (e.g. clicking the agentMetadata button on multiple test cases for the
+// same date) reuse a single network request.
+const blobTreeCache = new Map<string, Promise<BlobTree>>();
+
+function fetchBlobTree(date: string): Promise<BlobTree> {
+    const key = encodeURIComponent(date);
+    let cached = blobTreeCache.get(key);
+    if (!cached) {
+        cached = fetch(`/api/data/${key}`)
+            .then((res) => {
+                if (!res.ok) throw new Error(`API error: ${res.status}`);
+                return res.json() as Promise<BlobTree>;
+            })
+            .catch((err) => {
+                blobTreeCache.delete(key);
+                throw err;
+            });
+        blobTreeCache.set(key, cached);
+    }
+    return cached;
+}
+
 async function openAgentMetadataLinks(date: string, testName: string): Promise<void> {
-    const res = await fetch(`/api/data/${encodeURIComponent(date)}`);
-    if (!res.ok) throw new Error(`API error: ${res.status}`);
-    const tree = (await res.json()) as BlobTree;
+    const tree = await fetchBlobTree(date);
     const dateNode = tree[date];
     if (!dateNode) throw new Error("No data for this date.");
 

--- a/dashboard/src/integration-tests/integration-tests.css
+++ b/dashboard/src/integration-tests/integration-tests.css
@@ -379,6 +379,45 @@ body:has(.it-dashboard) {
     color: var(--color-pass);
 }
 
+/* ── View agentMetadata button ──────────── */
+
+.it-view-agent-metadata {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 4px;
+}
+
+.it-view-agent-metadata-btn {
+    padding: 2px 8px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    font-family: inherit;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.it-view-agent-metadata-btn:hover:not(:disabled) {
+    background: var(--color-focus);
+    color: #fff;
+    border-color: var(--color-focus);
+}
+
+.it-view-agent-metadata-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
+.it-view-agent-metadata-error {
+    font-size: 0.6875rem;
+    color: var(--color-fail);
+}
+
 /* ── Responsive ─────────────────────────── */
 
 @media (max-width: 768px) {

--- a/dashboard/src/msbench-nightly-runs/App.tsx
+++ b/dashboard/src/msbench-nightly-runs/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import FileViewer from "./FileViewer";
-import type { BlobEntry, BlobTree, BlobTreeNode } from "../../api/src/blobEnumerator";
+import type { BlobEntry, BlobTree, BlobTreeNode } from "../../shared/blobTree";
 
 /**
  * Recursively collect all .md files from a blob tree node.

--- a/dashboard/src/msbench-nightly-runs/App.tsx
+++ b/dashboard/src/msbench-nightly-runs/App.tsx
@@ -2,18 +2,7 @@ import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import FileViewer from "./FileViewer";
-
-interface BlobEntry {
-    name: string;
-    blobName: string;
-}
-
-interface BlobTreeNode {
-    files: BlobEntry[];
-    children: Record<string, BlobTreeNode>;
-}
-
-type BlobTree = Record<string, BlobTreeNode>;
+import type { BlobEntry, BlobTree, BlobTreeNode } from "../../api/src/blobEnumerator";
 
 /**
  * Recursively collect all .md files from a blob tree node.

--- a/dashboard/src/nightly-runs/App.tsx
+++ b/dashboard/src/nightly-runs/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import FileViewer from "./FileViewer";
-import type { BlobEntry, BlobTree, BlobTreeNode } from "../../api/src/blobEnumerator";
+import type { BlobEntry, BlobTree, BlobTreeNode } from "../../shared/blobTree";
 
 interface FileSection {
     label: string;

--- a/dashboard/src/nightly-runs/App.tsx
+++ b/dashboard/src/nightly-runs/App.tsx
@@ -2,18 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import FileViewer from "./FileViewer";
-
-interface BlobEntry {
-    name: string;
-    blobName: string;
-}
-
-interface BlobTreeNode {
-    files: BlobEntry[];
-    children: Record<string, BlobTreeNode>;
-}
-
-type BlobTree = Record<string, BlobTreeNode>;
+import type { BlobEntry, BlobTree, BlobTreeNode } from "../../api/src/blobEnumerator";
 
 interface FileSection {
     label: string;

--- a/dashboard/sync/src/functions/syncMsbenchEvalMetrics.ts
+++ b/dashboard/sync/src/functions/syncMsbenchEvalMetrics.ts
@@ -1,7 +1,8 @@
 import { app, HttpRequest, HttpResponseInit, InvocationContext, Timer } from "@azure/functions";
 import { TableClient } from "@azure/data-tables";
 import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
-import { listMsbenchDates, enumerateMsbenchBlobs, getMsbenchBlobContent, BlobTreeNode } from "../msbenchBlobEnumerator";
+import { listMsbenchDates, enumerateMsbenchBlobs, getMsbenchBlobContent } from "../msbenchBlobEnumerator";
+import type { BlobTreeNode } from "../../../shared/blobTree";
 
 const MSBENCH_STORAGE_ACCOUNT = process.env.MSBENCH_STORAGE_ACCOUNT;
 const EVAL_TABLE_NAME = process.env.MSBENCH_EVAL_TABLE_NAME;

--- a/dashboard/sync/src/msbenchBlobEnumerator.ts
+++ b/dashboard/sync/src/msbenchBlobEnumerator.ts
@@ -1,17 +1,6 @@
 import { BlobServiceClient } from "@azure/storage-blob";
 import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
-
-export interface BlobEntry {
-    name: string;
-    blobName: string;
-}
-
-export interface BlobTreeNode {
-    files: BlobEntry[];
-    children: Record<string, BlobTreeNode>;
-}
-
-export type BlobTree = Record<string, BlobTreeNode>;
+import type { BlobTree, BlobTreeNode } from "../../shared/blobTree";
 
 const MSBENCH_STORAGE_ACCOUNT = process.env.MSBENCH_STORAGE_ACCOUNT;
 const MSBENCH_REPORTS_CONTAINER_NAME = process.env.MSBENCH_REPORTS_CONTAINER;


### PR DESCRIPTION
## Description

For every test case enumerated in the integration-tests view, add a `view agentMetadata` button that can directly open the agent-metadata file viewer for this test case. This new UI flow replaces the tedious one of clicking the test case link to list all its artifacts and then click on the agent-metadata file link to view it.

The PR also implemented two misc improvements:
- Remove redundant interface definitions
- Add a helper npm command for starting the api backend for local testing

A screenshot of the test case list with the button:
<img width="313" height="458" alt="Screenshot 2026-04-29 at 10 48 15 AM" src="https://github.com/user-attachments/assets/5bf1625f-7cd6-4a0a-ae74-2a32fb0b642e" />


## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
