### PR TITLE
Fix broken VPA installation link in azure-aks-vpa.md

### DIFF
--- a/plugin/skills/azure-kubernetes/references/azure-aks-vpa.md
+++ b/plugin/skills/azure-kubernetes/references/azure-aks-vpa.md
@@ -5,8 +5,8 @@ Use VPA to get data-driven resource recommendations for rightsizing pods. Always
 ## Enable VPA (Recommendation Mode)
 
 ```bash
-# Install VPA (if not present)
-kubectl apply -f https://github.com/kubernetes/autoscaler/releases/latest/download/vertical-pod-autoscaler.yaml
+# Enable VPA addon on AKS cluster (if not already enabled)
+az aks update --enable-vpa --resource-group <RESOURCE_GROUP> --name <CLUSTER_NAME>
 
 # Create a VPA object in recommendation mode for a deployment
 kubectl apply -f - <<EOF


### PR DESCRIPTION
Replace unreliable GitHub /latest/ URL with AKS native VPA addon enablement using az aks update --enable-vpa. This removes the external dependency on changing release URLs and uses the officially supported AKS approach.

Fixes #1984

## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [x] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [x] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
