### PR TITLE
Add NO_SKILLS env var

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -730,11 +730,11 @@ export function useAgentRunner() {
         disabledSkills = skills.filter((skillName) => !config.includeSkills?.includes(skillName));
       }
 
-      const NO_SKILLS = process.env.NO_SKILLS;
+      const noSkills = process.env.NO_SKILLS === "true";
       const session = await client.createSession({
         model: modelOverride || "claude-sonnet-4.5",
         onPermissionRequest: approveAll,
-        skillDirectories: NO_SKILLS ? [] : [skillDirectory],
+        skillDirectories: noSkills ? [] : [skillDirectory],
         disabledSkills: disabledSkills,
         mcpServers: {
           azure: {

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -730,10 +730,11 @@ export function useAgentRunner() {
         disabledSkills = skills.filter((skillName) => !config.includeSkills?.includes(skillName));
       }
 
+      const NO_SKILLS = process.env.NO_SKILLS;
       const session = await client.createSession({
         model: modelOverride || "claude-sonnet-4.5",
         onPermissionRequest: approveAll,
-        skillDirectories: [skillDirectory],
+        skillDirectories: NO_SKILLS ? [] : [skillDirectory],
         disabledSkills: disabledSkills,
         mcpServers: {
           azure: {


### PR DESCRIPTION
## Description

Add an environment variable that can optionally let the agent runner run without loading any skills.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
