### PR TITLE
updated plugin.json to skip default hooks.json discovery from vscode

### DIFF
--- a/plugin/.plugin/plugin.json
+++ b/plugin/.plugin/plugin.json
@@ -21,5 +21,8 @@
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
-  "hooks": { "paths": ["./hooks/copilot-hooks.json"], "exclusive": true }
+  "hooks": {
+    "paths": ["./hooks/copilot-hooks.json"],
+    "exclusive": true
+  }
 }

--- a/plugin/.plugin/plugin.json
+++ b/plugin/.plugin/plugin.json
@@ -21,5 +21,5 @@
   ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
-  "hooks": "./hooks/copilot-hooks.json"
+  "hooks": { "paths": ["./hooks/copilot-hooks.json"], "exclusive": true }
 }


### PR DESCRIPTION
**Problem:**

VS Code 1.120 introduced automatic discovery of Copilot CLI plugins. When VS Code finds our plugin, it reads .plugin/plugin.json and enters Open Plugin parsing context. In this context, only ${PLUGIN_ROOT} is interpolated.

However, VS Code also auto-discovers hooks/hooks.json from the default location (per the Open Plugins spec). Our hooks/hooks.json is written for Claude Code and uses ${CLAUDE_PLUGIN_ROOT} — which VS Code does not resolve in the Open Plugin context. The variable resolves to empty, causing this error in the Copilot chat window:

 /bin/bash: /hooks/scripts/track-telemetry.sh: No such file or directory

Root cause: Our plugin ships two hooks files for different tools:

 - hooks/copilot-hooks.json — for Copilot CLI / VS Code (uses ${PLUGIN_ROOT})
 - hooks/hooks.json — for Claude Code (uses ${CLAUDE_PLUGIN_ROOT})

VS Code loads both by default, but can only resolve variables for the Open Plugin format.

**Fix:**

Added "hooks": { "paths": ["./hooks/copilot-hooks.json"], "exclusive": true } to .plugin/plugin.json.

Per the Open Plugins spec (https://open-plugins.com/plugin-builders/specification#component-path-fields), exclusive: true tells the tool to only load the specified hooks file and skip default path discovery. This prevents VS Code from picking up the Claude-format hooks/hooks.json.

Impact

 - VS Code: Only copilot-hooks.json (along with anyother hooks defined) — no more error ✅
 - Copilot CLI: Unaffected — reads .plugin/plugin.json, uses copilot-hooks.json
 - Claude Code: Unaffected — reads .claude-plugin/plugin.json, has its own discovery

References

 - https://github.com/microsoft/vscode/issues/315830 (https://github.com/microsoft/vscode/issues/315830)
 - https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/2307 (https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/2307)