### PR TITLE
Revert .md eol git attribute change

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
 *.sh text eol=lf
-*.md text eol=lf


### PR DESCRIPTION
## Description

Some of the files have been using CRLF. Removing this change would stop git from auto-updating eol symbols causing confusions to authors.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
