### PR TITLE
Fix integration test dashboard deployment

### DIFF
--- a/dashboard/api/src/blobEnumerator.ts
+++ b/dashboard/api/src/blobEnumerator.ts
@@ -1,6 +1,6 @@
 import { BlobServiceClient, ContainerClient } from "@azure/storage-blob";
 import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
-import type { BlobEntry, BlobTree, BlobTreeNode } from "../../shared/blobTree";
+import type { BlobEntry, BlobTree, BlobTreeNode } from "./shared/blobTree";
 
 const INTEGRATION_REPORTS_CONTAINER_NAME = "integration-reports";
 

--- a/dashboard/api/src/functions/getReports.ts
+++ b/dashboard/api/src/functions/getReports.ts
@@ -2,7 +2,7 @@ import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/fu
 import { enumerateBlobs, getBlobContent, } from "../blobEnumerator";
 import { logRequestIdentity } from "../requestIdentity";
 import { SKILL_REPORT_PATTERN } from "../skillReport";
-import type { BlobTree, BlobTreeNode } from "../../../shared/blobTree";
+import type { BlobTree, BlobTreeNode } from "../shared/blobTree";
 
 /**
  * Recursively collect all blob paths matching the SKILL-REPORT pattern from a tree node.

--- a/dashboard/api/src/functions/getTestResults.ts
+++ b/dashboard/api/src/functions/getTestResults.ts
@@ -2,7 +2,7 @@ import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/fu
 import { enumerateBlobs, getBlobContent } from "../blobEnumerator";
 import { logRequestIdentity } from "../requestIdentity";
 import { SKILL_REPORT_PATTERN } from "../skillReport";
-import type { BlobTree, BlobTreeNode } from "../../../shared/blobTree";
+import type { BlobTree, BlobTreeNode } from "../shared/blobTree";
 
 const TEST_RESULTS_FILENAME = "testResults.json";
 

--- a/dashboard/api/src/msbenchBlobEnumerator.ts
+++ b/dashboard/api/src/msbenchBlobEnumerator.ts
@@ -1,6 +1,6 @@
 import { BlobServiceClient, ContainerClient } from "@azure/storage-blob";
 import { listDatePrefixes, enumerateBlobTree, downloadBlobContent, getCredential } from "./blobEnumerator";
-import type { BlobTree } from "../../shared/blobTree";
+import type { BlobTree } from "./shared/blobTree";
 
 const MSBENCH_STORAGE_ACCOUNT = process.env.MSBENCH_STORAGE_ACCOUNT;
 const MSBENCH_REPORTS_CONTAINER_NAME = process.env.MSBENCH_REPORTS_CONTAINER;

--- a/dashboard/api/src/shared/blobTree.ts
+++ b/dashboard/api/src/shared/blobTree.ts
@@ -1,0 +1,35 @@
+/**
+ * Blob-tree types used by the dashboard SWA API (`dashboard/api`).
+ *
+ * Note: This file is duplicated across `dashboard/src/shared`,
+ * `dashboard/api/src/shared`, and `dashboard/sync/src/shared` so each
+ * sub-project can compile under its own `rootDir`. Keep them in sync.
+ *
+ * WARNING: Do NOT consolidate these interfaces into a single file at the
+ * root of the project. Each sub-project (root, api/, sync/) has its own
+ * tsconfig with a scoped `rootDir`, and the deployment-time build will
+ * fail if a shared file lives outside the sub-project's source tree.
+ */
+
+export interface BlobEntry {
+    /** Name of the last segment in the blob path. */
+    name: string;
+    /** Full blob path. */
+    blobName: string;
+}
+
+/**
+ * A nested tree node representing a segment of a blob path.
+ * Directories have children; leaf entries live in `files`.
+ */
+export interface BlobTreeNode {
+    /** Files directly in this path segment (leaf blobs). */
+    files: BlobEntry[];
+    /** Child path segments, keyed by segment name. */
+    children: Record<string, BlobTreeNode>;
+}
+
+/**
+ * Top-level structure: date string (yyyy-mm-dd) -> nested tree of path segments.
+ */
+export type BlobTree = Record<string, BlobTreeNode>;

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import type { BlobTree, BlobTreeNode } from "../../shared/blobTree";
+import type { BlobTree, BlobTreeNode } from "../shared/blobTree";
 
 interface TestCase {
     testName: string;

--- a/dashboard/src/msbench-nightly-runs/App.tsx
+++ b/dashboard/src/msbench-nightly-runs/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import FileViewer from "./FileViewer";
-import type { BlobEntry, BlobTree, BlobTreeNode } from "../../shared/blobTree";
+import type { BlobEntry, BlobTree, BlobTreeNode } from "../shared/blobTree";
 
 /**
  * Recursively collect all .md files from a blob tree node.

--- a/dashboard/src/nightly-runs/App.tsx
+++ b/dashboard/src/nightly-runs/App.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState, useCallback } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import FileViewer from "./FileViewer";
-import type { BlobEntry, BlobTree, BlobTreeNode } from "../../shared/blobTree";
+import type { BlobEntry, BlobTree, BlobTreeNode } from "../shared/blobTree";
 
 interface FileSection {
     label: string;

--- a/dashboard/src/shared/blobTree.ts
+++ b/dashboard/src/shared/blobTree.ts
@@ -1,0 +1,35 @@
+/**
+ * Blob-tree types used by the dashboard frontend (Vite/React).
+ *
+ * Note: This file is duplicated across `dashboard/src/shared`,
+ * `dashboard/api/src/shared`, and `dashboard/sync/src/shared` so each
+ * sub-project can compile under its own `rootDir`. Keep them in sync.
+ *
+ * WARNING: Do NOT consolidate these interfaces into a single file at the
+ * root of the project. Each sub-project (root, api/, sync/) has its own
+ * tsconfig with a scoped `rootDir`, and the deployment-time build will
+ * fail if a shared file lives outside the sub-project's source tree.
+ */
+
+export interface BlobEntry {
+    /** Name of the last segment in the blob path. */
+    name: string;
+    /** Full blob path. */
+    blobName: string;
+}
+
+/**
+ * A nested tree node representing a segment of a blob path.
+ * Directories have children; leaf entries live in `files`.
+ */
+export interface BlobTreeNode {
+    /** Files directly in this path segment (leaf blobs). */
+    files: BlobEntry[];
+    /** Child path segments, keyed by segment name. */
+    children: Record<string, BlobTreeNode>;
+}
+
+/**
+ * Top-level structure: date string (yyyy-mm-dd) -> nested tree of path segments.
+ */
+export type BlobTree = Record<string, BlobTreeNode>;

--- a/dashboard/sync/src/functions/syncMsbenchEvalMetrics.ts
+++ b/dashboard/sync/src/functions/syncMsbenchEvalMetrics.ts
@@ -2,7 +2,7 @@ import { app, HttpRequest, HttpResponseInit, InvocationContext, Timer } from "@a
 import { TableClient } from "@azure/data-tables";
 import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
 import { listMsbenchDates, enumerateMsbenchBlobs, getMsbenchBlobContent } from "../msbenchBlobEnumerator";
-import type { BlobTreeNode } from "../../../shared/blobTree";
+import type { BlobTreeNode } from "../shared/blobTree";
 
 const MSBENCH_STORAGE_ACCOUNT = process.env.MSBENCH_STORAGE_ACCOUNT;
 const EVAL_TABLE_NAME = process.env.MSBENCH_EVAL_TABLE_NAME;

--- a/dashboard/sync/src/msbenchBlobEnumerator.ts
+++ b/dashboard/sync/src/msbenchBlobEnumerator.ts
@@ -1,6 +1,6 @@
 import { BlobServiceClient } from "@azure/storage-blob";
 import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
-import type { BlobTree, BlobTreeNode } from "../../shared/blobTree";
+import type { BlobTree, BlobTreeNode } from "./shared/blobTree";
 
 const MSBENCH_STORAGE_ACCOUNT = process.env.MSBENCH_STORAGE_ACCOUNT;
 const MSBENCH_REPORTS_CONTAINER_NAME = process.env.MSBENCH_REPORTS_CONTAINER;

--- a/dashboard/sync/src/shared/blobTree.ts
+++ b/dashboard/sync/src/shared/blobTree.ts
@@ -1,0 +1,35 @@
+/**
+ * Blob-tree types used by the sync function app (`dashboard/sync`).
+ *
+ * Note: This file is duplicated across `dashboard/src/shared`,
+ * `dashboard/api/src/shared`, and `dashboard/sync/src/shared` so each
+ * sub-project can compile under its own `rootDir`. Keep them in sync.
+ *
+ * WARNING: Do NOT consolidate these interfaces into a single file at the
+ * root of the project. Each sub-project (root, api/, sync/) has its own
+ * tsconfig with a scoped `rootDir`, and the deployment-time build will
+ * fail if a shared file lives outside the sub-project's source tree.
+ */
+
+export interface BlobEntry {
+    /** Name of the last segment in the blob path. */
+    name: string;
+    /** Full blob path. */
+    blobName: string;
+}
+
+/**
+ * A nested tree node representing a segment of a blob path.
+ * Directories have children; leaf entries live in `files`.
+ */
+export interface BlobTreeNode {
+    /** Files directly in this path segment (leaf blobs). */
+    files: BlobEntry[];
+    /** Child path segments, keyed by segment name. */
+    children: Record<string, BlobTreeNode>;
+}
+
+/**
+ * Top-level structure: date string (yyyy-mm-dd) -> nested tree of path segments.
+ */
+export type BlobTree = Record<string, BlobTreeNode>;


### PR DESCRIPTION
## Description

It turns out the deployment-time build would fail if we consolidate the shared interface. This PR ensures each sub-project has one copy of the shared interfaces and has comment warning people from trying to consolidate them like I did.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
