### PR TITLE
Support publishing adhoc integration test results

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: boolean
         default: false
+      ReportStorageAccount:
+        description: 'Optional: Azure Storage account name to publish reports to (only used for manual runs)'
+        required: false
+        type: string
+        default: ''
 
 # SCHEDULE CONFIGURATION
 # Customize the inputs for each scheduled run by modifying these env vars.
@@ -332,6 +337,29 @@ jobs:
           RUN_ID: ${{ github.run_id }}
           JOB_ID: ${{ github.job }}
           STORAGE_ACCOUNT: ${{ vars.REPORT_STORAGE_ACCOUNT }}
+          STORAGE_CONTAINER: ${{ vars.REPORT_STORAGE_CONTAINER || 'integration-reports' }}
+          SKILL: ${{ matrix.skill }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          PREFIX="${DATE}/${RUN_ID}/${SKILL}/"
+          echo "Uploading reports to ${STORAGE_ACCOUNT}/${STORAGE_CONTAINER}/${PREFIX}"
+          az storage blob upload-batch \
+            --account-name "$STORAGE_ACCOUNT" \
+            --destination "$STORAGE_CONTAINER" \
+            --destination-path "$PREFIX" \
+            --source reports/test-run-all-integration/ \
+            --auth-mode login \
+            --overwrite
+
+      # Publish reports to a user-provided storage account for manual runs.
+      # Note: The managed identity must have write permission to the target storage account.
+      - name: Publish report to Azure Storage (manual run)
+        if: always() && github.event_name == 'workflow_dispatch' && inputs.ReportStorageAccount != ''
+        id: publish-report-manual
+        env:
+          RUN_ID: ${{ github.run_id }}
+          JOB_ID: ${{ github.job }}
+          STORAGE_ACCOUNT: ${{ inputs.ReportStorageAccount }}
           STORAGE_CONTAINER: ${{ vars.REPORT_STORAGE_CONTAINER || 'integration-reports' }}
           SKILL: ${{ matrix.skill }}
         run: |

--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -46,11 +46,6 @@ on:
         required: false
         type: boolean
         default: false
-      ReportStorageAccount:
-        description: 'Optional: Azure Storage account name to publish reports to (only used for manual runs)'
-        required: false
-        type: string
-        default: ''
 
 # SCHEDULE CONFIGURATION
 # Customize the inputs for each scheduled run by modifying these env vars.
@@ -351,16 +346,16 @@ jobs:
             --auth-mode login \
             --overwrite
 
-      # Publish reports to a user-provided storage account for manual runs.
+      # Publish reports to the same storage account but a separate container for manual runs.
       # Note: The managed identity must have write permission to the target storage account.
       - name: Publish report to Azure Storage (manual run)
-        if: always() && github.event_name == 'workflow_dispatch' && inputs.ReportStorageAccount != ''
+        if: always() && github.event_name == 'workflow_dispatch' && vars.REPORT_STORAGE_ACCOUNT != ''
         id: publish-report-manual
         env:
           RUN_ID: ${{ github.run_id }}
           JOB_ID: ${{ github.job }}
-          STORAGE_ACCOUNT: ${{ inputs.ReportStorageAccount }}
-          STORAGE_CONTAINER: ${{ vars.REPORT_STORAGE_CONTAINER || 'integration-reports' }}
+          STORAGE_ACCOUNT: ${{ vars.REPORT_STORAGE_ACCOUNT }}
+          STORAGE_CONTAINER: ${{ vars.MANUAL_REPORT_STORAGE_CONTAINER || 'manual-integration-reports' }}
           SKILL: ${{ matrix.skill }}
         run: |
           DATE=$(date -u +%Y-%m-%d)

--- a/dashboard/api/src/blobEnumerator.ts
+++ b/dashboard/api/src/blobEnumerator.ts
@@ -2,7 +2,7 @@ import { BlobServiceClient, ContainerClient } from "@azure/storage-blob";
 import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
 import type { BlobEntry, BlobTree, BlobTreeNode } from "./shared/blobTree";
 
-const INTEGRATION_REPORTS_CONTAINER_NAME = "integration-reports";
+const INTEGRATION_REPORTS_CONTAINER_NAME = process.env.INTEGRATION_REPORTS_CONTAINER_NAME || "integration-reports";
 
 const EXCLUDED_FILENAMES = new Set(["token-usage.json", "agent-metadata.json"]);
 

--- a/dashboard/infra/modules/storage.bicep
+++ b/dashboard/infra/modules/storage.bicep
@@ -69,6 +69,11 @@ resource integrationReportsContainer 'Microsoft.Storage/storageAccounts/blobServ
   name: 'integration-reports'
 }
 
+resource manualIntegrationReportsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobServices
+  name: 'manual-integration-reports'
+}
+
 resource nonIntegrationContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
   parent: blobServices
   name: 'non-integration'


### PR DESCRIPTION
## Description

This would allow people to run adhoc integration tests and collect the test artifacts.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
