### PR TITLE
Patch a flaky quota integration test

### DIFF
--- a/tests/azure-quotas/integration.test.ts
+++ b/tests/azure-quotas/integration.test.ts
@@ -151,7 +151,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
         const isSkillUsed = isSkillInvoked(agentMetadata, SKILL_NAME);
         const mentionsExtension = doesAssistantMessageIncludeKeyword(agentMetadata, "az extension add");
-        const installsExtension = matchesCommand(agentMetadata, /az\s+extension\+add/);
+        const installsExtension = matchesCommand(agentMetadata, /az\s+extension\s+add/);
 
         expect(isSkillUsed).toBe(true);
         expect(mentionsExtension || installsExtension).toBe(true);

--- a/tests/azure-quotas/integration.test.ts
+++ b/tests/azure-quotas/integration.test.ts
@@ -16,7 +16,7 @@ import {
   shouldSkipIntegrationTests,
   getIntegrationSkipReason
 } from "../utils/agent-runner";
-import { softCheckSkill, isSkillInvoked, shouldEarlyTerminateForSkillInvocation, withTestResult } from "../utils/evaluate";
+import { softCheckSkill, isSkillInvoked, shouldEarlyTerminateForSkillInvocation, withTestResult, matchesCommand } from "../utils/evaluate";
 
 /**
  * Check if any tool call arguments contain a keyword.
@@ -151,9 +151,10 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
         const isSkillUsed = isSkillInvoked(agentMetadata, SKILL_NAME);
         const mentionsExtension = doesAssistantMessageIncludeKeyword(agentMetadata, "az extension add");
+        const installsExtension = matchesCommand(agentMetadata, /az\s+extension\+add/);
 
         expect(isSkillUsed).toBe(true);
-        expect(mentionsExtension).toBe(true);
+        expect(mentionsExtension || installsExtension).toBe(true);
       });
     });
   });


### PR DESCRIPTION
## Description

We have seen agent installing the az cli extension via the command instead of mentioning the command in the assistant message.

https://agreeable-dune-0f718070f.1.azurestaticapps.net/nightly-runs.html?file=2026-05-16%2F25961724038%2Fazure-quotas%2Fazure-quotas_-_Integration_Tests_azure-quotas_mentions_extension_installation_requirement%2Fagent-metadata-2026-05-16T13-27-00-916Z.md

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

resolves #2285
