### PR TITLE
Pin copilot cli version for tests

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@azure/identity": "^4.13.1",
         "@eslint/js": "^10.0.0",
+        "@github/copilot": "1.0.34",
         "@github/copilot-sdk": "^0.2.0",
         "@microsoft/vally-cli": "^0.4.0",
         "@types/jest": "^30.0.0",
@@ -931,27 +932,27 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.43.tgz",
-      "integrity": "sha512-2FO825Aq4bwmHcXVyplW+CpZaJFUYjqtqjBGnueM31gu4ufn6ReurzB2swBQ6bn4Pquyy2KeodMRPpT6JaLMhw==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.34.tgz",
+      "integrity": "sha512-jFYulj1v00b3j43Er9+WwhZ/XldGq7+gti2s2pRhrdPwYEd1PMvscDZwRa/1iUBz/XQ5HUGac1tD8P7+VUpWjg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.43",
-        "@github/copilot-darwin-x64": "1.0.43",
-        "@github/copilot-linux-arm64": "1.0.43",
-        "@github/copilot-linux-x64": "1.0.43",
-        "@github/copilot-win32-arm64": "1.0.43",
-        "@github/copilot-win32-x64": "1.0.43"
+        "@github/copilot-darwin-arm64": "1.0.34",
+        "@github/copilot-darwin-x64": "1.0.34",
+        "@github/copilot-linux-arm64": "1.0.34",
+        "@github/copilot-linux-x64": "1.0.34",
+        "@github/copilot-win32-arm64": "1.0.34",
+        "@github/copilot-win32-x64": "1.0.34"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.43.tgz",
-      "integrity": "sha512-VMaWfoUwIt19TGzmvTv/In5ITgFWfu91ZILt4Lb77gSmVbwbs+DahP2lbvM1s/GtGwOknwhOJLp4q2WMgK3CoQ==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.34.tgz",
+      "integrity": "sha512-g94EhSLd3a6fckZ6xb/zP2DZJZEx7kONWdOoDiHXUtSqc4RiZ7OBq1EwT4WrPY1lsmy9sioJIcZSGzJd0C1M7Q==",
       "cpu": [
         "arm64"
       ],
@@ -966,9 +967,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.43.tgz",
-      "integrity": "sha512-lCxg75zbgtWggb1p+IHhlhmulQj7BKIc+9pUsTwJ3Mjt51kiUYmD6LF2BD1/Ed4M3GMumSu4UTSIv9pL96n0Wg==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.34.tgz",
+      "integrity": "sha512-tIgFEZV0ohCF/VgTODJWre3xURsvEd+6IPN/HPKWxG6AXtJOxzjlr5kLYYdPHdNlHNmSxGQw8fWsN2FZ4nyDdw==",
       "cpu": [
         "x64"
       ],
@@ -983,9 +984,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.43.tgz",
-      "integrity": "sha512-Jr1rvt/Syz5oVSiU53keRKEV8f5xTLkmiB2qasAV6Emk7K82/BZW5HfW8cDadfHnlAS1+UVPpoO+8ykgx4dikw==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.34.tgz",
+      "integrity": "sha512-feqjEetrlqBUhYskIsPmwACQOWO99cvRpKwIFl3OlEjWoj+//HA7yXh49UIe0gD8wQUI8hy05uVz3K2/xti2nQ==",
       "cpu": [
         "arm64"
       ],
@@ -1000,9 +1001,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.43.tgz",
-      "integrity": "sha512-uyWyPpcwMC1tIHJTA1OPzIm1i/Eeku0NjFzPYnFvpfGug9pkL4xcUr8A2UNl8cVvxq/VQMwtYckV3G12ySJTFw==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.34.tgz",
+      "integrity": "sha512-3l0rZZqmceklHizJaaO+Iy2PsAZpVZS9Mn9VYnVcY/8Yzt4Y2hmXSFcKVfc4l+JlhFsPs7trhMdIkfwkjaKPLg==",
       "cpu": [
         "x64"
       ],
@@ -1032,9 +1033,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.43.tgz",
-      "integrity": "sha512-vY3rwkW1h7ixSqYd9XT/xGjxkepvQVJK2q1sYhSPBN4Wvuk37fRjN7ox3QU1lhpxlYQMc/g+ZR58u5cx31n1lw==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.34.tgz",
+      "integrity": "sha512-06kEJO3iyohmAqF4iIbOxOfWLFSIpLDJ1L1oEHRtouMrH2Ll1wrUjsoQT1gXgBOv7rifl25qx/Avx5zKqvuORw==",
       "cpu": [
         "arm64"
       ],
@@ -1049,9 +1050,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.43",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.43.tgz",
-      "integrity": "sha512-AjGsebDbJmBxe9FFf2McSN5r2Joi8cFY879lxaQaXxfGjzOHblzvbhflbsX9x2GnvCfDdDiow413WvOGqKDH8g==",
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.34.tgz",
+      "integrity": "sha512-QLL8pS4q2TTyQbClEXxqXtQGPr4lk+pwc8hPMUL7iw7HGDOvs1WCLMT1ZSDPPcxSrTnR/dURX5za1NMA8uF/fw==",
       "cpu": [
         "x64"
       ],
@@ -1968,6 +1969,92 @@
         "vally": "dist/index.js"
       }
     },
+    "node_modules/@microsoft/vally/node_modules/@github/copilot": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.44.tgz",
+      "integrity": "sha512-wr/GmNOUaJK/giJK5abyB1oTpEowgFKLi+NJnlyAymKiK/GKCaRlJqiX23H2RetM8vD2hDYUFUFm9lTCooGy0g==",
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "bin": {
+        "copilot": "npm-loader.js"
+      },
+      "optionalDependencies": {
+        "@github/copilot-darwin-arm64": "1.0.44",
+        "@github/copilot-darwin-x64": "1.0.44",
+        "@github/copilot-linux-arm64": "1.0.44",
+        "@github/copilot-linux-x64": "1.0.44",
+        "@github/copilot-win32-arm64": "1.0.44",
+        "@github/copilot-win32-x64": "1.0.44"
+      }
+    },
+    "node_modules/@microsoft/vally/node_modules/@github/copilot-darwin-arm64": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.44.tgz",
+      "integrity": "sha512-9NqA5sT2spmNsehxhs51GhXRZIZga5nq+WcMl4LG2QrUPJRDwvHf1bDKqETJUBbYvBY8jONGuTKMRofkMI68YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-arm64": "copilot"
+      }
+    },
+    "node_modules/@microsoft/vally/node_modules/@github/copilot-darwin-x64": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.44.tgz",
+      "integrity": "sha512-QPD8KtXx07SIKILGBl4JDhPyL2Qo0FMmaTYVxR6nkyHkHnFPsUZD6VWGR+T/KMLkcUXFM85Xc1ba9Y27s4nRrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "copilot-darwin-x64": "copilot"
+      }
+    },
+    "node_modules/@microsoft/vally/node_modules/@github/copilot-linux-arm64": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.44.tgz",
+      "integrity": "sha512-Z8ScIUP433xS18f68NP9jM9zW320Xzpi2wf7Nig/VyfrwupBy25UTezydQMT0KQHLWTEleHOPcYnASY3HgJXnQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-arm64": "copilot"
+      }
+    },
+    "node_modules/@microsoft/vally/node_modules/@github/copilot-linux-x64": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.44.tgz",
+      "integrity": "sha512-KUl6lvJt0HNKaXSx0T0bIWJ3rvrGwgZYMlkDfqMbuMnZatEQJbjPwxmL/IDfp/c0DyKd7K+ajl17wHYcN/hJIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "copilot-linux-x64": "copilot"
+      }
+    },
     "node_modules/@microsoft/vally/node_modules/@github/copilot-sdk": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.3.0.tgz",
@@ -1981,6 +2068,40 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@microsoft/vally/node_modules/@github/copilot-win32-arm64": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.44.tgz",
+      "integrity": "sha512-JVJxZJwAc95ZfapgOXjNFwSqrWlvC3heo128L+CDkdZ6lwpD1dTGMHT/6rMMEeo3xjZmMm8tiynfwsHLDgTtvQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-arm64": "copilot.exe"
+      }
+    },
+    "node_modules/@microsoft/vally/node_modules/@github/copilot-win32-x64": {
+      "version": "1.0.44",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.44.tgz",
+      "integrity": "sha512-Yj3KQ/DqwS50PwRtyQITX2mWIVZeJeX+y0faVSMwUUzG1qxmMcme7wimhKOyc4LSV11DpgVB9MSiBw2xys7iww==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "copilot-win32-x64": "copilot.exe"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -31,7 +31,9 @@
   "devDependencies": {
     "@azure/identity": "^4.13.1",
     "@eslint/js": "^10.0.0",
+    "@github/copilot": "1.0.34",
     "@github/copilot-sdk": "^0.2.0",
+    "@microsoft/vally-cli": "^0.4.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",
     "cross-env": "^10.1.0",
@@ -47,7 +49,6 @@
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "typescript": "6.0.2",
-    "@microsoft/vally-cli": "^0.4.0",
     "typescript-eslint": "^8.58.0"
   },
   "jest-junit": {


### PR DESCRIPTION
## Description

Pin the version to dodge a regression in Copilot CLI causing Copilot SDK not able to approve tool call requests. https://github.com/github/copilot-sdk/issues/1133

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
