### PR TITLE
Update skill owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,30 +8,31 @@
 /.github/workflows/ @microsoft/ghcp4a
 
 # Plugin skills owners
-/plugin/skills/airunway-aks-setup/ @tmeschter
-/plugin/skills/appinsights-instrumentation/ @JasonYeMSFT
-/plugin/skills/azure-ai/ @charris-msft
-/plugin/skills/azure-aigateway/ @azaslonov
-/plugin/skills/azure-cloud-migrate/ @saikoumudi @MadhuraBharadwaj-MSFT
-/plugin/skills/azure-compliance/ @saikoumudi
-/plugin/skills/azure-compute/ @alex-thompson @rakal-dyh @joybb @rmmue21
-/plugin/skills/azure-cost/ @saikoumudi
-/plugin/skills/azure-deploy/ @tmeschter @wbreza @kvenkatrajan @paulyuk
-/plugin/skills/azure-diagnostics/ @tmeschter @saikoumudi
-/plugin/skills/azure-enterprise-infra-planner/ @Jbrocket @micha31r @arunrab
-/plugin/skills/azure-hosted-copilot-sdk/ @tmeschter @JasonYeMSFT
-/plugin/skills/azure-kubernetes/ @saikoumudi @chandraneel @gambtho
-/plugin/skills/azure-kusto/ @saikoumudi
-/plugin/skills/azure-messaging/ @kashifkhan
-/plugin/skills/azure-prepare/ @tmeschter @wbreza @kvenkatrajan
-/plugin/skills/azure-quotas/ @rakal-dyh
-/plugin/skills/azure-rbac/ @JasonYeMSFT @msalaman
-/plugin/skills/azure-reliability/ @MadhuraBharadwaj-MSFT @saikoumudi
-/plugin/skills/azure-resource-lookup/ @charris-msft
-/plugin/skills/azure-resource-visualizer/ @tmeschter
-/plugin/skills/azure-storage/ @charris-msft
-/plugin/skills/azure-upgrade/ @MadhuraBharadwaj-MSFT @saikoumudi
-/plugin/skills/azure-validate/ @wbreza @tmeschter @kvenkatrajan
-/plugin/skills/entra-agent-id/ @ArLucaID
-/plugin/skills/entra-app-registration/ @JasonYeMSFT @kvenkatrajan
-/plugin/skills/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu
+/plugin/skills/ @RickWinter
+/plugin/skills/airunway-aks-setup/ @tmeschter @RickWinter
+/plugin/skills/appinsights-instrumentation/ @JasonYeMSFT @RickWinter
+/plugin/skills/azure-ai/ @JasonYeMSFT @RickWinter
+/plugin/skills/azure-aigateway/ @azaslonov @RickWinter
+/plugin/skills/azure-cloud-migrate/ @saikoumudi @MadhuraBharadwaj-MSFT @RickWinter
+/plugin/skills/azure-compliance/ @saikoumudi @RickWinter
+/plugin/skills/azure-compute/ @alex-thompson @rakal-dyh @joybb @rmmue21 @RickWinter
+/plugin/skills/azure-cost/ @saikoumudi @RickWinter
+/plugin/skills/azure-deploy/ @tmeschter @wbreza @kvenkatrajan @paulyuk @RickWinter
+/plugin/skills/azure-diagnostics/ @tmeschter @saikoumudi @RickWinter
+/plugin/skills/azure-enterprise-infra-planner/ @Jbrocket @micha31r @arunrab @RickWinter
+/plugin/skills/azure-hosted-copilot-sdk/ @tmeschter @JasonYeMSFT @RickWinter
+/plugin/skills/azure-kubernetes/ @saikoumudi @chandraneel @gambtho @RickWinter
+/plugin/skills/azure-kusto/ @saikoumudi @RickWinter
+/plugin/skills/azure-messaging/ @kashifkhan @RickWinter
+/plugin/skills/azure-prepare/ @tmeschter @wbreza @kvenkatrajan @RickWinter
+/plugin/skills/azure-quotas/ @rakal-dyh @RickWinter
+/plugin/skills/azure-rbac/ @JasonYeMSFT @msalaman @RickWinter
+/plugin/skills/azure-reliability/ @MadhuraBharadwaj-MSFT @saikoumudi @RickWinter
+/plugin/skills/azure-resource-lookup/ @JasonYeMSFT @RickWinter
+/plugin/skills/azure-resource-visualizer/ @tmeschter @RickWinter
+/plugin/skills/azure-storage/ @JasonYeMSFT @RickWinter
+/plugin/skills/azure-upgrade/ @MadhuraBharadwaj-MSFT @saikoumudi @RickWinter
+/plugin/skills/azure-validate/ @wbreza @tmeschter @kvenkatrajan @RickWinter
+/plugin/skills/entra-agent-id/ @ArLucaID @RickWinter
+/plugin/skills/entra-app-registration/ @JasonYeMSFT @kvenkatrajan @RickWinter
+/plugin/skills/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter


### PR DESCRIPTION
## Description

Add @RickWinter  as the owner of every skill since he will be the new lead of azure-skills plugin.
Remove Chris from skill owners.
Ensure every skill has at least two owners.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
