### PR TITLE
Log agent runner error

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -689,6 +689,9 @@ export function useAgentRunner() {
     entry.workspace = testWorkspace;
     entry.preserveWorkspace = config.preserveWorkspace;
 
+    const agentMetadata: AgentMetadata = { events: [], testComments: [], toolCounts: {}, skillFiles: {} };
+    entry.agentMetadata = agentMetadata;
+
     try {
       // Run optional setup
       if (config.setup) {
@@ -743,9 +746,6 @@ export function useAgentRunner() {
         systemMessage: config.systemPrompt
       });
       entry.session = session;
-
-      const agentMetadata: AgentMetadata = { events: [], testComments: [], toolCounts: {}, skillFiles: {} };
-      entry.agentMetadata = agentMetadata;
 
       const done = new Promise<void>((resolve) => {
         session.on(async (event: SessionEvent) => {
@@ -876,6 +876,7 @@ export function useAgentRunner() {
       // Mark as complete to stop event processing
       isComplete = true;
       console.error("Agent runner error:", error);
+      agentMetadata.testComments.push(`❗️Agent runner error: ${(error as Error)?.message ?? JSON.stringify(error)}`);
       throw error;
     } finally {
       if (!isTest()) {

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -875,8 +875,11 @@ export function useAgentRunner() {
     } catch (error) {
       // Mark as complete to stop event processing
       isComplete = true;
-      console.error("Agent runner error:", error);
-      agentMetadata.testComments.push(`❗️Agent runner error: ${(error as Error)?.message ?? JSON.stringify(error)}`);
+      const errorDetails = error instanceof Error
+        ? (error.message)
+        : String(error);
+      agentMetadata.testComments.push(`❗️Agent runner error: ${errorDetails}`);
+      console.error("Agent runner error:", errorDetails);
       throw error;
     } finally {
       if (!isTest()) {


### PR DESCRIPTION
## Description

In 5/2/2026 test runs, I saw in several azure-deploy tests, the agent exited early without reaching the Session.Idle event or timeout. My hypothesis is that Copilot SDK crashed and threw an error and thus exited earlier than expected. This PR makes our code log the error thrown by Copilot SDK to give each test run more observability. 

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
