### PR TITLE
azure-deploy test website preview

### DIFF
--- a/dashboard/api/src/blobEnumerator.ts
+++ b/dashboard/api/src/blobEnumerator.ts
@@ -103,7 +103,7 @@ export async function downloadBlobBuffer(containerClient: ContainerClient, blobP
     const blobClient = containerClient.getBlobClient(blobPath);
     const response = await blobClient.download();
     if (!response.readableStreamBody) {
-        return Buffer.alloc(0);
+        throw new Error(`Blob download did not return a readable stream for path: ${blobPath}`);
     }
     const chunks: Buffer[] = [];
     for await (const chunk of response.readableStreamBody) {

--- a/dashboard/api/src/blobEnumerator.ts
+++ b/dashboard/api/src/blobEnumerator.ts
@@ -97,19 +97,27 @@ export async function enumerateBlobTree(containerClient: ContainerClient, prefix
 }
 
 /**
- * Download a blob's content as a UTF-8 string.
+ * Download a blob's content as a Buffer.
  */
-export async function downloadBlobContent(containerClient: ContainerClient, blobPath: string): Promise<string> {
+export async function downloadBlobBuffer(containerClient: ContainerClient, blobPath: string): Promise<Buffer> {
     const blobClient = containerClient.getBlobClient(blobPath);
     const response = await blobClient.download();
     if (!response.readableStreamBody) {
-        return "";
+        return Buffer.alloc(0);
     }
     const chunks: Buffer[] = [];
     for await (const chunk of response.readableStreamBody) {
         chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
     }
-    return Buffer.concat(chunks).toString("utf-8");
+    return Buffer.concat(chunks);
+}
+
+/**
+ * Download a blob's content as a UTF-8 string.
+ */
+export async function downloadBlobContent(containerClient: ContainerClient, blobPath: string): Promise<string> {
+    const buffer = await downloadBlobBuffer(containerClient, blobPath);
+    return buffer.toString("utf-8");
 }
 
 // --- Integration-reports-specific wrappers ---
@@ -124,6 +132,10 @@ export async function enumerateBlobs(prefix?: string): Promise<BlobTree> {
 
 export async function getBlobContent(blobPath: string): Promise<string> {
     return downloadBlobContent(getContainerClient(INTEGRATION_REPORTS_CONTAINER_NAME), blobPath);
+}
+
+export async function getBlobBuffer(blobPath: string): Promise<Buffer> {
+    return downloadBlobBuffer(getContainerClient(INTEGRATION_REPORTS_CONTAINER_NAME), blobPath);
 }
 
 const azureDeploySkillName = "azure-deploy";

--- a/dashboard/api/src/functions/fetchBlob.ts
+++ b/dashboard/api/src/functions/fetchBlob.ts
@@ -1,0 +1,42 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import { getBlobBuffer } from "../blobEnumerator";
+import { logRequestIdentity } from "../requestIdentity";
+
+/**
+ * Returns the raw bytes of a specific blob (no Content-Disposition).
+ * Useful for loading binary assets (e.g. images) directly via <img src>.
+ * GET /api/fetch?path={blobPath}
+ */
+async function fetchBlob(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+    logRequestIdentity(request, context, "fetchBlob");
+
+    const blobPath = request.query.get("path");
+    if (!blobPath) {
+        return { status: 400, body: "Missing 'path' query parameter" };
+    }
+
+    // Prevent directory traversal
+    if (blobPath.includes("..")) {
+        return { status: 400, body: "Invalid path" };
+    }
+
+    try {
+        const buffer = await getBlobBuffer(blobPath);
+        return {
+            status: 200,
+            headers: {
+                "Content-Type": "application/octet-stream",
+            },
+            body: buffer,
+        };
+    } catch {
+        return { status: 404, body: "Blob not found" };
+    }
+}
+
+app.http("fetchBlob", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    route: "fetch",
+    handler: fetchBlob,
+});

--- a/dashboard/api/src/functions/getTestResults.ts
+++ b/dashboard/api/src/functions/getTestResults.ts
@@ -11,6 +11,7 @@ interface TestCaseResult {
     isPass: boolean;
     message?: string;
     skillInvocationRate?: number;
+    expectsScreenshot?: boolean;
 }
 
 /** The raw testResults.json file: test-name → result */
@@ -20,6 +21,7 @@ interface TestCase {
     testName: string;
     message?: string;
     skillInvocationRate?: number;
+    expectsScreenshot?: boolean;
 }
 
 export interface SkillStats {
@@ -215,12 +217,14 @@ function computeSkillStats(allResults: RawTestResults[]): SkillStats {
                     testName,
                     message: tc.message,
                     skillInvocationRate: tc.skillInvocationRate,
+                    expectsScreenshot: tc.expectsScreenshot,
                 });
             } else {
                 passedTests.push({
                     testName,
                     message: tc.message,
                     skillInvocationRate: tc.skillInvocationRate,
+                    expectsScreenshot: tc.expectsScreenshot,
                 });
             }
         }

--- a/dashboard/image-viewer.html
+++ b/dashboard/image-viewer.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy"
+        content="default-src 'self'; img-src 'self' data: blob:; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'">
+    <title>Image Viewer</title>
+    <link rel="stylesheet" href="assets/style.css">
+    <style>
+        html,
+        body {
+            margin: 0;
+            padding: 0;
+            height: 100%;
+            background: #1e1e1e;
+        }
+
+        .iv-container {
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 100vh;
+            padding: 16px;
+            box-sizing: border-box;
+        }
+
+        .iv-image {
+            max-width: 100%;
+            max-height: 100vh;
+            object-fit: contain;
+            display: block;
+        }
+
+        .iv-error {
+            color: #ddd;
+            font-family: system-ui, -apple-system, sans-serif;
+            text-align: center;
+        }
+
+        .iv-error a {
+            color: #4ea1ff;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="iv-container" id="container">
+        <p class="iv-error" id="error" hidden>
+            Missing <code>path</code> query parameter.
+        </p>
+    </div>
+    <script type="module" src="/src/image-viewer/main.ts"></script>
+</body>
+
+</html>

--- a/dashboard/src/image-viewer/main.ts
+++ b/dashboard/src/image-viewer/main.ts
@@ -1,0 +1,28 @@
+const params = new URLSearchParams(window.location.search);
+const path = params.get("path");
+const container = document.getElementById("container") as HTMLDivElement;
+const errorEl = document.getElementById("error") as HTMLParagraphElement;
+
+function showError(message: string): void {
+    errorEl.textContent = message;
+    errorEl.hidden = false;
+}
+
+if (!path) {
+    showError("Missing 'path' query parameter.");
+} else if (path.includes("..")) {
+    showError("Invalid path.");
+} else {
+    const fileName = path.split("/").pop() ?? "image";
+    document.title = fileName;
+
+    const img = document.createElement("img");
+    img.className = "iv-image";
+    img.alt = fileName;
+    img.src = `/api/fetch?path=${encodeURIComponent(path)}`;
+    img.onerror = () => {
+        img.remove();
+        showError("Failed to load image.");
+    };
+    container.appendChild(img);
+}

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -291,6 +291,7 @@ function App() {
                                             date={selectedDate!}
                                             testName={ft.testName}
                                         />
+                                        {/* Show the preview for legacy items which don't the flag set */}
                                         {detailsPanelSkill === AZURE_DEPLOY_SKILL && ft.expectsScreenshot !== false && (
                                             <AppSnapshotPreview
                                                 date={selectedDate!}
@@ -327,6 +328,7 @@ function App() {
                                             date={selectedDate!}
                                             testName={pt.testName}
                                         />
+                                        {/* Show the preview for legacy items which don't the flag set */}
                                         {detailsPanelSkill === AZURE_DEPLOY_SKILL && pt.expectsScreenshot !== false && (
                                             <AppSnapshotPreview
                                                 date={selectedDate!}

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -5,6 +5,7 @@ interface TestCase {
     testName: string;
     message?: string;
     skillInvocationRate?: number;
+    expectsScreenshot?: boolean;
 }
 
 // Cache /api/data/{date} responses keyed by encoded date so repeated lookups
@@ -290,7 +291,7 @@ function App() {
                                             date={selectedDate!}
                                             testName={ft.testName}
                                         />
-                                        {detailsPanelSkill === AZURE_DEPLOY_SKILL && (
+                                        {detailsPanelSkill === AZURE_DEPLOY_SKILL && ft.expectsScreenshot !== false && (
                                             <AppSnapshotPreview
                                                 date={selectedDate!}
                                                 testName={ft.testName}
@@ -326,7 +327,7 @@ function App() {
                                             date={selectedDate!}
                                             testName={pt.testName}
                                         />
-                                        {detailsPanelSkill === AZURE_DEPLOY_SKILL && (
+                                        {detailsPanelSkill === AZURE_DEPLOY_SKILL && pt.expectsScreenshot !== false && (
                                             <AppSnapshotPreview
                                                 date={selectedDate!}
                                                 testName={pt.testName}

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -30,19 +30,16 @@ function fetchBlobTree(date: string): Promise<BlobTree> {
     return cached;
 }
 
-async function openAgentMetadataLinks(date: string, testName: string): Promise<void> {
-    const tree = await fetchBlobTree(date);
-    const dateNode = tree[date];
-    if (!dateNode) throw new Error("No data for this date.");
-
+function findTestCaseBlobs(
+    dateNode: BlobTreeNode,
+    testName: string,
+    pattern: RegExp,
+): string[] {
     const targetFolder = `/${formatTestName(testName)}/`;
     const matches: string[] = [];
     const walk = (node: BlobTreeNode): void => {
         for (const file of node.files) {
-            if (
-                file.blobName.includes(targetFolder) &&
-                /\/agent-metadata-[^/]+\.md$/.test(file.blobName)
-            ) {
+            if (file.blobName.includes(targetFolder) && pattern.test(file.blobName)) {
                 matches.push(file.blobName);
             }
         }
@@ -51,6 +48,15 @@ async function openAgentMetadataLinks(date: string, testName: string): Promise<v
         }
     };
     walk(dateNode);
+    return matches;
+}
+
+async function openAgentMetadataLinks(date: string, testName: string): Promise<void> {
+    const tree = await fetchBlobTree(date);
+    const dateNode = tree[date];
+    if (!dateNode) throw new Error("No data for this date.");
+
+    const matches = findTestCaseBlobs(dateNode, testName, /\/agent-metadata-[^/]+\.md$/);
 
     if (matches.length === 0) {
         throw new Error("No agentMetadata files found for this test case.");
@@ -66,6 +72,16 @@ async function openAgentMetadataLinks(date: string, testName: string): Promise<v
         );
     }
 }
+
+async function findAppSnapshotBlob(date: string, testName: string): Promise<string | null> {
+    const tree = await fetchBlobTree(date);
+    const dateNode = tree[date];
+    if (!dateNode) return null;
+    const found = findTestCaseBlobs(dateNode, testName, /\/app-snapshot\.jpe?g$/i);
+    return found[0] ?? null;
+}
+
+const AZURE_DEPLOY_SKILL = "azure-deploy";
 
 interface SkillStats {
     skillInvocationTestsPassed: number;
@@ -274,6 +290,12 @@ function App() {
                                             date={selectedDate!}
                                             testName={ft.testName}
                                         />
+                                        {detailsPanelSkill === AZURE_DEPLOY_SKILL && (
+                                            <AppSnapshotPreview
+                                                date={selectedDate!}
+                                                testName={ft.testName}
+                                            />
+                                        )}
                                     </li>
                                 ))}
                             </ul>
@@ -304,6 +326,12 @@ function App() {
                                             date={selectedDate!}
                                             testName={pt.testName}
                                         />
+                                        {detailsPanelSkill === AZURE_DEPLOY_SKILL && (
+                                            <AppSnapshotPreview
+                                                date={selectedDate!}
+                                                testName={pt.testName}
+                                            />
+                                        )}
                                     </li>
                                 ))}
                             </ul>
@@ -342,6 +370,61 @@ function ViewAgentMetadataButton({ date, testName }: { date: string; testName: s
             </button>
             {err && <span className="it-view-agent-metadata-error">{err}</span>}
         </span>
+    );
+}
+
+function AppSnapshotPreview({ date, testName }: { date: string; testName: string }) {
+    const [blobName, setBlobName] = useState<string | null | undefined>(undefined);
+    const [imgFailed, setImgFailed] = useState(false);
+
+    useEffect(() => {
+        let cancelled = false;
+        setBlobName(undefined);
+        setImgFailed(false);
+        findAppSnapshotBlob(date, testName)
+            .then((found) => {
+                if (!cancelled) setBlobName(found);
+            })
+            .catch(() => {
+                if (!cancelled) setBlobName(null);
+            });
+        return () => {
+            cancelled = true;
+        };
+    }, [date, testName]);
+
+    if (blobName === undefined) {
+        return <div className="it-app-snapshot it-app-snapshot-empty">Loading snapshot&hellip;</div>;
+    }
+
+    if (blobName === null || imgFailed) {
+        return (
+            <div className="it-app-snapshot it-app-snapshot-empty">
+                Snapshot not available
+            </div>
+        );
+    }
+
+    const url = `/api/fetch?path=${encodeURIComponent(blobName)}`;
+    console.log("snapshot url", url);
+    return (
+        <div className="it-app-snapshot">
+            <a
+                className="it-app-snapshot-link"
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                title="Open snapshot in new tab"
+            >
+                <img
+                    className="it-app-snapshot-img"
+                    src={url}
+                    alt={`App snapshot for ${formatTestName(testName)}`}
+                    loading="lazy"
+                    onError={() => setImgFailed(true)}
+                />
+            </a>
+        </div>
     );
 }
 

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -406,12 +406,12 @@ function AppSnapshotPreview({ date, testName }: { date: string; testName: string
     }
 
     const url = `/api/fetch?path=${encodeURIComponent(blobName)}`;
-    console.log("snapshot url", url);
+    const viewerUrl = `/image-viewer.html?path=${encodeURIComponent(blobName)}`;
     return (
         <div className="it-app-snapshot">
             <a
                 className="it-app-snapshot-link"
-                href={url}
+                href={viewerUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 title="Open snapshot in new tab"

--- a/dashboard/src/integration-tests/integration-tests.css
+++ b/dashboard/src/integration-tests/integration-tests.css
@@ -418,6 +418,46 @@ body:has(.it-dashboard) {
     color: var(--color-fail);
 }
 
+/* ── App snapshot preview ───────────────── */
+
+.it-app-snapshot {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 6px;
+    width: 100%;
+}
+
+.it-app-snapshot-empty {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+    font-style: italic;
+}
+
+.it-app-snapshot-link {
+    display: inline-block;
+    line-height: 0;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    overflow: hidden;
+    transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.it-app-snapshot-link:hover {
+    border-color: var(--color-focus);
+    box-shadow: 0 0 0 2px rgba(0, 120, 212, 0.25);
+}
+
+.it-app-snapshot-img {
+    display: block;
+    max-width: 200px;
+    max-height: 140px;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    cursor: zoom-in;
+}
+
 /* ── Responsive ─────────────────────────── */
 
 @media (max-width: 768px) {

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
                 "nightly-runs": resolve(__dirname, "nightly-runs.html"),
                 "performance-dashboard": resolve(__dirname, "performance-dashboard.html"),
                 "msbench-nightly-runs": resolve(__dirname, "msbench-nightly-runs.html"),
+                "image-viewer": resolve(__dirname, "image-viewer.html"),
             },
         },
         outDir: "dist",

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -140,8 +140,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   // Static Web Apps (SWA)
   describe("vanilla-static-web-apps-deploy", () => {
     test("creates whiteboard application with bicep", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -167,8 +167,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, deployTestTimeoutMs);
 
     test("creates static portfolio website with bicep", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -198,8 +198,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   // App Service
   describe("vanilla-app-service-deploy", () => {
     test("creates discussion board", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -225,8 +225,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, deployTestTimeoutMs);
 
     test("creates todo list with frontend and API", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -444,8 +444,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   // Terraform - Static Web Apps
   describe("terraform-static-web-apps-deploy", () => {
     test("creates whiteboard application with Terraform", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -471,8 +471,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, deployTestTimeoutMs);
 
     test("creates static portfolio website with Terraform infrastructure", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -501,8 +501,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   // Terraform - App Service
   describe("terraform-app-service-deploy", () => {
     test("creates discussion board with Terraform", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -528,8 +528,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, deployTestTimeoutMs);
 
     test("creates todo list with frontend and API using Terraform", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -749,8 +749,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
   describe("brownfield-dotnet", () => {
     test("deploys eShop", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         const ESHOP_REPO = "https://github.com/dotnet/eShop.git";
 
         const agentMetadata = await agent.run({
@@ -783,8 +783,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys MvcMovie 90", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         const ASPNETCORE_DOCS_REPO = "https://github.com/dotnet/AspNetCore.Docs.git";
         const MVCMOVIE90_SPARSE_PATH = "aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie90";
 
@@ -820,8 +820,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire azure functions", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         const ASPIRE_FUNCTIONS_SPARSE_PATH = "samples/aspire-with-azure-functions";
 
         const agentMetadata = await agent.run({
@@ -856,8 +856,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire client apps integration", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         const CLIENT_APPS_SPARSE_PATH = "samples/client-apps-integration";
 
         const agentMetadata = await agent.run({
@@ -1045,8 +1045,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
   describe("brownfield-javascript", () => {
     test("deploys nodejs-demoapp", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         const NODEJS_DEMOAPP_REPO = "https://github.com/benc-uk/nodejs-demoapp.git";
 
         const agentMetadata = await agent.run({
@@ -1079,8 +1079,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire with javascript", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         const ASPIRE_JAVASCRIPT_SPARSE_PATH = "samples/aspire-with-javascript";
 
         const agentMetadata = await agent.run({
@@ -1115,8 +1115,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire with node", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         const ASPIRE_NODE_SPARSE_PATH = "samples/aspire-with-node";
 
         const agentMetadata = await agent.run({
@@ -1153,8 +1153,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
   describe("brownfield-python", () => {
     test("deploys flask calculator", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         const FLASK_CALCULATOR_REPO = "https://github.com/UltiRequiem/flask-calculator.git";
 
         const agentMetadata = await agent.run({
@@ -1187,8 +1187,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire with python", async () => {
-      await withTestResult(async ({ setScreenshotFlag }) => {
-        setScreenshotFlag();
+      await withTestResult(async ({ expectScreenshot }) => {
+        expectScreenshot();
         const ASPIRE_PYTHON_SPARSE_PATH = "samples/aspire-with-python";
 
         const agentMetadata = await agent.run({

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -140,7 +140,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   // Static Web Apps (SWA)
   describe("vanilla-static-web-apps-deploy", () => {
     test("creates whiteboard application with bicep", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -166,7 +167,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, deployTestTimeoutMs);
 
     test("creates static portfolio website with bicep", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -196,7 +198,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   // App Service
   describe("vanilla-app-service-deploy", () => {
     test("creates discussion board", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -222,7 +225,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, deployTestTimeoutMs);
 
     test("creates todo list with frontend and API", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -440,7 +444,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   // Terraform - Static Web Apps
   describe("terraform-static-web-apps-deploy", () => {
     test("creates whiteboard application with Terraform", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -466,7 +471,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, deployTestTimeoutMs);
 
     test("creates static portfolio website with Terraform infrastructure", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -495,7 +501,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   // Terraform - App Service
   describe("terraform-app-service-deploy", () => {
     test("creates discussion board with Terraform", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -521,7 +528,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, deployTestTimeoutMs);
 
     test("creates todo list with frontend and API using Terraform", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
@@ -741,7 +749,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
   describe("brownfield-dotnet", () => {
     test("deploys eShop", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         const ESHOP_REPO = "https://github.com/dotnet/eShop.git";
 
         const agentMetadata = await agent.run({
@@ -774,7 +783,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys MvcMovie 90", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         const ASPNETCORE_DOCS_REPO = "https://github.com/dotnet/AspNetCore.Docs.git";
         const MVCMOVIE90_SPARSE_PATH = "aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie90";
 
@@ -810,7 +820,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire azure functions", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         const ASPIRE_FUNCTIONS_SPARSE_PATH = "samples/aspire-with-azure-functions";
 
         const agentMetadata = await agent.run({
@@ -845,7 +856,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire client apps integration", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         const CLIENT_APPS_SPARSE_PATH = "samples/client-apps-integration";
 
         const agentMetadata = await agent.run({
@@ -1033,7 +1045,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
   describe("brownfield-javascript", () => {
     test("deploys nodejs-demoapp", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         const NODEJS_DEMOAPP_REPO = "https://github.com/benc-uk/nodejs-demoapp.git";
 
         const agentMetadata = await agent.run({
@@ -1066,7 +1079,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire with javascript", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         const ASPIRE_JAVASCRIPT_SPARSE_PATH = "samples/aspire-with-javascript";
 
         const agentMetadata = await agent.run({
@@ -1101,7 +1115,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire with node", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         const ASPIRE_NODE_SPARSE_PATH = "samples/aspire-with-node";
 
         const agentMetadata = await agent.run({
@@ -1138,7 +1153,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
   describe("brownfield-python", () => {
     test("deploys flask calculator", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         const FLASK_CALCULATOR_REPO = "https://github.com/UltiRequiem/flask-calculator.git";
 
         const agentMetadata = await agent.run({
@@ -1171,7 +1187,8 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     }, brownfieldTestTimeoutMs);
 
     test("deploys aspire with python", async () => {
-      await withTestResult(async () => {
+      await withTestResult(async ({ setScreenshotFlag }) => {
+        setScreenshotFlag();
         const ASPIRE_PYTHON_SPARSE_PATH = "samples/aspire-with-python";
 
         const agentMetadata = await agent.run({

--- a/tests/globals.d.ts
+++ b/tests/globals.d.ts
@@ -9,7 +9,7 @@ declare global {
   var TESTS_PATH: string;
   function getSkillPath(skillName: string): string;
   function getFixturesPath(skillName: string): string;
-  function setTestResult(data: { isPass: boolean, message?: string, skillInvocationRate?: number }): void;
+  function setTestResult(data: { isPass: boolean, message?: string, skillInvocationRate?: number, expectsScreenshot: boolean }): void;
 
   namespace jest {
     interface Matchers<R> {

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -131,15 +131,15 @@ export function doesWorkspaceFileIncludePattern(workspace: string, valuePattern:
 export type SeparateFilesPatternResult =
   | { isSeparate: true }
   | {
-      isSeparate: false;
-      reason: "pattern-not-found";
-      missingPatterns: Array<"patternA" | "patternB">;
-    }
+    isSeparate: false;
+    reason: "pattern-not-found";
+    missingPatterns: Array<"patternA" | "patternB">;
+  }
   | {
-      isSeparate: false;
-      reason: "same-file";
-      filePaths: string[];
-    };
+    isSeparate: false;
+    reason: "same-file";
+    filePaths: string[];
+  };
 
 /**
  * Checks that two value patterns exist in **different** files within the workspace.
@@ -447,6 +447,7 @@ const maxToolCallBeforeSkillInvocationTerminate = 3;
  */
 interface WithTestResultContext {
   setSkillInvocationRate: (rate: number) => void;
+  setScreenshotFlag: () => void;
 }
 
 /**
@@ -457,19 +458,26 @@ interface WithTestResultContext {
  */
 export async function withTestResult(fn: (ctx: WithTestResultContext) => Promise<void> | void): Promise<void> {
   let skillInvocationRate: number | undefined;
-
+  let expectsScreenshot: boolean = false;
   const ctx: WithTestResultContext = {
     setSkillInvocationRate: (rate: number) => {
       skillInvocationRate = rate;
     },
+    setScreenshotFlag: () => {
+      expectsScreenshot = true;
+    }
   };
 
   try {
     // Before agent run starts, initialize the test result as if it failed.
     // This ensures every test case has a result even when the agent run times out.
-    global.setTestResult({ isPass: false, message: "agent run did not finish; test likely timed out or was terminated before completion" });
+    global.setTestResult({
+      isPass: false,
+      message: "agent run did not finish; test likely timed out or was terminated before completion",
+      expectsScreenshot: false
+    });
     await fn(ctx);
-    global.setTestResult({ isPass: true, skillInvocationRate });
+    global.setTestResult({ isPass: true, skillInvocationRate, expectsScreenshot });
   } catch (e) {
     let message: string | undefined;
     if (e instanceof Error) {
@@ -478,7 +486,7 @@ export async function withTestResult(fn: (ctx: WithTestResultContext) => Promise
     } else {
       message = String(e).slice(0, 4096);
     }
-    global.setTestResult({ isPass: false, message, skillInvocationRate });
+    global.setTestResult({ isPass: false, message, skillInvocationRate, expectsScreenshot });
     throw e;
   }
 }

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -446,8 +446,14 @@ const maxToolCallBeforeSkillInvocationTerminate = 3;
  * Helper context passed to the test function inside `withTestResult`.
  */
 interface WithTestResultContext {
+  /**
+   * Sets the skill vocation rate in the test results indicating how many attempts successfully invoked a skill of interest.
+   */
   setSkillInvocationRate: (rate: number) => void;
-  setScreenshotFlag: () => void;
+  /**
+   * Sets the screenshot flag in the test result indicating the test case expects a screenshot of a deployed website.
+   */
+  expectScreenshot: () => void;
 }
 
 /**
@@ -463,7 +469,7 @@ export async function withTestResult(fn: (ctx: WithTestResultContext) => Promise
     setSkillInvocationRate: (rate: number) => {
       skillInvocationRate = rate;
     },
-    setScreenshotFlag: () => {
+    expectScreenshot: () => {
       expectsScreenshot = true;
     }
   };


### PR DESCRIPTION
## Description

This PR adds a website preview element for azure-deploy test cases that should have deployed a website with UI. The preview is displayed as a thumbnail in its test result entry, like this screenshot shows.
<img width="324" height="484" alt="image" src="https://github.com/user-attachments/assets/36b8bd2a-e6ad-41a4-aa0e-8ecd10f97b0e" />

Clicking on one of such screenshot will open a full sized page for it in a new browser tab.
<img width="1302" height="732" alt="image" src="https://github.com/user-attachments/assets/3389d285-37d0-49b4-a8ad-b011b844e22d" />

This PR adds a context method for a test case to declare in the test result that it expects a screenshot to be taken. This allows the dashboard website to only attempt to show the website preview for test cases that expect them in the future. Unfortunately, test results that have been published don't have this flag set so the website will attempt to show a preview for every test case.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

#1008 
