### PR TITLE
update the path in script to support claude marketplace file refs

### DIFF
--- a/plugin/hooks/scripts/track-telemetry.ps1
+++ b/plugin/hooks/scripts/track-telemetry.ps1
@@ -142,7 +142,7 @@ function Get-ToolInputPath {
 
 # Azure-skills path patterns per client (used for SKILL.md and file-reference matching)
 $pathPatternCopilot = '\.copilot/installed-plugins/azure-skills/azure/skills/'
-$pathPatternClaude = '\.claude/plugins/cache/azure-skills/azure/[0-9.]+/skills/'
+$pathPatternClaude = '\.claude/plugins/cache/(azure-skills|claude-plugins-official)/azure/[0-9.]+/skills/'
 $pathPatternVscodeAgentPlugins = 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-skills/skills/'
 $pathPatternAgentsSkills = '\.agents/skills/'
 

--- a/plugin/hooks/scripts/track-telemetry.ps1
+++ b/plugin/hooks/scripts/track-telemetry.ps1
@@ -32,6 +32,47 @@
 #                     transcript_path may be absent, so stable vs Insiders can only be
 #                     distinguished when skills are called from agent-plugins (which
 #                     includes transcript_path)
+#
+# === Event Types ===
+#
+# 1. skill_invocation
+#    - Triggered when: the "skill"/"Skill" tool is called with a skill name,
+#      OR a SKILL.md file is read from a recognized azure-skills path
+#    - Tracked field: --skill-name <name>
+#
+# 2. tool_invocation
+#    - Triggered when: a tool matching an Azure MCP prefix is called
+#      (azure-*, mcp__plugin_azure_azure__*, mcp_azure_mcp_*)
+#    - Tracked field: --tool-name <toolName>
+#
+# 3. reference_file_read
+#    - Triggered when: a file read tool (view/Read/read_file) targets a file
+#      inside a recognized azure-skills path that is NOT a SKILL.md
+#    - These are the reference/instruction files that skills bundle alongside
+#      SKILL.md (e.g., recipes, templates, requirement docs)
+#    - Tracked field: --file-reference <relative-path-after-skills/>
+#    - Example: azure-validate/references/recipes/azd/README.md
+#
+# === Reference File Detection ===
+#
+# When a file read tool is invoked (Copilot CLI: "view", Claude Code: "Read",
+# VS Code: "read_file"), the script extracts the file path from the tool input
+# and checks if it falls within a recognized azure-skills folder:
+#
+#   Path field lookup order:
+#     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
+#     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
+#
+#   Recognized azure-skills install paths:
+#     - .copilot/installed-plugins/azure-skills/azure/skills/...
+#     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
+#     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
+#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
+#     - .agents/skills/...
+#
+#   If the path matches AND is not a SKILL.md file, the relative path after
+#   "skills/" is extracted and emitted as a reference_file_read event.
+#   SKILL.md reads are tracked as skill_invocation instead (not double-counted).
 
 $ErrorActionPreference = "SilentlyContinue"
 

--- a/plugin/hooks/scripts/track-telemetry.sh
+++ b/plugin/hooks/scripts/track-telemetry.sh
@@ -173,6 +173,7 @@ is_azure_skills_path() {
     local p="$1"
     [[ "$p" == *".copilot/installed-plugins/azure-skills/azure/skills/"* ]] && return 0
     [[ "$p" == *".claude/plugins/cache/azure-skills/azure/"*"/skills/"* ]] && return 0
+    [[ "$p" == *".claude/plugins/cache/claude-plugins-official/azure/"*"/skills/"* ]] && return 0
     [[ "$p" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/"* ]] && return 0
     [[ "$p" == *".agents/skills/"* ]] && return 0
     return 1

--- a/plugin/hooks/scripts/track-telemetry.sh
+++ b/plugin/hooks/scripts/track-telemetry.sh
@@ -34,6 +34,47 @@
 #                     transcript_path may be absent, so stable vs Insiders can only be
 #                     distinguished when skills are called from agent-plugins (which
 #                     includes transcript_path)
+#
+# === Event Types ===
+#
+# 1. skill_invocation
+#    - Triggered when: the "skill"/"Skill" tool is called with a skill name,
+#      OR a SKILL.md file is read from a recognized azure-skills path
+#    - Tracked field: --skill-name <name>
+#
+# 2. tool_invocation
+#    - Triggered when: a tool matching an Azure MCP prefix is called
+#      (azure-*, mcp__plugin_azure_azure__*, mcp_azure_mcp_*)
+#    - Tracked field: --tool-name <toolName>
+#
+# 3. reference_file_read
+#    - Triggered when: a file read tool (view/Read/read_file) targets a file
+#      inside a recognized azure-skills path that is NOT a SKILL.md
+#    - These are the reference/instruction files that skills bundle alongside
+#      SKILL.md (e.g., recipes, templates, requirement docs)
+#    - Tracked field: --file-reference <relative-path-after-skills/>
+#    - Example: azure-validate/references/recipes/azd/README.md
+#
+# === Reference File Detection ===
+#
+# When a file read tool is invoked (Copilot CLI: "view", Claude Code: "Read",
+# VS Code: "read_file"), the script extracts the file path from the tool input
+# and checks if it falls within a recognized azure-skills folder:
+#
+#   Path field lookup order:
+#     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
+#     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
+#
+#   Recognized azure-skills install paths:
+#     - .copilot/installed-plugins/azure-skills/azure/skills/...
+#     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
+#     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
+#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
+#     - .agents/skills/...
+#
+#   If the path matches AND is not a SKILL.md file, the relative path after
+#   "skills/" is extracted and emitted as a reference_file_read event.
+#   SKILL.md reads are tracked as skill_invocation instead (not double-counted).
 
 set +e  # Don't exit on errors - fail silently for privacy
 


### PR DESCRIPTION
Tested hooks for Azure Plugin in official Claude Marketplace. The file reference path needs to be updated to emit file reference name telemetry. Update powershell script for consistency and claude only refers to bash file.