### PR TITLE
Use Claude Sonnet 4.6 as the default integration test model

### DIFF
--- a/.github/skills/analyze-test-run/references/issue-template.md
+++ b/.github/skills/analyze-test-run/references/issue-template.md
@@ -106,7 +106,7 @@ bug, integration-test
 
 - **Runner OS:** ubuntu-latest
 - **Node.js:** (from workflow)
-- **Model:** claude-sonnet-4.5 (or as overridden)
+- **Model:** claude-sonnet-4.6 (or as overridden)
 - **Run URL:** {run-url}
 - **Commit:** {commit-sha}
 ````

--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -29,8 +29,8 @@ on:
         required: false
         type: choice
         options:
-          - claude-sonnet-4.5
-          - claude-opus-4.5
+          - claude-sonnet-4.6
+          - claude-opus-4.6
       skill-test-pattern:
         description: 'Optional: pattern by name or describe block for filtering skill tests. This parameter does not apply to azure-deploy tests'
         required: false

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -17,8 +17,8 @@ on:
         required: false
         type: choice
         options:
-          - claude-sonnet-4.5
-          - claude-opus-4.5
+          - claude-sonnet-4.6
+          - claude-opus-4.6
       test-pattern:
         description: 'Optional: Comma separated patterns by name or describe block (e.g. "creates todo list", "vanilla-static-web-apps-deploy", "Terraform"). If empty, all tests will be run.'
         required: false

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -731,9 +731,9 @@ export function useAgentRunner() {
       }
 
       const noSkills = process.env.NO_SKILLS === "true";
-      const defaultModel = "claude-sonnet-4.6";
+      const model = modelOverride || "claude-sonnet-4.6";
       const session = await client.createSession({
-        model: modelOverride || defaultModel,
+        model: model,
         onPermissionRequest: approveAll,
         skillDirectories: noSkills ? [] : [skillDirectory],
         disabledSkills: disabledSkills,
@@ -792,7 +792,7 @@ export function useAgentRunner() {
         cacheWriteTokens: 0,
         totalApiDurationMs: 0,
         apiCallCount: 0,
-        model: modelOverride || defaultModel,
+        model: model,
         perCallUsage: [],
       };
 

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -731,8 +731,9 @@ export function useAgentRunner() {
       }
 
       const noSkills = process.env.NO_SKILLS === "true";
+      const defaultModel = "claude-sonnet-4.6";
       const session = await client.createSession({
-        model: modelOverride || "claude-sonnet-4.5",
+        model: modelOverride || defaultModel,
         onPermissionRequest: approveAll,
         skillDirectories: noSkills ? [] : [skillDirectory],
         disabledSkills: disabledSkills,
@@ -791,7 +792,7 @@ export function useAgentRunner() {
         cacheWriteTokens: 0,
         totalApiDurationMs: 0,
         apiCallCount: 0,
-        model: modelOverride || "claude-sonnet-4.5",
+        model: modelOverride || defaultModel,
         perCallUsage: [],
       };
 


### PR DESCRIPTION
## Description

Telemetry of our VS Code extension indicates the usage of Sonnet 4.6 has far exceeded the usage of Sonnet 4.5. This PR upgrades the default model of integration tests to Sonnet 4.6.

Here are the exact percentage of model usage from last week.

5/4/2026, 12:00:00 AM	Auto	25.425742574257427
5/4/2026, 12:00:00 AM	ClaudeHaiku45	6.178217821782178
5/4/2026, 12:00:00 AM	ClaudeOpus46	8.158415841584159
5/4/2026, 12:00:00 AM	ClaudeSonnet45	5.02970297029703
5/4/2026, 12:00:00 AM	ClaudeSonnet46	24.91089108910891
5/4/2026, 12:00:00 AM	GPT41	6.574257425742575

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
