### PR TITLE
Fix copilot sdk user permission handler

### DIFF
--- a/tests/entra-agent-id/utils.ts
+++ b/tests/entra-agent-id/utils.ts
@@ -70,7 +70,10 @@ function getScriptContent(agentMetadata: AgentMetadata): string {
     if (WRITE_TOOL_FRAGMENTS.some((fragment) => toolName.toLowerCase().includes(fragment))) {
       const filePath = extractFilePath(data.arguments);
       if (filePath && isScriptFile(filePath)) {
-        parts.push(argsString(event));
+        // @todo: Stop using any when copilot-sdk ships this fix
+        // https://github.com/github/copilot-sdk/issues/1156
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        parts.push(argsString(event as any));
       }
     }
   }

--- a/tests/entra-agent-id/utils.ts
+++ b/tests/entra-agent-id/utils.ts
@@ -70,7 +70,7 @@ function getScriptContent(agentMetadata: AgentMetadata): string {
     if (WRITE_TOOL_FRAGMENTS.some((fragment) => toolName.toLowerCase().includes(fragment))) {
       const filePath = extractFilePath(data.arguments);
       if (filePath && isScriptFile(filePath)) {
-        // @todo: Stop using any when copilot-sdk ships this fix
+        // @todo: Use the actual type when copilot-sdk ships this fix
         // https://github.com/github/copilot-sdk/issues/1156
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         parts.push(argsString(event as any));

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -11,7 +11,7 @@
         "@azure/identity": "^4.13.1",
         "@eslint/js": "^10.0.0",
         "@github/copilot": "1.0.49",
-        "@github/copilot-sdk": "^0.2.0",
+        "@github/copilot-sdk": "^0.3.0",
         "@microsoft/vally-cli": "^0.4.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.6.0",
@@ -1054,13 +1054,13 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.2.0.tgz",
-      "integrity": "sha512-fCEpD9W9xqcaCAJmatyNQ1PkET9P9liK2P4Vk0raDFoMXcvpIdqewa5JQeKtWCBUsN/HCz7ExkkFP8peQuo+DA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.3.0.tgz",
+      "integrity": "sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.10",
+        "@github/copilot": "^1.0.36-0",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -2003,21 +2003,6 @@
       },
       "bin": {
         "vally": "dist/index.js"
-      }
-    },
-    "node_modules/@microsoft/vally/node_modules/@github/copilot-sdk": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.3.0.tgz",
-      "integrity": "sha512-SUo35k56pzzgYgwmDPHcu7kZxPrzXbH66IWXaEf6pmb94DlA709F82HrrDeja087TL4djJ9OuvRFWWOKCosAsg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@github/copilot": "^1.0.36-0",
-        "vscode-jsonrpc": "^8.2.1",
-        "zod": "^4.3.6"
-      },
-      "engines": {
-        "node": ">=20.0.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -30,7 +30,7 @@
     "@azure/identity": "^4.13.1",
     "@eslint/js": "^10.0.0",
     "@github/copilot": "1.0.49",
-    "@github/copilot-sdk": "^0.2.0",
+    "@github/copilot-sdk": "^0.3.0",
     "@microsoft/vally-cli": "^0.4.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.6.0",

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -370,7 +370,10 @@ export function getAllToolText(metadata: AgentMetadata): string {
   const parts: string[] = [];
   for (const event of metadata.events) {
     if (event.type === "tool.execution_start") {
-      parts.push(argsString(event));
+      // @todo: Stop using any when copilot-sdk ships this fix
+      // https://github.com/github/copilot-sdk/issues/1156
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      parts.push(argsString(event as any));
     }
     if (event.type === "tool.execution_complete") {
       const result = event.data.result as { content?: string } | undefined;

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -370,7 +370,7 @@ export function getAllToolText(metadata: AgentMetadata): string {
   const parts: string[] = [];
   for (const event of metadata.events) {
     if (event.type === "tool.execution_start") {
-      // @todo: Stop using any when copilot-sdk ships this fix
+      // @todo: Use the actual type when copilot-sdk ships this fix
       // https://github.com/github/copilot-sdk/issues/1156
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       parts.push(argsString(event as any));

--- a/tests/utils/regression-detectors.ts
+++ b/tests/utils/regression-detectors.ts
@@ -34,7 +34,10 @@ export function countSecretsInCode(metadata: AgentMetadata): number {
     const toolName = event.data.toolName as string;
     if (!writeTools.some(t => toolName.includes(t))) continue;
 
-    const args = argsString(event);
+    // @todo: Stop using any when copilot-sdk ships this fix
+    // https://github.com/github/copilot-sdk/issues/1156
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const args = argsString(event as any);
     for (const pattern of secretPatterns) {
       // Reset lastIndex for global regexes
       pattern.lastIndex = 0;

--- a/tests/utils/regression-detectors.ts
+++ b/tests/utils/regression-detectors.ts
@@ -34,7 +34,7 @@ export function countSecretsInCode(metadata: AgentMetadata): number {
     const toolName = event.data.toolName as string;
     if (!writeTools.some(t => toolName.includes(t))) continue;
 
-    // @todo: Stop using any when copilot-sdk ships this fix
+    // @todo: Use the actual type when copilot-sdk ships this fix
     // https://github.com/github/copilot-sdk/issues/1156
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const args = argsString(event as any);


### PR DESCRIPTION
## Description

To fix the permission handler regression we see in integration tests, we also need to upgrade copilot-sdk which was missed in the previous PR:
https://github.com/microsoft/GitHub-Copilot-for-Azure/pull/2305

I have to mark several variables as any type because copilot-sdk forgot to export their types.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
