### PR TITLE
fix: use COPILOT_GITHUB_TOKEN env var for Vally SDK auth

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -62,7 +62,7 @@ jobs:
           --junit
           --threshold 0.8
         env:
-          GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
+          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
The `@github/copilot-sdk` checks `COPILOT_GITHUB_TOKEN` first (priority 1), before `GH_TOKEN` and `GITHUB_TOKEN`. Using `GITHUB_TOKEN` can conflict with the built-in Actions token.

This PR changes the eval workflow to use `COPILOT_GITHUB_TOKEN` instead.
