### PR TITLE
Tweak test prompt to avoid unnecessary work

### DIFF
--- a/tests/azure-hosted-copilot-sdk/integration.test.ts
+++ b/tests/azure-hosted-copilot-sdk/integration.test.ts
@@ -175,7 +175,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       await withTestResult(async () => {
         const rawMetadata = await agent.run({
           setup: setupCopilotSdkApp,
-          prompt: "Deploy this app to Azure",
+          prompt: "Show me how to deploy this app to Azure but don't deploy it",
           nonInteractive: true,
         });
         const agentMetadata = sanitizeMetadata(rawMetadata);


### PR DESCRIPTION
## Description

Tweak prompt to prevent the agent from trying to do the deploy work without asking for confirmation. The test case doesn't intend to test the deployment.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

Resolves #2249
