### PR TITLE
Run comparison integration tests without skills

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -268,9 +268,18 @@ jobs:
                 hasError = true;
             }
 
-            // 2. Integration test schedule coverages all skills
+            // 2. Integration test schedule coverages all skills.
+            // Only consider the cron schedules referenced by .github/workflows/test-all-integration.yml.
+            // Other entries in integrationTestSchedule (e.g. Sunday comparison runs) don't count
+            // toward the coverage check.
+            const requiredCronSchedules = [
+                '0 5 * * 2-6',
+                '0 8 * * 2-6',
+                '0 12 * * 2-6',
+            ];
             let scheduledSkills = [];
-            Object.values(skillsJson.integrationTestSchedule).forEach(value => {
+            requiredCronSchedules.forEach(cron => {
+                const value = skillsJson.integrationTestSchedule[cron];
                 if (value) {
                     value.split(',').forEach(s => scheduledSkills.push(s));
                 }

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -268,7 +268,7 @@ jobs:
                 hasError = true;
             }
 
-            // 2. Integration test schedule coverages all skills.
+            // 2. Integration test schedule covers all skills.
             // Only consider the cron schedules referenced by .github/workflows/test-all-integration.yml.
             // Other entries in integrationTestSchedule (e.g. Sunday comparison runs) don't count
             // toward the coverage check.

--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -18,6 +18,9 @@ on:
     - cron: '0 8 * * 2-6'
     # 4:00 AM PST Tue-Sat (12:00 PM UTC Tue-Sat)
     - cron: '0 12 * * 2-6'
+    # 4:00 AM PST Sun (12:00 PM UTC Sun)
+    # Comparison test runs that don't use skills
+    - cron: '0 12 * * 7'
   workflow_dispatch:
     inputs:
       skills:
@@ -51,10 +54,10 @@ on:
 # Customize the inputs for each scheduled run by modifying these env vars.
 # Skills for each schedule are defined in tests/skills.json under integrationTestSchedule.
 env:
-  SCHEDULED_DEBUG_21: 'false'        # debug flag for 9:00 PM PST run
-  SCHEDULED_DEBUG_00: 'false'        # debug flag for 12:00 AM PST run
-  SCHEDULED_DEBUG_04: 'false'         # debug flag for 4:00 AM PST run
-
+  SCHEDULED_DEBUG_21: 'false'        # debug flag for 9:00 PM PST run (Weekday)
+  SCHEDULED_DEBUG_00: 'false'        # debug flag for 12:00 AM PST run (Weekday)
+  SCHEDULED_DEBUG_04: 'false'        # debug flag for 4:00 AM PST run (Weekday)
+  SCHEDULED_DEBUG_SUN: 'false'       # debug flag for 4:00 AM PST run (Sunday)
 jobs:
   resolve-inputs:
     name: Resolve workflow inputs
@@ -64,6 +67,7 @@ jobs:
       skills: ${{ steps.resolve.outputs.skills }}
       deploy-test-pattern: ${{ steps.resolve.outputs.deploy-test-pattern }}
       debug: ${{ steps.resolve.outputs.debug }}
+      no-skills: ${{ steps.resolve.outputs.no-skills }}
     steps:
       - name: Checkout repository
         if: github.event_name == 'schedule'
@@ -112,6 +116,10 @@ jobs:
                 ;;
               "0 12 * * 2-6")
                 echo "debug=$SCHEDULED_DEBUG_04" >> "$GITHUB_OUTPUT"
+                ;;
+              "0 12 * * 7")
+                echo "debug=$SCHEDULED_DEBUG_SUN" >> "$GITHUB_OUTPUT"
+                echo "no-skills=true" >> "$GITHUB_OUTPUT"
                 ;;
               *)
                 echo "Unknown schedule: $CRON"
@@ -168,6 +176,7 @@ jobs:
       test-pattern: ${{ needs.resolve-inputs.outputs.deploy-test-pattern }}
       debug: ${{ needs.resolve-inputs.outputs.debug == 'true' }}
       publish-reports: ${{ github.event_name == 'schedule' }}
+      no-skills: ${{ needs.resolve-inputs.outputs.no-skills == 'true' }}
     secrets:
       COPILOT_CLI_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
 
@@ -282,6 +291,7 @@ jobs:
           MODEL_OVERRIDE: ${{ inputs.model-override }}
           SKILL_TEST_PATTERN: ${{ inputs.skill-test-pattern }}
           SKILL: ${{ matrix.skill }}
+          NO_SKILLS: ${{ needs.resolve-inputs.outputs.no-skills == 'true' && 'true' || '' }}
         run: |
           echo test with $MODEL_OVERRIDE
           # Handle azure-ai vs azure-aigateway prefix collision

--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -57,7 +57,7 @@ env:
   SCHEDULED_DEBUG_21: 'false'        # debug flag for 9:00 PM PST run (Weekday)
   SCHEDULED_DEBUG_00: 'false'        # debug flag for 12:00 AM PST run (Weekday)
   SCHEDULED_DEBUG_04: 'false'        # debug flag for 4:00 AM PST run (Weekday)
-  SCHEDULED_DEBUG_SUN: 'false'       # debug flag for 4:00 AM PST run (Sunday)
+  SCHEDULED_DEBUG_NO_SKILLS: 'false'       # debug flag for 4:00 AM PST run (Sunday)
 jobs:
   resolve-inputs:
     name: Resolve workflow inputs
@@ -118,7 +118,7 @@ jobs:
                 echo "debug=$SCHEDULED_DEBUG_04" >> "$GITHUB_OUTPUT"
                 ;;
               "0 12 * * 7")
-                echo "debug=$SCHEDULED_DEBUG_SUN" >> "$GITHUB_OUTPUT"
+                echo "debug=$SCHEDULED_DEBUG_NO_SKILLS" >> "$GITHUB_OUTPUT"
                 echo "no-skills=true" >> "$GITHUB_OUTPUT"
                 ;;
               *)

--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -18,9 +18,6 @@ on:
     - cron: '0 8 * * 2-6'
     # 4:00 AM PST Tue-Sat (12:00 PM UTC Tue-Sat)
     - cron: '0 12 * * 2-6'
-    # 4:00 AM PST Sun (12:00 PM UTC Sun)
-    # Comparison test runs that don't use skills
-    - cron: '0 12 * * 0'
   workflow_dispatch:
     inputs:
       skills:
@@ -54,10 +51,10 @@ on:
 # Customize the inputs for each scheduled run by modifying these env vars.
 # Skills for each schedule are defined in tests/skills.json under integrationTestSchedule.
 env:
-  SCHEDULED_DEBUG_21: 'false'        # debug flag for 9:00 PM PST run (Weekday)
-  SCHEDULED_DEBUG_00: 'false'        # debug flag for 12:00 AM PST run (Weekday)
-  SCHEDULED_DEBUG_04: 'false'        # debug flag for 4:00 AM PST run (Weekday)
-  SCHEDULED_DEBUG_NO_SKILLS: 'false'       # debug flag for 4:00 AM PST run (Sunday)
+  SCHEDULED_DEBUG_21: 'false'        # debug flag for 9:00 PM PST run
+  SCHEDULED_DEBUG_00: 'false'        # debug flag for 12:00 AM PST run
+  SCHEDULED_DEBUG_04: 'false'         # debug flag for 4:00 AM PST run
+
 jobs:
   resolve-inputs:
     name: Resolve workflow inputs
@@ -67,7 +64,6 @@ jobs:
       skills: ${{ steps.resolve.outputs.skills }}
       deploy-test-pattern: ${{ steps.resolve.outputs.deploy-test-pattern }}
       debug: ${{ steps.resolve.outputs.debug }}
-      no-skills: ${{ steps.resolve.outputs.no-skills }}
     steps:
       - name: Checkout repository
         if: github.event_name == 'schedule'
@@ -116,10 +112,6 @@ jobs:
                 ;;
               "0 12 * * 2-6")
                 echo "debug=$SCHEDULED_DEBUG_04" >> "$GITHUB_OUTPUT"
-                ;;
-              "0 12 * * 0")
-                echo "debug=$SCHEDULED_DEBUG_NO_SKILLS" >> "$GITHUB_OUTPUT"
-                echo "no-skills=true" >> "$GITHUB_OUTPUT"
                 ;;
               *)
                 echo "Unknown schedule: $CRON"
@@ -176,7 +168,6 @@ jobs:
       test-pattern: ${{ needs.resolve-inputs.outputs.deploy-test-pattern }}
       debug: ${{ needs.resolve-inputs.outputs.debug == 'true' }}
       publish-reports: ${{ github.event_name == 'schedule' }}
-      no-skills: ${{ needs.resolve-inputs.outputs.no-skills == 'true' }}
     secrets:
       COPILOT_CLI_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
 
@@ -291,7 +282,6 @@ jobs:
           MODEL_OVERRIDE: ${{ inputs.model-override }}
           SKILL_TEST_PATTERN: ${{ inputs.skill-test-pattern }}
           SKILL: ${{ matrix.skill }}
-          NO_SKILLS: ${{ needs.resolve-inputs.outputs.no-skills == 'true' && 'true' || '' }}
         run: |
           echo test with $MODEL_OVERRIDE
           # Handle azure-ai vs azure-aigateway prefix collision

--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -20,7 +20,7 @@ on:
     - cron: '0 12 * * 2-6'
     # 4:00 AM PST Sun (12:00 PM UTC Sun)
     # Comparison test runs that don't use skills
-    - cron: '0 12 * * 7'
+    - cron: '0 12 * * 0'
   workflow_dispatch:
     inputs:
       skills:
@@ -117,7 +117,7 @@ jobs:
               "0 12 * * 2-6")
                 echo "debug=$SCHEDULED_DEBUG_04" >> "$GITHUB_OUTPUT"
                 ;;
-              "0 12 * * 7")
+              "0 12 * * 0")
                 echo "debug=$SCHEDULED_DEBUG_NO_SKILLS" >> "$GITHUB_OUTPUT"
                 echo "no-skills=true" >> "$GITHUB_OUTPUT"
                 ;;

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -50,6 +50,11 @@ on:
         required: false
         type: boolean
         default: false
+      no-skills:
+        description: 'Whether to set NO_SKILLS=true for jest tests (skip loading skills)'
+        required: false
+        type: boolean
+        default: false
     secrets:
       COPILOT_CLI_TOKEN:
         required: true
@@ -189,6 +194,7 @@ jobs:
           DEBUG: ${{ inputs.debug && '1' || '' }}
           MODEL_OVERRIDE: ${{ inputs.model-override }}
           TEST_GROUP: ${{ matrix.test-group }}
+          NO_SKILLS: ${{ inputs.no-skills && 'true' || '' }}
         run: |
           echo test with $MODEL_OVERRIDE
           npm run test:integration -- azure-deploy "$TEST_GROUP"

--- a/.github/workflows/test-comparison-no-skills.yml
+++ b/.github/workflows/test-comparison-no-skills.yml
@@ -1,0 +1,51 @@
+# Comparison integration tests (no skills).
+#
+# Runs azure-deploy deployment tests with NO_SKILLS=true on Sundays as a
+# baseline / comparison run against the regular weekday integration tests.
+# This workflow has its own name so downstream automation (e.g. the
+# "Analyze Test Run" agentic workflow that listens to "Integration Tests - all")
+# does not get triggered by the Sunday baseline runs.
+
+name: Integration Tests - comparison (no skills)
+
+permissions:
+  id-token: write
+  contents: read
+
+on:
+  schedule:
+    # 4:00 AM PST Sun (12:00 PM UTC Sun) — comparison runs that don't use skills
+    - cron: "0 12 * * 0"
+  workflow_dispatch:
+    inputs:
+      model-override:
+        description: "Model to use for testing"
+        required: false
+        type: choice
+        options:
+          - claude-sonnet-4.5
+          - claude-opus-4.5
+      test-pattern:
+        description: 'Optional: Comma separated patterns by name or describe block. If empty, all tests will be run.'
+        required: false
+        type: string
+        default: ""
+      debug:
+        description: "Whether to set DEBUG=1 for jest tests"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  azure-deploy:
+    name: Integration – azure-deploy (no skills)
+    if: github.repository == 'microsoft/GitHub-Copilot-for-Azure'
+    uses: ./.github/workflows/test-azure-deploy.yml
+    with:
+      model-override: ${{ inputs.model-override }}
+      test-pattern: ${{ inputs.test-pattern }}
+      debug: ${{ inputs.debug || false }}
+      publish-reports: ${{ github.event_name == 'schedule' }}
+      no-skills: true
+    secrets:
+      COPILOT_CLI_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -43,7 +43,8 @@ const pseudoRandomResourceGroupNameSystemPromptModifier = {
 
 describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
   const agent = useAgentRunner();
-  describe("skill-invocation", () => {
+  const describeSkillInvocation = process.env.NO_SKILLS === "true" ? describe.skip : describe;
+  describeSkillInvocation("skill-invocation", () => {
     const followUp = ["Continue with recommended options until complete."];
     test("invokes azure-deploy skill for deployment prompt", async () => {
       await withTestResult(async ({ setSkillInvocationRate }) => {

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -31,6 +31,6 @@
         "0 5 * * 2-6": "microsoft-foundry",
         "0 8 * * 2-6": "azure-deploy",
         "0 12 * * 2-6": "airunway-aks-setup,appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost,azure-diagnostics,azure-enterprise-infra-planner,azure-hosted-copilot-sdk,azure-kubernetes,azure-kusto,azure-messaging,azure-prepare,azure-quotas,azure-rbac,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-upgrade,azure-validate,entra-agent-id,entra-app-registration",
-        "0 12 * * 7": "azure-deploy"
+        "0 12 * * 0": "azure-deploy"
     }
 }

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -30,6 +30,7 @@
     "integrationTestSchedule": {
         "0 5 * * 2-6": "microsoft-foundry",
         "0 8 * * 2-6": "azure-deploy",
-        "0 12 * * 2-6": "airunway-aks-setup,appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost,azure-diagnostics,azure-enterprise-infra-planner,azure-hosted-copilot-sdk,azure-kubernetes,azure-kusto,azure-messaging,azure-prepare,azure-quotas,azure-rbac,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-upgrade,azure-validate,entra-agent-id,entra-app-registration"
+        "0 12 * * 2-6": "airunway-aks-setup,appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost,azure-diagnostics,azure-enterprise-infra-planner,azure-hosted-copilot-sdk,azure-kubernetes,azure-kusto,azure-messaging,azure-prepare,azure-quotas,azure-rbac,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-upgrade,azure-validate,entra-agent-id,entra-app-registration",
+        "0 12 * * 7": "azure-deploy"
     }
 }

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -30,7 +30,6 @@
     "integrationTestSchedule": {
         "0 5 * * 2-6": "microsoft-foundry",
         "0 8 * * 2-6": "azure-deploy",
-        "0 12 * * 2-6": "airunway-aks-setup,appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost,azure-diagnostics,azure-enterprise-infra-planner,azure-hosted-copilot-sdk,azure-kubernetes,azure-kusto,azure-messaging,azure-prepare,azure-quotas,azure-rbac,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-upgrade,azure-validate,entra-agent-id,entra-app-registration",
-        "0 12 * * 0": "azure-deploy"
+        "0 12 * * 2-6": "airunway-aks-setup,appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost,azure-diagnostics,azure-enterprise-infra-planner,azure-hosted-copilot-sdk,azure-kubernetes,azure-kusto,azure-messaging,azure-prepare,azure-quotas,azure-rbac,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-upgrade,azure-validate,entra-agent-id,entra-app-registration"
     }
 }

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -300,6 +300,9 @@ export function isToolCalled(metadata: AgentMetadata, toolName: string, argument
 }
 
 export function softCheckSkill(agentMetadata: AgentMetadata, skillName: string): void {
+  if (process.env.NO_SKILLS === "true") {
+    return;
+  }
   const isSkillUsed = isSkillInvoked(agentMetadata, skillName);
 
   if (!isSkillUsed) {


### PR DESCRIPTION
## Description

Extend the integration test workflow to run comparison tests on Sunday. Unlike regular integration tests, these comparison tests don't load any skills. They are intended for comparing the behavior of the agent with/without our skills to help us guage if our skills are helpful and if they may cause the agent to use significantly more tokens.

Currently, the cron job config only runs azure-deploy tests for the comparison tests.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
