### PR TITLE
Update checks for container app deployment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,2 @@
 .github/workflows/*.lock.yml linguist-generated=true merge=ours
 *.sh text eol=lf
-*.md text eol=lf

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../utils/agent-runner";
 import { hasDeployLinks, softCheckDeploySkills, softCheckContainerDeployEnvVars, shouldEarlyTerminateForCompletedDeployment, shouldEarlyTerminateForAzdProvision } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
-import { expectFiles, softCheckSkill, doesWorkspaceFileIncludePattern, shouldEarlyTerminateForSkillInvocation, isSkillInvoked, withTestResult } from "../utils/evaluate";
+import { expectFiles, softCheckSkill, doesWorkspaceFileIncludePattern, doesBicepContainerAppUsePublicPlaceholderImage, doesTerraformContainerAppUsePublicPlaceholderImage, doesTerraformContainerAppIgnoreImageChanges, shouldEarlyTerminateForSkillInvocation, isSkillInvoked, withTestResult } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-deploy";
 const RUNS_PER_PROMPT = 1;
@@ -367,7 +367,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
   // Azure Container Apps (ACA) - not custom IaC specification
   describe("vanilla-azure-container-apps-deploy", () => {
-    test("creates containerized web application", async () => {
+    test("creates containerized web application with Bicep", async () => {
       await withTestResult(async () => {
         let workspacePath: string | undefined;
 
@@ -395,14 +395,12 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Verify two-phase deployment pattern (three modules in main.bicep):
         // Phase 1: ACR module
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.ContainerRegistry\/registries/i, bicepPattern)).toBe(true);
-        // Phase 1: Container App with placeholder image and system-assigned managed identity
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, bicepPattern)).toBe(true);
+        // Phase 1: Container App with public placeholder image and system-assigned managed identity
+        expect(doesBicepContainerAppUsePublicPlaceholderImage(workspacePath!)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
         // Phase 1: Registries block with system identity for ACR pull authentication
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /registries/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, bicepPattern)).toBe(true);
-        // Phase 1: Empty default for containerImageName param to use placeholder during provisioning
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /param\s+containerImageName\s+string\s*=\s*''/i, bicepPattern)).toBe(true);
         // AcrPull role assignment (GUID 7f951dda) ensures managed identity can pull from ACR
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
       });
@@ -436,14 +434,12 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Verify two-phase deployment pattern (three modules in main.bicep):
         // Phase 1: ACR module
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.ContainerRegistry\/registries/i, bicepPattern)).toBe(true);
-        // Phase 1: Container App with placeholder image and system-assigned managed identity
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com([^A-Za-z0-9.-]|$)/i, bicepPattern)).toBe(true);
+        // Phase 1: Container App with public placeholder image and system-assigned managed identity
+        expect(doesBicepContainerAppUsePublicPlaceholderImage(workspacePath!)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
         // Phase 1: Registries block with system identity for ACR pull authentication
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /registries/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, bicepPattern)).toBe(true);
-        // Phase 1: Empty default for containerImageName param to use placeholder during provisioning
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /param\s+containerImageName\s+string\s*=\s*''/i, bicepPattern)).toBe(true);
         // AcrPull role assignment (GUID 7f951dda) ensures managed identity can pull from ACR
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
       });
@@ -674,9 +670,9 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: ACR resource
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_registry/i, tfPattern)).toBe(true);
         // Phase 1: Container App with placeholder image, system-assigned identity, and lifecycle ignore_changes
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com\//i, tfPattern)).toBe(true);
+        expect(doesTerraformContainerAppUsePublicPlaceholderImage(workspacePath!)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
+        expect(doesTerraformContainerAppIgnoreImageChanges(workspacePath!)).toBe(true);
         // Phase 1: Registry block with managed identity for ACR pull authentication
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /registry/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, tfPattern)).toBe(true);
@@ -716,9 +712,9 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: ACR resource
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_registry/i, tfPattern)).toBe(true);
         // Phase 1: Container App with placeholder image, system-assigned identity, and lifecycle ignore_changes
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, tfPattern)).toBe(true);
+        expect(doesTerraformContainerAppUsePublicPlaceholderImage(workspacePath!)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
+        expect(doesTerraformContainerAppIgnoreImageChanges(workspacePath!)).toBe(true);
         // Phase 1: Registry block with managed identity for ACR pull authentication
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /registry/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, tfPattern)).toBe(true);
@@ -758,9 +754,9 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: ACR resource
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /azurerm_container_registry/i, tfPattern)).toBe(true);
         // Phase 1: Container App with placeholder image, system-assigned identity, and lifecycle ignore_changes
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, tfPattern)).toBe(true);
+        expect(doesTerraformContainerAppUsePublicPlaceholderImage(workspacePath!)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
+        expect(doesTerraformContainerAppIgnoreImageChanges(workspacePath!)).toBe(true);
         // Phase 1: Registry block with managed identity for ACR pull authentication
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /registry/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, tfPattern)).toBe(true);
@@ -956,14 +952,12 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Verify two-phase deployment pattern (three modules in main.bicep):
         // Phase 1: ACR module
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /Microsoft\.ContainerRegistry\/registries/i, bicepPattern)).toBe(true);
-        // Phase 1: Container App with placeholder image and system-assigned managed identity
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, bicepPattern)).toBe(true);
+        // Phase 1: Container App with public placeholder image and system-assigned managed identity
+        expect(doesBicepContainerAppUsePublicPlaceholderImage(workspacePath!)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
         // Phase 1: Registries block with system identity for ACR pull authentication
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /registries/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, bicepPattern)).toBe(true);
-        // Phase 1: Empty default for containerImageName param to use placeholder during provisioning
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /param\s+containerImageName\s+string\s*=\s*''/i, bicepPattern)).toBe(true);
         // AcrPull role assignment (GUID 7f951dda) ensures managed identity can pull from ACR
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
       });

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -16,7 +16,7 @@ import {
 } from "../utils/agent-runner";
 import { hasDeployLinks, softCheckDeploySkills, softCheckContainerDeployEnvVars, shouldEarlyTerminateForCompletedDeployment, shouldEarlyTerminateForAzdProvision } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
-import { expectFiles, softCheckSkill, doesWorkspaceFileIncludePattern, arePatternsInSeparateFiles, shouldEarlyTerminateForSkillInvocation, isSkillInvoked, withTestResult } from "../utils/evaluate";
+import { expectFiles, softCheckSkill, doesWorkspaceFileIncludePattern, shouldEarlyTerminateForSkillInvocation, isSkillInvoked, withTestResult } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-deploy";
 const RUNS_PER_PROMPT = 1;
@@ -385,8 +385,13 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: Container App with placeholder image and system-assigned managed identity
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
-        // Phase 2: AcrPull role assignment in a separate module file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toEqual({ isSeparate: true });
+        // Phase 1: Registries block with system identity for ACR pull authentication
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /registries/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, bicepPattern)).toBe(true);
+        // Phase 1: Empty default for containerImageName param to use placeholder during provisioning
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /param\s+containerImageName\s+string\s*=\s*''/i, bicepPattern)).toBe(true);
+        // AcrPull role assignment (GUID 7f951dda) ensures managed identity can pull from ACR
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
 
@@ -420,8 +425,13 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: Container App with placeholder image and system-assigned managed identity
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com([^A-Za-z0-9.-]|$)/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
-        // Phase 2: AcrPull role assignment in a separate module file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toEqual({ isSeparate: true });
+        // Phase 1: Registries block with system identity for ACR pull authentication
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /registries/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, bicepPattern)).toBe(true);
+        // Phase 1: Empty default for containerImageName param to use placeholder during provisioning
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /param\s+containerImageName\s+string\s*=\s*''/i, bicepPattern)).toBe(true);
+        // AcrPull role assignment (GUID 7f951dda) ensures managed identity can pull from ACR
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
 
@@ -641,8 +651,13 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com\//i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
-        // Phase 2: AcrPull role assignment in a separate file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toEqual({ isSeparate: true });
+        // Phase 1: Registry block with managed identity for ACR pull authentication
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /registry/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, tfPattern)).toBe(true);
+        // Phase 1: Image variable defaults to empty so placeholder is used during provisioning
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /container_image|image_name/i, tfPattern)).toBe(true);
+        // AcrPull role assignment ensures managed identity can pull from ACR
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /AcrPull/i, tfPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
 
@@ -677,8 +692,13 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
-        // Phase 2: AcrPull role assignment in a separate file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toEqual({ isSeparate: true });
+        // Phase 1: Registry block with managed identity for ACR pull authentication
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /registry/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, tfPattern)).toBe(true);
+        // Phase 1: Image variable defaults to empty so placeholder is used during provisioning
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /container_image|image_name/i, tfPattern)).toBe(true);
+        // AcrPull role assignment ensures managed identity can pull from ACR
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /AcrPull/i, tfPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
 
@@ -713,8 +733,13 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /ignore_changes/i, tfPattern)).toBe(true);
-        // Phase 2: AcrPull role assignment in a separate file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /azurerm_container_app[^_]/i, /AcrPull/i, tfPattern)).toEqual({ isSeparate: true });
+        // Phase 1: Registry block with managed identity for ACR pull authentication
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /registry/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, tfPattern)).toBe(true);
+        // Phase 1: Image variable defaults to empty so placeholder is used during provisioning
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /container_image|image_name/i, tfPattern)).toBe(true);
+        // AcrPull role assignment ensures managed identity can pull from ACR
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /AcrPull/i, tfPattern)).toBe(true);
       });
     }, deployTestTimeoutMs);
   });
@@ -902,8 +927,13 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         // Phase 1: Container App with placeholder image and system-assigned managed identity
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /(^|[^A-Za-z0-9.-])mcr\.microsoft\.com($|[^A-Za-z0-9.-])/i, bicepPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /SystemAssigned/i, bicepPattern)).toBe(true);
-        // Phase 2: AcrPull role assignment in a separate module file from the Container App
-        expect(arePatternsInSeparateFiles(workspacePath!, /Microsoft\.App\/containerApps/i, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toEqual({ isSeparate: true });
+        // Phase 1: Registries block with system identity for ACR pull authentication
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /registries/i, bicepPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, bicepPattern)).toBe(true);
+        // Phase 1: Empty default for containerImageName param to use placeholder during provisioning
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /param\s+containerImageName\s+string\s*=\s*''/i, bicepPattern)).toBe(true);
+        // AcrPull role assignment (GUID 7f951dda) ensures managed identity can pull from ACR
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /7f951dda-4ed3-4680-a7ca-43fe172d538d/i, bicepPattern)).toBe(true);
       });
     }, brownfieldTestTimeoutMs);
 

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -234,9 +234,12 @@ export function doesTerraformContainerAppUsePublicPlaceholderImage(workspace: st
       symbolExpressions.set(match[1], match[2]);
     }
 
-    for (const match of content.matchAll(/^\s*image\s*=\s*(.+)$/gmi)) {
-      if (expressionContainsPublicPlaceholderImage(match[1], symbolExpressions)) {
-        return true;
+    const containerAppBlocks = extractBlocks(content, /resource\s+"azurerm_container_app"\s+"[^"]+"\s*{/gi);
+    for (const containerAppBlock of containerAppBlocks) {
+      for (const match of containerAppBlock.matchAll(/^\s*image\s*=\s*(.+)$/gmi)) {
+        if (expressionContainsPublicPlaceholderImage(match[1], symbolExpressions)) {
+          return true;
+        }
       }
     }
   }

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -101,31 +101,7 @@ export function matchesCommand(metadata: AgentMetadata, pattern: RegExp): boolea
  * @returns True if any file contains content matching the value pattern
  */
 export function doesWorkspaceFileIncludePattern(workspace: string, valuePattern: RegExp, filePattern?: RegExp): boolean {
-  const scanDirectory = (dir: string): boolean => {
-    const entries = fs.readdirSync(dir, { withFileTypes: true });
-    for (const entry of entries) {
-      const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory() && entry.name !== "node_modules") {
-        if (scanDirectory(fullPath)) return true;
-      } else if (entry.isFile()) {
-        // Skip if filePattern is provided and doesn't match
-        if (filePattern && !entry.name.match(filePattern)) {
-          continue;
-        }
-        try {
-          const content = fs.readFileSync(fullPath, "utf-8");
-          if (content.match(valuePattern)) {
-            return true;
-          }
-        } catch {
-          // Skip files that can't be read as text
-        }
-      }
-    }
-    return false;
-  };
-
-  return scanDirectory(workspace);
+  return readWorkspaceTextFiles(workspace, filePattern ?? /.*/).some(content => content.match(valuePattern));
 }
 
 function readWorkspaceTextFiles(workspace: string, filePattern: RegExp): string[] {

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -198,9 +198,16 @@ export function doesBicepContainerAppUsePublicPlaceholderImage(workspace: string
       symbolExpressions.set(match[1], match[2]);
     }
 
-    for (const match of content.matchAll(/^\s*image\s*:\s*(.+)$/gmi)) {
-      if (expressionContainsPublicPlaceholderImage(match[1], symbolExpressions)) {
-        return true;
+    const containerAppBlocks = extractBlocks(
+      content,
+      /^\s*resource\s+[A-Za-z_]\w*\s+'Microsoft\.App\/containerApps@[^']+'\s*=\s*{/gmi,
+    );
+
+    for (const block of containerAppBlocks) {
+      for (const match of block.matchAll(/^\s*image\s*:\s*(.+)$/gmi)) {
+        if (expressionContainsPublicPlaceholderImage(match[1], symbolExpressions)) {
+          return true;
+        }
       }
     }
   }

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -128,6 +128,162 @@ export function doesWorkspaceFileIncludePattern(workspace: string, valuePattern:
   return scanDirectory(workspace);
 }
 
+function readWorkspaceTextFiles(workspace: string, filePattern: RegExp): string[] {
+  const contents: string[] = [];
+
+  const scanDirectory = (dir: string): void => {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory() && entry.name !== "node_modules") {
+        scanDirectory(fullPath);
+      } else if (entry.isFile() && entry.name.match(filePattern)) {
+        try {
+          contents.push(fs.readFileSync(fullPath, "utf-8"));
+        } catch {
+          // Skip files that can't be read as text
+        }
+      }
+    }
+  };
+
+  scanDirectory(workspace);
+  return contents;
+}
+
+function expressionContainsPublicPlaceholderImage(expression: string, symbolExpressions: Map<string, string>, seenSymbols = new Set<string>()): boolean {
+  if (/["']mcr\.microsoft\.com\//i.test(expression)) {
+    return true;
+  }
+
+  for (const symbolName of expression.matchAll(/\b[A-Za-z_]\w*\b/g)) {
+    const name = symbolName[0];
+    if (seenSymbols.has(name)) {
+      continue;
+    }
+
+    const symbolExpression = symbolExpressions.get(name);
+    if (!symbolExpression) {
+      continue;
+    }
+
+    seenSymbols.add(name);
+    if (expressionContainsPublicPlaceholderImage(symbolExpression, symbolExpressions, seenSymbols)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function extractBlocks(content: string, blockStartPattern: RegExp): string[] {
+  const blocks: string[] = [];
+
+  for (const match of content.matchAll(blockStartPattern)) {
+    const blockStart = match.index;
+    const openBraceIndex = content.indexOf("{", blockStart);
+    if (openBraceIndex === -1) {
+      continue;
+    }
+
+    let depth = 0;
+    for (let index = openBraceIndex; index < content.length; index++) {
+      if (content[index] === "{") {
+        depth += 1;
+      } else if (content[index] === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          blocks.push(content.slice(blockStart, index + 1));
+          break;
+        }
+      }
+    }
+  }
+
+  return blocks;
+}
+
+/**
+ * Checks that generated Bicep provisions Container Apps with a public MCR placeholder image.
+ * This verifies the deployment behavior instead of a specific parameter name/default spelling.
+ */
+export function doesBicepContainerAppUsePublicPlaceholderImage(workspace: string): boolean {
+  const bicepFiles = readWorkspaceTextFiles(workspace, /\.bicep$/i)
+    .filter(content => /Microsoft\.App\/containerApps/i.test(content));
+
+  for (const content of bicepFiles) {
+    const symbolExpressions = new Map<string, string>();
+
+    for (const match of content.matchAll(/^\s*param\s+([A-Za-z_]\w*)\s+string\s*=\s*(.+)$/gmi)) {
+      symbolExpressions.set(match[1], match[2]);
+    }
+
+    for (const match of content.matchAll(/^\s*var\s+([A-Za-z_]\w*)\s*=\s*(.+)$/gmi)) {
+      symbolExpressions.set(match[1], match[2]);
+    }
+
+    for (const match of content.matchAll(/^\s*image\s*:\s*(.+)$/gmi)) {
+      if (expressionContainsPublicPlaceholderImage(match[1], symbolExpressions)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Checks that generated Terraform provisions Container Apps with a public MCR placeholder image.
+ * This verifies the container app image expression instead of any incidental MCR string in the workspace.
+ */
+export function doesTerraformContainerAppUsePublicPlaceholderImage(workspace: string): boolean {
+  const terraformFiles = readWorkspaceTextFiles(workspace, /\.tf$/i)
+    .filter(content => /azurerm_container_app\b/i.test(content));
+
+  for (const content of terraformFiles) {
+    const symbolExpressions = new Map<string, string>();
+
+    for (const match of content.matchAll(/variable\s+"([A-Za-z_]\w*)"\s*{[\s\S]*?default\s*=\s*(.+?)\s*(?:\n|})/gi)) {
+      symbolExpressions.set(match[1], match[2]);
+    }
+
+    for (const match of content.matchAll(/^\s*([A-Za-z_]\w*)\s*=\s*(.+)$/gmi)) {
+      symbolExpressions.set(match[1], match[2]);
+    }
+
+    for (const match of content.matchAll(/^\s*image\s*=\s*(.+)$/gmi)) {
+      if (expressionContainsPublicPlaceholderImage(match[1], symbolExpressions)) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Checks that generated Terraform tells Container Apps to ignore externally deployed image changes.
+ */
+export function doesTerraformContainerAppIgnoreImageChanges(workspace: string): boolean {
+  const terraformFiles = readWorkspaceTextFiles(workspace, /\.tf$/i)
+    .filter(content => /azurerm_container_app\b/i.test(content));
+
+  for (const content of terraformFiles) {
+    const containerAppBlocks = extractBlocks(content, /resource\s+"azurerm_container_app"\s+"[^"]+"\s*{/gi);
+    for (const containerAppBlock of containerAppBlocks) {
+      const lifecycleBlocks = extractBlocks(containerAppBlock, /lifecycle\s*{/gi);
+      for (const lifecycleBlock of lifecycleBlocks) {
+        const ignoreChanges = lifecycleBlock.match(/ignore_changes\s*=\s*(\[[\s\S]*?\]|[^\n]+)/i)?.[1];
+        if (ignoreChanges && /\b(image|all)\b/i.test(ignoreChanges)) {
+          return true;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
 export type SeparateFilesPatternResult =
   | { isSeparate: true }
   | {


### PR DESCRIPTION
## Description

Update IaC code pattern checks for container app deployment to ensure that two-phase deployment pattern has been implemented properly.

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

Fixes #2129, #2093, #2083, #2081
