### PR TITLE
Formalize script for enumerating skill references

### DIFF
--- a/scripts/src/references/cli.ts
+++ b/scripts/src/references/cli.ts
@@ -11,8 +11,16 @@
  *      through a chain of markdown links starting from SKILL.md.
  *
  * Usage:
- *   npm run references              # Validate all skills
- *   npm run references <skill>      # Validate a single skill
+ *   npm run references                       # Validate all skills
+ *   npm run references <skill>               # Validate a single skill
+ *   npm run references -- --json             # Emit validation results as JSON
+ *   npm run references -- --list             # Emit every discovered local
+ *                                            # and remote link as JSON
+ *
+ * Tip: when redirecting JSON output to a file, pass `--silent` to npm so it
+ * does not prepend its own banner lines (which would corrupt the JSON):
+ *
+ *   npm run --silent references -- --list > out.json
  */
 
 import { dirname, resolve, relative, normalize } from "node:path";
@@ -68,11 +76,21 @@ interface RemoteLinkDetail {
   path: string;
 }
 
+interface LocalLinkDetail {
+  file: string;
+  line: number;
+  link: string;
+  absPath: string;
+  exists: boolean;
+  isDirectory?: boolean;
+}
+
 interface ValidationResult {
   skill: string;
   issues: LinkIssue[];
   orphanedFiles: OrphanedFile[];
   remoteLinks: RemoteLinkDetail[];
+  localLinks: LocalLinkDetail[];
 }
 
 // ── Markdown file discovery ──────────────────────────────────────────────────
@@ -149,6 +167,7 @@ function findReferenceFiles(skillDir: string): string[] {
 function validateFile(mdFile: string, skillDir: string): {
   issues: LinkIssue[];
   remoteLinks: RemoteLinkDetail[];
+  localLinks: LocalLinkDetail[];
 } {
   // Local links
   const localLinks = extractLocalLinks(mdFile, skillDir);
@@ -214,7 +233,17 @@ function validateFile(mdFile: string, skillDir: string): {
         host: item.host,
         path: item.path,
       };
-    })
+    }),
+    localLinks: localLinks.map((item) => {
+      return {
+        file: mdFile,
+        line: item.line,
+        link: item.link,
+        absPath: item.absPath,
+        exists: item.exists,
+        isDirectory: item.isDirectory,
+      };
+    }),
   };
 }
 
@@ -223,12 +252,14 @@ function validateSkill(skillName: string): ValidationResult {
   const mdFiles = findMarkdownFiles(skillDir);
   const issues: LinkIssue[] = [];
   const remoteLinks: RemoteLinkDetail[] = [];
+  const localLinks: LocalLinkDetail[] = [];
 
   // Validate all markdown files for link issues
   for (const mdFile of mdFiles) {
     const result = validateFile(mdFile, skillDir);
     issues.push(...result.issues);
     remoteLinks.push(...result.remoteLinks);
+    localLinks.push(...result.localLinks);
   }
 
   // Track visited files for orphan detection
@@ -276,7 +307,7 @@ function validateSkill(skillName: string): ValidationResult {
     }
   }
 
-  return { skill: skillName, issues, orphanedFiles, remoteLinks };
+  return { skill: skillName, issues, orphanedFiles, remoteLinks, localLinks };
 }
 
 // ── JSON output ──────────────────────────────────────────────────────────────
@@ -349,6 +380,75 @@ function buildReferencesJson(
   };
 }
 
+// ── List output ─────────────────────────────────────────────────────────────
+
+export interface LinkListEntry {
+  source: string;
+  sourceLine: number;
+  link: string;
+}
+
+export interface LocalLinkListEntry extends LinkListEntry {
+  resolved: string;
+  status: "file" | "directory" | "missing";
+}
+
+export interface RemoteLinkListEntry extends LinkListEntry {
+  protocol: "http" | "https";
+  host: string;
+  path: string;
+}
+
+export interface SkillLinkList {
+  skill: string;
+  localLinks: LocalLinkListEntry[];
+  remoteLinks: RemoteLinkListEntry[];
+}
+
+export interface ReferencesListResult {
+  skills: SkillLinkList[];
+  summary: {
+    totalSkills: number;
+    totalLocalLinks: number;
+    totalRemoteLinks: number;
+  };
+}
+
+function buildListJson(results: ValidationResult[]): ReferencesListResult {
+  let totalLocal = 0;
+  let totalRemote = 0;
+
+  const skills: SkillLinkList[] = results.map((result) => {
+    const localLinks: LocalLinkListEntry[] = result.localLinks.map((l) => ({
+      source: formatPath(l.file),
+      sourceLine: l.line,
+      link: l.link,
+      resolved: formatPath(l.absPath),
+      status: !l.exists ? "missing" : l.isDirectory ? "directory" : "file",
+    }));
+    const remoteLinks: RemoteLinkListEntry[] = result.remoteLinks.map((r) => ({
+      source: formatPath(r.file),
+      sourceLine: r.line,
+      link: r.link,
+      protocol: r.protocol,
+      host: r.host,
+      path: r.path,
+    }));
+    totalLocal += localLinks.length;
+    totalRemote += remoteLinks.length;
+    return { skill: result.skill, localLinks, remoteLinks };
+  });
+
+  return {
+    skills,
+    summary: {
+      totalSkills: results.length,
+      totalLocalLinks: totalLocal,
+      totalRemoteLinks: totalRemote,
+    },
+  };
+}
+
 // ── CLI entry point ──────────────────────────────────────────────────────────
 
 function listSkills(): string[] {
@@ -369,6 +469,7 @@ function main(): void {
     args: process.argv.slice(2),
     options: {
       json: { type: "boolean", default: false },
+      list: { type: "boolean", default: false },
       "skills-dir": { type: "string" },
     },
     strict: false,
@@ -385,6 +486,7 @@ function main(): void {
   }
 
   const jsonOutput = values.json ?? false;
+  const listOutput = values.list ?? false;
   const requestedSkill = positionals[0];
 
   const skills = requestedSkill ? [requestedSkill] : listSkills();
@@ -407,6 +509,13 @@ function main(): void {
   const results: ValidationResult[] = [];
   for (const skill of skills) {
     results.push(validateSkill(skill));
+  }
+
+  // ── List output mode ────────────────────────────────────────────────────
+  if (listOutput) {
+    const listResult = buildListJson(results);
+    console.log(JSON.stringify(listResult, null, 2));
+    return;
   }
 
   // ── JSON output mode ────────────────────────────────────────────────────
@@ -454,18 +563,6 @@ function main(): void {
       for (const orphan of result.orphanedFiles) {
         console.log(`     ${formatPath(orphan.file)}`);
         console.log(`       ${orphan.reason}`);
-      }
-    }
-
-    if (result.remoteLinks.length > 0) {
-      console.log(`     🌐 Remote links (${result.remoteLinks.length})`);
-      for (const remote of result.remoteLinks) {
-        const loc = `${formatPath(remote.file)}:${remote.line}`;
-        console.log(`       ${loc}`);
-        console.log(`         URL: ${remote.link}`);
-        console.log(`         Protocol: ${remote.protocol}`);
-        console.log(`         Host: ${remote.host}`);
-        console.log(`         Path: ${remote.path}`);
       }
     }
   }


### PR DESCRIPTION
## Description

This PR formalizes the reference script for reference file listing and added local references files to the output. This script will help detect dead reference files to guide clean up and optimization.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

#2180 
