### PR TITLE
Increase timeout of deploy tests by 10 min

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -33,8 +33,8 @@ if (skipTests && skipReason) {
 }
 
 const describeIntegration = skipTests ? describe.skip : describe;
-const deployTestTimeoutMs = 1800000;
-const brownfieldTestTimeoutMs = 2700000;
+const deployTestTimeoutMs = 40 * 60 * 1000; // 40 minutes
+const brownfieldTestTimeoutMs = 3300000; // 55 minutes
 
 const pseudoRandomResourceGroupNameSystemPromptModifier = {
   mode: "append" as const,

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -34,7 +34,7 @@ if (skipTests && skipReason) {
 
 const describeIntegration = skipTests ? describe.skip : describe;
 const deployTestTimeoutMs = 40 * 60 * 1000; // 40 minutes
-const brownfieldTestTimeoutMs = 3300000; // 55 minutes
+const brownfieldTestTimeoutMs = 55 * 60 * 1000; // 55 minutes
 
 const pseudoRandomResourceGroupNameSystemPromptModifier = {
   mode: "append" as const,


### PR DESCRIPTION
## Description

We've seen more tests running into timeout while still making reasonable progress. Increase the time to 10 minute to see if this is Azure/azd regression or there are issues yet to be found by the agent generated code.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
