### PR TITLE
Fix integration test schedule

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -269,8 +269,15 @@ jobs:
             }
 
             // 2. Integration test schedule coverages all skills
+            // Only consider the active cron schedules from .github/workflows/integration-tests.yml
+            const activeCronSchedules = [
+                '0 5 * * 2-6',
+                '0 8 * * 2-6',
+                '0 12 * * 2-6',
+            ];
             let scheduledSkills = [];
-            Object.values(skillsJson.integrationTestSchedule).forEach(value => {
+            activeCronSchedules.forEach(cron => {
+                const value = skillsJson.integrationTestSchedule[cron];
                 if (value) {
                     value.split(',').forEach(s => scheduledSkills.push(s));
                 }

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -31,7 +31,6 @@
     "integrationTestSchedule": {
         "0 5 * * 2-6": "microsoft-foundry",
         "0 8 * * 2-6": "azure-deploy",
-        "0 10 * * 2-6": "azure-reliability",
-        "0 12 * * 2-6": "airunway-aks-setup,appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost,azure-diagnostics,azure-enterprise-infra-planner,azure-hosted-copilot-sdk,azure-kubernetes,azure-kusto,azure-messaging,azure-prepare,azure-quotas,azure-rbac,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-upgrade,azure-validate,entra-agent-id,entra-app-registration"
+        "0 12 * * 2-6": "airunway-aks-setup,appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost,azure-diagnostics,azure-enterprise-infra-planner,azure-hosted-copilot-sdk,azure-kubernetes,azure-kusto,azure-messaging,azure-prepare,azure-quotas,azure-rbac,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-upgrade,azure-validate,entra-agent-id,entra-app-registration,azure-reliability"
     }
 }


### PR DESCRIPTION
## Description

The integration test only runs at the 3 scheduled time. Adding a new schedule in skills.json alone won't make it run tests for the skill. This PR adds the skill to a slot that actually runs and fixed the PR validation script to catch this issues in the future.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
