### PR TITLE
azure-upgrade: add Redis (ACR/OSS and ACRE) -> AMR migration scenarios

### DIFF
--- a/plugin/skills/azure-upgrade/SKILL.md
+++ b/plugin/skills/azure-upgrade/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-upgrade
-description: "Assess and upgrade Azure workloads between plans, tiers, or SKUs, or modernize Azure SDK dependencies in source code. WHEN: upgrade Consumption to Flex Consumption, upgrade Azure Functions plan, migrate hosting plan, change hosting plan, function app SKU, migrate App Service to Container Apps, migrate legacy Azure SDKs for Java, upgrade legacy Azure Java SDK, com.microsoft.azure to com.azure."
+description: "Assess and upgrade Azure workloads between plans, tiers, or SKUs, or modernize Azure SDK dependencies in source code. WHEN: upgrade Consumption to Flex Consumption, upgrade Azure Functions plan, change hosting plan, function app SKU, migrate App Service to Container Apps, modernize legacy Azure Java SDKs (com.microsoft.azure to com.azure), migrate Azure Cache for Redis (ACR/ACRE) to Azure Managed Redis (AMR)."
 license: MIT
 compatibility: python3.10+
 metadata:
@@ -21,6 +21,8 @@ metadata:
 | Assess upgrade readiness | "Is my function app ready for Flex Consumption?" |
 | Automate plan migration | "Automate the steps to upgrade my Functions plan" |
 | Modernize legacy Azure Java SDK | "Migrate legacy Azure SDKs for Java", "Upgrade legacy Azure Java SDK", "Migrate my Java project from com.microsoft.azure to com.azure" |
+| Migrate Azure Cache for Redis (ACR/OSS) to Azure Managed Redis (AMR) | "Migrate my Redis cache to AMR", "ACR to AMR", "OSS to AMR", "Upgrade my Premium P2 cache to Managed Redis", "Pick an AMR SKU", "Convert my Redis IaC template to AMR" |
+| Migrate Azure Cache for Redis Enterprise (ACRE) to Azure Managed Redis (AMR) | "Migrate my Enterprise_E10 cache to AMR", "ACRE to AMR", "Update my ACRE IaC template for AMR", "Migrate EnterpriseFlash to AMR", "Migrate my geo-replicated Enterprise Redis" |
 
 ## Rules
 
@@ -39,6 +41,8 @@ metadata:
 |--------|--------|-----------|
 | Azure Functions Consumption Plan | Azure Functions Flex Consumption Plan | [consumption-to-flex.md](references/services/functions/consumption-to-flex.md) |
 | Legacy Azure Java SDK (`com.microsoft.azure.*`) | Modern Azure Java SDK (`com.azure.*`) | [languages/java/README.md](references/languages/java/README.md) |
+| Azure Cache for Redis (ACR/OSS) Basic/Standard/Premium | Azure Managed Redis (AMR) | [services/redis/redis-to-amr.md](references/services/redis/redis-to-amr.md) |
+| Azure Cache for Redis Enterprise (ACRE) / Enterprise Flash | Azure Managed Redis (AMR) | [services/redis/redis-to-amr.md](references/services/redis/redis-to-amr.md) |
 
 > SDK upgrade scenarios (e.g. Java legacy → modern) run a **source-code modernization flow** that is distinct from Azure service/plan/SKU upgrades: follow the scenario reference, **not** the Steps below.
 
@@ -73,6 +77,8 @@ Track progress in `upgrade-status.md` inside the workspace root.
   - [Consumption to Flex Consumption](references/services/functions/consumption-to-flex.md)
   - [Assessment](references/services/functions/assessment.md)
   - [Automation Scripts](references/services/functions/automation.md)
+- **Redis**
+  - [Redis (ACR or ACRE) to AMR Migration](references/services/redis/redis-to-amr.md) — routes to dedicated [amr-migration-skill](https://github.com/AzureManagedRedis/amr-migration-skill) (ACR/OSS) or [acre-to-amr-migration-skill](https://github.com/AzureManagedRedis/acre-to-amr-migration-skill) (Enterprise)
 - **Java SDK Migration Templates**
   - [Plan Template](references/languages/java/templates/PLAN_TEMPLATE.md)
   - [Progress Template](references/languages/java/templates/PROGRESS_TEMPLATE.md)

--- a/plugin/skills/azure-upgrade/references/services/redis/redis-to-amr.md
+++ b/plugin/skills/azure-upgrade/references/services/redis/redis-to-amr.md
@@ -1,0 +1,102 @@
+# Azure Cache for Redis → Azure Managed Redis (AMR) Migration
+
+> **Target for both paths**: Azure Managed Redis (AMR) — M, B, X (Flash), A series
+> **Source determines which dedicated skill to install** — see decision table below.
+
+There are **two distinct migration paths** to AMR, depending on the source SKU. Each path is owned by a dedicated, versioned skill maintained by the Azure Managed Redis team. The `azure-upgrade` skill does **not** ship the SKU specs, pricing scripts, ARM automation, or template-transformation logic needed for either migration — it routes the user to the correct dedicated skill.
+
+## Decision Table — Which Skill?
+
+| Source SKU | ARM Resource Type | CLI / PowerShell | Dedicated Skill | Repo |
+|---|---|---|---|---|
+| **ACR / OSS Redis** — Basic, Standard, Premium (C0–C6, P1–P5) | `Microsoft.Cache/redis` | `az redis`, `*-AzRedisCache` | `amr-migration-skill` | https://github.com/AzureManagedRedis/amr-migration-skill |
+| **ACRE** — Enterprise (`Enterprise_E*`), Enterprise Flash (`EnterpriseFlash_F*`) | `Microsoft.Cache/redisEnterprise` | `az redisenterprise`, `*-AzRedisEnterprise*` | `acre-to-amr-migration-skill` | https://github.com/AzureManagedRedis/acre-to-amr-migration-skill |
+
+> ACR and ACRE are **fundamentally different products** with different ARM resource types, different APIs, and different migration mechanics. Picking the wrong skill will give the user wrong guidance. Always disambiguate before pointing.
+
+## Disambiguation — How to Tell ACR from ACRE
+
+Ask the user, or inspect the resource. Any **one** of these signals identifies the source:
+
+**ACR (OSS) indicators** → use `amr-migration-skill`:
+- Resource type `Microsoft.Cache/redis` (no "Enterprise" suffix)
+- SKU names `Basic`, `Standard`, `Premium`, or sizes `C0`–`C6`, `P1`–`P5`
+- CLI: `az redis ...` commands
+- PowerShell: `New-AzRedisCache`, `Get-AzRedisCache`, etc.
+- DNS suffix `.redis.cache.windows.net`
+- Default TLS port `6380`
+
+**ACRE indicators** → use `acre-to-amr-migration-skill`:
+- Resource type `Microsoft.Cache/redisEnterprise`
+- SKU names starting with `Enterprise_` (e.g. `Enterprise_E10`, `Enterprise_E20`) or `EnterpriseFlash_` (e.g. `EnterpriseFlash_F300`)
+- CLI: `az redisenterprise ...` commands
+- PowerShell: `New-AzRedisEnterpriseCache`, `Get-AzRedisEnterpriseCache`, etc.
+- Default TLS port `10000`
+- May reference geo-replication groups (`databases create-replica-link`), Private Endpoints, or Private Link DNS zones
+
+If the user has a **mix of ACR and ACRE** resources, both skills should be installed and run separately on the relevant resources. Most users (~97% of the Azure Cache for Redis fleet) are on ACR; ACRE is the smaller (~3%) but functionally distinct case.
+
+## What Each Skill Provides
+
+### `amr-migration-skill` (ACR/OSS → AMR)
+
+- SKU mapping ACR Basic/Standard/Premium → AMR M/B/X/A with validated SKU specs
+- Real-time pricing scripts (PowerShell + bash) with HA, clustering, and MRPP logic
+- Cache metrics assessment (default 7-day window) for sizing
+- Automated migration via ARM REST APIs with **DNS switching** (old hostname keeps working; port still changes)
+- Validate-before-migrate workflow with explicit confirmation on destructive actions
+- IaC template migration for ARM, Bicep, and Terraform with worked before/after examples
+- Feature comparison and retirement FAQ
+- **Retirement deadlines this skill addresses**: ACR Basic/Standard/Premium tiers are being retired — for the current retirement and creation-block dates, see the [official ACR retirement announcement](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-retired-tiers).
+
+### `acre-to-amr-migration-skill` (ACRE → AMR)
+
+- Three modes: automation-script update (ARM/Bicep/CLI/PowerShell/Terraform checklist), interactive cache migration with confirmation gates, generic step-by-step guide
+- ACRE → AMR SKU resolution via `listSkusForScaling` with fallback mapping table
+- In-place migration for standalone caches; create-new-and-swap for geo-replicated caches
+- Geo-replication database config parity (eviction policy, modules, etc.)
+- Private Endpoint / Private Link migration and DNS zone updates
+- Breaking-changes reference (property changes, DNS, API versions)
+- Reusable polling scripts (`Poll-MigrationStatus.ps1`, `poll-migration-status.sh`)
+- Post-migration ACRE resource cleanup
+- **Retirement deadline this skill addresses**: ACRE / Enterprise Flash are being retired — for the current retirement date, see the [official ACR retirement announcement](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-retired-tiers).
+
+## Agent Behavior
+
+When a user asks about migrating any flavor of Azure Cache for Redis to Azure Managed Redis:
+
+1. **Do not attempt the migration from this skill.** Neither SKU specs nor migration automation are inlined here.
+2. **Determine the source** using the disambiguation signals above. If unclear, ask the user (or inspect the script/resource).
+3. **Point the user to the correct dedicated skill** with its repo URL. The repo READMEs include install instructions for GitHub Copilot, Claude Code, and other compatible hosts.
+4. After installation, the user's agent will match the dedicated skill on its trigger phrases (e.g. *"migrate my P2 cache to AMR"*, *"convert my Bicep Redis template"*, *"migrate my Enterprise_E10 cache"*, *"update my ACRE ARM template for AMR"*).
+5. If the user has **both** ACR and ACRE resources, recommend installing **both** skills and running them on the relevant resources separately.
+
+## Key Migration Facts (so the agent can set expectations)
+
+These are summarized for awareness. For anything operational, defer to the dedicated skills.
+
+### ACR → AMR
+- **Port**: 6380 → **10000**. Non-TLS 6379 not supported on AMR.
+- **DNS suffix**: `.redis.cache.windows.net` → `<region>.redis.azure.net`
+- **Redis version**: 6 → **7.4**
+- **No "shards"** in AMR-facing terminology — sharding is internal. Use performance tier (Balanced, Memory Optimized) and size (e.g. B10, M20).
+- **Auth**: Recommend adopting **Microsoft Entra ID** post-migration. Entra config is **not** auto-migrated.
+- **DNS-switch automated migration** keeps old hostname working, but the port change still applies — apps must be updated.
+
+### ACRE → AMR
+- **ARM resource type is unchanged** between the ACRE source and AMR target — both use `Microsoft.Cache/redisEnterprise`. Property values do change (API version, SKU naming, etc.); see the breaking-changes reference in the dedicated skill.
+- **Geo-replicated caches** require create-new-and-swap, not in-place migration.
+- **Private Endpoints / Private Link** DNS zones must be updated.
+- **Database config parity** (eviction policy, modules) must match across replicas before migration.
+
+## Why this is not implemented inline
+
+Both migrations require maintained SKU tables, live pricing or capability lookups, and ARM-level orchestration that is updated independently of the `azure-skills` release cycle. Keeping that logic in two places would drift. The dedicated skill repos are the single source of truth and are versioned independently.
+
+## References
+
+- AMR Migration Skill (ACR → AMR): https://github.com/AzureManagedRedis/amr-migration-skill
+- ACRE → AMR Migration Skill: https://github.com/AzureManagedRedis/acre-to-amr-migration-skill
+- Azure Managed Redis docs: https://learn.microsoft.com/en-us/azure/redis/managed-redis/
+- ACR retirement announcement: https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-retired-tiers
+- Entra ID auth for AMR: https://learn.microsoft.com/en-us/azure/redis/managed-redis/managed-redis-entra-for-access-control-configuration

--- a/tests/azure-upgrade/__snapshots__/triggers.test.ts.snap
+++ b/tests/azure-upgrade/__snapshots__/triggers.test.ts.snap
@@ -2,13 +2,15 @@
 
 exports[`azure-upgrade - Trigger Tests Trigger Keywords Snapshot skill description triggers match snapshot 1`] = `
 {
-  "description": "Assess and upgrade Azure workloads between plans, tiers, or SKUs, or modernize Azure SDK dependencies in source code. WHEN: upgrade Consumption to Flex Consumption, upgrade Azure Functions plan, migrate hosting plan, change hosting plan, function app SKU, migrate App Service to Container Apps, migrate legacy Azure SDKs for Java, upgrade legacy Azure Java SDK, com.microsoft.azure to com.azure.",
+  "description": "Assess and upgrade Azure workloads between plans, tiers, or SKUs, or modernize Azure SDK dependencies in source code. WHEN: upgrade Consumption to Flex Consumption, upgrade Azure Functions plan, change hosting plan, function app SKU, migrate App Service to Container Apps, modernize legacy Azure Java SDKs (com.microsoft.azure to com.azure), migrate Azure Cache for Redis (ACR/ACRE) to Azure Managed Redis (AMR).",
   "extractedKeywords": [
+    "acre",
     "app service",
     "apps",
     "assess",
     "azure",
     "between",
+    "cache",
     "change",
     "code",
     "consumption",
@@ -21,6 +23,7 @@ exports[`azure-upgrade - Trigger Tests Trigger Keywords Snapshot skill descripti
     "hosting",
     "java",
     "legacy",
+    "managed",
     "mcp",
     "microsoft",
     "migrate",
@@ -28,6 +31,7 @@ exports[`azure-upgrade - Trigger Tests Trigger Keywords Snapshot skill descripti
     "monitor",
     "plan",
     "plans",
+    "redis",
     "sdks",
     "service",
     "skus",
@@ -44,11 +48,13 @@ exports[`azure-upgrade - Trigger Tests Trigger Keywords Snapshot skill descripti
 
 exports[`azure-upgrade - Trigger Tests Trigger Keywords Snapshot skill keywords match snapshot 1`] = `
 [
+  "acre",
   "app service",
   "apps",
   "assess",
   "azure",
   "between",
+  "cache",
   "change",
   "code",
   "consumption",
@@ -61,6 +67,7 @@ exports[`azure-upgrade - Trigger Tests Trigger Keywords Snapshot skill keywords 
   "hosting",
   "java",
   "legacy",
+  "managed",
   "mcp",
   "microsoft",
   "migrate",
@@ -68,6 +75,7 @@ exports[`azure-upgrade - Trigger Tests Trigger Keywords Snapshot skill keywords 
   "monitor",
   "plan",
   "plans",
+  "redis",
   "sdks",
   "service",
   "skus",

--- a/tests/azure-upgrade/integration.test.ts
+++ b/tests/azure-upgrade/integration.test.ts
@@ -35,6 +35,10 @@ import {
   shouldEarlyTerminateForSkillInvocation,
   softCheckSkill,
   withTestResult,
+  getAllToolText,
+  getAllAssistantMessages,
+  doesAssistantOrToolsIncludeKeyword,
+  getToolCalls,
 } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-upgrade";
@@ -70,6 +74,10 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
       softCheckSkill(agentMetadata, SKILL_NAME);
       expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
+
+      // Negative routing: a non-Redis migration prompt must NOT surface Redis migration skills.
+      expect(doesAssistantOrToolsIncludeKeyword(agentMetadata, "amr-migration-skill")).toBe(false);
+      expect(doesAssistantOrToolsIncludeKeyword(agentMetadata, "acre-to-amr-migration-skill")).toBe(false);
     }));
 
     test("invokes azure-upgrade skill for upgrading Functions plan prompt", () => withTestResult(async () => {
@@ -106,6 +114,85 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
       softCheckSkill(agentMetadata, SKILL_NAME);
       expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
+    }));
+
+    test("invokes azure-upgrade skill for Azure Cache for Redis (ACR/OSS) to Azure Managed Redis migration prompt", () => withTestResult(async () => {
+      const agentMetadata = await agent.run({
+        prompt: "Migrate my Azure Cache for Redis Premium P2 cache to Azure Managed Redis (AMR)",
+        nonInteractive: true,
+        followUp: ["Continue with recommended options until complete."],
+        // Custom termination: keep running past skill invocation until the agent
+        // both navigates to the reference doc AND surfaces the dedicated skill name,
+        // capped at 30 tool calls.
+        shouldEarlyTerminate: (m) => {
+          if (!isSkillInvoked(m, SKILL_NAME)) {
+            return getToolCalls(m).length > 30;
+          }
+          const navigated = /redis-to-amr\.md/.test(getAllToolText(m));
+          const surfaced = doesAssistantOrToolsIncludeKeyword(m, "amr-migration-skill");
+          return (navigated && surfaced) || getToolCalls(m).length > 30;
+        }
+      });
+
+      softCheckSkill(agentMetadata, SKILL_NAME);
+      expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
+
+      // Tier 1: agent navigated to the Redis routing reference doc.
+      expect(getAllToolText(agentMetadata)).toMatch(/redis-to-amr\.md/);
+
+      // Tier 2: agent surfaces the ACR/OSS dedicated skill name.
+      // (We don't assert ACRE skill absence — the reference doc mentions both routes,
+      // so its tool text necessarily contains the ACRE skill name as well.)
+      expect(doesAssistantOrToolsIncludeKeyword(agentMetadata, "amr-migration-skill")).toBe(true);
+    }));
+
+    test("invokes azure-upgrade skill for Azure Cache for Redis Enterprise (ACRE) to Azure Managed Redis migration prompt", () => withTestResult(async () => {
+      const agentMetadata = await agent.run({
+        prompt: "Migrate my Azure Cache for Redis Enterprise (Enterprise_E10) cache to Azure Managed Redis",
+        nonInteractive: true,
+        followUp: ["Continue with recommended options until complete."],
+        shouldEarlyTerminate: (m) => {
+          if (!isSkillInvoked(m, SKILL_NAME)) {
+            return getToolCalls(m).length > 30;
+          }
+          const navigated = /redis-to-amr\.md/.test(getAllToolText(m));
+          const surfaced = doesAssistantOrToolsIncludeKeyword(m, "acre-to-amr-migration-skill");
+          return (navigated && surfaced) || getToolCalls(m).length > 30;
+        }
+      });
+
+      softCheckSkill(agentMetadata, SKILL_NAME);
+      expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
+
+      // Tier 1: agent navigated to the Redis routing reference doc.
+      expect(getAllToolText(agentMetadata)).toMatch(/redis-to-amr\.md/);
+
+      // Tier 2: agent surfaces the ACRE-specific dedicated skill.
+      expect(doesAssistantOrToolsIncludeKeyword(agentMetadata, "acre-to-amr-migration-skill")).toBe(true);
+    }));
+
+    // Tier 3: ambiguous Redis prompt should trigger disambiguation rather than guessing a tier.
+    test("invokes azure-upgrade skill and disambiguates Redis tier for ambiguous Redis migration prompt", () => withTestResult(async () => {
+      const disambiguationPattern = /enterprise|premium|standard|basic|tier|sku|acre|\bacr\b/i;
+      const agentMetadata = await agent.run({
+        prompt: "I want to migrate my Redis cache to Azure Managed Redis",
+        nonInteractive: true,
+        followUp: ["Continue with recommended options until complete."],
+        shouldEarlyTerminate: (m) => {
+          if (!isSkillInvoked(m, SKILL_NAME)) {
+            return getToolCalls(m).length > 30;
+          }
+          const asked = disambiguationPattern.test(getAllAssistantMessages(m));
+          return asked || getToolCalls(m).length > 30;
+        }
+      });
+
+      softCheckSkill(agentMetadata, SKILL_NAME);
+      expect(isSkillInvoked(agentMetadata, SKILL_NAME)).toBe(true);
+
+      // The agent should ask about the source tier/SKU (Basic/Standard/Premium vs. Enterprise)
+      // or otherwise reference the disambiguation signals from the routing doc.
+      expect(getAllAssistantMessages(agentMetadata)).toMatch(disambiguationPattern);
     }));
   });
 

--- a/tests/azure-upgrade/triggers.test.ts
+++ b/tests/azure-upgrade/triggers.test.ts
@@ -37,6 +37,10 @@ describe(`${SKILL_NAME} - Trigger Tests`, () => {
       "Migrate legacy Azure SDKs for Java",
       "Upgrade legacy Azure Java SDK",
       "Migrate my Java project from com.microsoft.azure to com.azure",
+      // Azure Cache for Redis (ACR/ACRE) → Azure Managed Redis (AMR) migration
+      "Migrate my Azure Cache for Redis to Azure Managed Redis",
+      "Upgrade my Premium P2 Redis cache to AMR",
+      "Migrate my Enterprise_E10 ACRE cache to Azure Managed Redis",
     ];
 
     test.each(shouldTriggerPrompts)(
@@ -59,6 +63,9 @@ describe(`${SKILL_NAME} - Trigger Tests`, () => {
       "What is the capital of France?",
       "Help me debug my React application",
       "How do I optimize MySQL queries?",
+      // Generic IaC questions unrelated to Azure upgrades — should NOT trigger
+      "Write me a Bicep template for a storage account",
+      "Author a Terraform module for a virtual network",
     ];
 
     test.each(shouldNotTriggerPrompts)(


### PR DESCRIPTION
## Description

Adds a single 'Redis to AMR' reference doc that routes users to the correct dedicated skill based on source SKU:

ACR/OSS (Basic/Standard/Premium) -> https://github.com/AzureManagedRedis/amr-migration-skill

ACRE (Enterprise/EnterpriseFlash) -> https://github.com/AzureManagedRedis/acre-to-amr-migration-skill

Both migrations target Azure Managed Redis but use different ARM resource types and migration mechanics, so disambiguation guidance is included.

## Checklist

- [X] Tests pass locally (`cd tests && npm test`)
- [X] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [X] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

Fixes #2156
