### PR TITLE
Disable eval runs in PR check

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,10 +1,10 @@
 name: Run Skill Evaluations
 on:
-  # pull_request:
-  #   paths:
-  #     - 'plugin/skills/**'
-  #     - 'evals/**'
-  #     - '.vally.yaml'
+  pull_request:
+    paths:
+      - 'plugin/skills/**'
+      - 'evals/**'
+      - '.vally.yaml'
   workflow_dispatch:
     inputs:
       suite:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -1,10 +1,10 @@
 name: Run Skill Evaluations
 on:
-  pull_request:
-    paths:
-      - 'plugin/skills/**'
-      - 'evals/**'
-      - '.vally.yaml'
+  # pull_request:
+  #   paths:
+  #     - 'plugin/skills/**'
+  #     - 'evals/**'
+  #     - '.vally.yaml'
   workflow_dispatch:
     inputs:
       suite:

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -30,6 +30,9 @@ jobs:
   eval:
     name: Run Evaluations
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:


### PR DESCRIPTION
## Description

This is blocking PRs made from forked repos because they don't have access to the secret. We also don't want to expose secrets for such PRs because attackers may modify the workflow to exfiltrate secrets, if we aren't careful enough and accidentally approved their workflow runs.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
