### PR TITLE
FAOS skill

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/observe/observe.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/observe/observe.md
@@ -13,7 +13,7 @@ USE FOR: evaluate my agent, run an eval, test my agent, check agent quality, run
 | Property | Value |
 |----------|-------|
 | MCP server | `azure` |
-| Key Foundry MCP tools | `evaluator_catalog_get`, `evaluation_agent_batch_eval_create`, `evaluator_catalog_create`, `evaluation_comparison_create`, `prompt_optimize`, `agent_update` |
+| Key Foundry MCP tools | `evaluator_catalog_get`, `evaluation_agent_batch_eval_create`, `evaluator_catalog_create`, `evaluation_comparison_create`, `prompt_optimize`, `agent_update`, `agent_optimization_start`, `agent_optimization_get`, `agent_optimization_list` |
 | Prerequisite | Agent deployed and running (use [deploy skill](../deploy/deploy.md)) |
 | Local cache | `.foundry/agent-metadata.yaml`, `.foundry/evaluators/`, `.foundry/datasets/`, `.foundry/results/` |
 
@@ -26,6 +26,7 @@ USE FOR: evaluate my agent, run an eval, test my agent, check agent quality, run
 | "Evaluate my agent" / "Run an eval" | [Step 1: Auto-Setup Evaluators](references/deploy-and-setup.md) first if `.foundry/evaluators/` or `.foundry/datasets/` cache is missing, stale, or the user requests refresh, then [Step 2: Evaluate](references/evaluate-step.md) |
 | "Why did my eval fail?" / "Analyze results" | [Step 3: Analyze](references/analyze-results.md) |
 | "Improve my agent" / "Optimize prompt" | [Step 4: Optimize](references/optimize-deploy.md) |
+| "Run optimization candidate search" / "Tune with optimization job" | [Step 4: Optimize](references/optimize-deploy.md) + [Optimization Candidate Jobs](references/optimize-candidate-jobs.md) |
 | "Compare agent versions" | [Step 5: Compare](references/compare-iterate.md) |
 | "Set up CI/CD evals" | [Step 6: CI/CD](references/cicd-monitoring.md) |
 
@@ -71,6 +72,10 @@ USE FOR: evaluate my agent, run an eval, test my agent, check agent quality, run
 12. **Use a two-phase evaluator strategy.** Phase 1 is built-in only: `relevance`, `task_adherence`, `intent_resolution`, `indirect_attack`, and `builtin.tool_call_accuracy` when the agent uses tools. Generate seed datasets with `query` and `expected_behavior` so Phase 2 can reuse or create targeted custom evaluators only after the first run exposes gaps.
 13. **Account for LLM judge knowledge cutoff.** When the agent uses real-time data sources (web search, Bing Grounding, live APIs), the LLM judge's training cutoff means it cannot verify current facts. Custom evaluators that score factual accuracy or behavioral adherence will produce systematic false negatives - flagging the agent's real-time data as "fabricated" or "beyond knowledge cutoff." Mitigations: (a) instruct the evaluator prompt to accept sourced claims it cannot verify, (b) use `expected_behavior` rubrics that describe the shape of a good answer rather than specific facts, (c) flag suspected knowledge-cutoff false negatives in the failure analysis rather than treating them as real failures.
 14. **Show Data Viewer deeplinks (for VS Code runtime only).** Append a Data Viewer deeplink immediately after reference to a dataset file or evaluation result file in your response. Format: "[Open in Data Viewer](vscode://ms-windows-ai-studio.windows-ai-studio/open_data_viewer?file=<file_path>&source=microsoft-foundry-skill) for details and perform analysis". This applies to files in `.foundry/datasets/`, `.foundry/results/`.
+15. **Treat optimization jobs as suggestion-only.** When using `agent_optimization_*` tools, present candidate configs/results as recommendations and never auto-apply candidate instructions or settings.
+16. **Use the optimization reference.** For optimization-job tools, workflow steps, and errors, follow [Optimization Candidate Jobs](references/optimize-candidate-jobs.md).
+17. **Block invalid optimization starts.** Never call `agent_optimization_start` until both prerequisites are satisfied: (a) exactly one valid dataset mode is resolved (`datasetJson` or `trainDatasetName` + `trainDatasetVersion`) and (b) evaluators are selected and confirmed with the user after `evaluator_catalog_get` (and `evaluator_catalog_create` only if needed).
+18. **Always ask evaluator preference explicitly for optimization jobs.** Before finalizing `evaluators`, ask the user which evaluator option they want (built-in only, existing custom, mixed, or create new custom). Do not silently pick defaults when the user has not answered.
 
 ## Two-Phase Evaluator Strategy
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/observe/references/optimize-candidate-jobs.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/observe/references/optimize-candidate-jobs.md
@@ -1,0 +1,124 @@
+# Optimization Candidate Jobs
+
+Use this reference when you want to run `agent_optimization_start` instead of direct `prompt_optimize`.
+
+## Tools
+
+- `agent_optimization_start`, `agent_optimization_get`
+- `evaluator_catalog_get`, `evaluator_catalog_create`
+
+## Required Inputs
+
+Do not call `agent_optimization_start` until all four inputs are resolved:
+
+1. `agentName`
+2. `projectEndpoint`
+3. dataset input
+4. `evaluators`
+
+## Input 1 — Agent Name
+
+1. Read `agent.manifest.yaml` first.
+2. In Foundry samples, the agent name is the top-level `name` field. Use that value as `agentName`.
+3. If the manifest has only `displayName`, treat that as a label, not the deployed `agentName`. Ask the user to confirm the actual agent name instead of assuming `displayName` is correct.
+4. If `agent.manifest.yaml` is missing or the top-level `name` field is missing, ask the user for the agent name.
+5. Restate the resolved agent name before continuing.
+
+Example pattern from Foundry samples:
+
+```yaml
+name: toolbox-azd-web-search
+displayName: "LangGraph Web Search Toolbox Agent"
+```
+
+Interpretation:
+
+- use `name` for `agentName`
+- do not use `displayName` as the optimization target unless the user explicitly confirms it
+
+## Input 2 — Project Endpoint
+
+1. If a project endpoint is already present in the current context, reuse it.
+2. Otherwise, ask the user for the Azure AI Project endpoint.
+3. Do not infer or invent the endpoint.
+4. Restate the resolved endpoint before continuing.
+
+## Input 3 — Dataset
+
+The optimization job must use exactly one dataset mode:
+
+- `datasetJson`, or
+- `trainDatasetName` + `trainDatasetVersion`
+
+### Use existing dataset
+
+If the user already has a dataset, confirm whether to use:
+
+- a local `.foundry/datasets/` file, or
+- a registered Foundry dataset (`trainDatasetName` + `trainDatasetVersion`)
+
+### Create new dataset
+
+If the user wants a new dataset, route through the eval-datasets skill first:
+
+- [Generate Seed Dataset](../../eval-datasets/references/generate-seed-dataset.md)
+- [Trace-to-Dataset Pipeline](../../eval-datasets/references/trace-to-dataset.md)
+
+After dataset creation, convert the result into the optimization input shape if using `datasetJson`:
+
+```json
+[
+  {
+    "query": "What is 12 + 7?",
+    "name": "math-basic-add",
+    "groundTruth": "19"
+  }
+]
+```
+
+Rules:
+
+- `query` is required
+- `name` is optional
+- `groundTruth` is optional
+- show the final dataset input to the user before continuing
+
+## Input 4 — Evaluators
+
+1. Call `evaluator_catalog_get` using the resolved `projectEndpoint`.
+2. Show the user the available evaluators grouped as built-in and custom.
+3. Ask the user which evaluators they want to use.
+4. If the user wants a new custom evaluator, call `evaluator_catalog_create`, then show the created evaluator and ask for confirmation.
+5. Do not silently choose default evaluators.
+
+Mandatory question:
+
+> "Which evaluators do you want for this optimization run? You can choose from existing built-in evaluators, existing custom evaluators, or ask me to create a new custom evaluator."
+
+## Invocation Flow
+
+1. Resolve `agentName` from `agent.manifest.yaml`; otherwise ask the user.
+2. Resolve `projectEndpoint` from current context; otherwise ask the user.
+3. Resolve dataset input by reusing an existing dataset or creating a new one through eval-datasets.
+4. Call `evaluator_catalog_get` and show built-in and custom evaluators.
+5. Ask the user to choose evaluators.
+6. If needed, create a custom evaluator with `evaluator_catalog_create`.
+7. Restate all final inputs: `agentName`, `projectEndpoint`, dataset mode, and evaluator list.
+8. Only then call `agent_optimization_start`.
+
+## Guardrails
+
+- Never call `agent_optimization_start` before all four inputs are resolved.
+- Never proceed without asking the user about evaluators.
+- Never auto-apply optimization outputs.
+- Treat optimization candidates as suggestions only.
+
+## Error Handling
+
+|Error|Likely Cause|Resolution|
+|---|---|---|
+|`projectEndpoint is required`|Missing project endpoint|Ask the user for the endpoint and retry|
+|`Either datasetJson or trainDatasetName+trainDatasetVersion must be provided`|Missing dataset input|Resolve one dataset mode before calling the tool|
+|`trainDatasetVersion is required`|Dataset name given without version|Add `trainDatasetVersion`|
+|`evaluators must not be empty`|Evaluator list missing|Call `evaluator_catalog_get`, ask the user to choose evaluators, then retry|
+|`Failed to parse datasetJson`|Invalid dataset JSON|Validate the JSON array and ensure each row has `query`|


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
