### PR TITLE
feature: Move quota workflow to a script

### DIFF
--- a/plugin/skills/azure-quotas/SKILL.md
+++ b/plugin/skills/azure-quotas/SKILL.md
@@ -96,35 +96,53 @@ Invoke this skill when:
 
 > **📖 Detailed mapping examples and workflow:** See [commands.md - Resource Name Mapping](./references/commands.md#resource-name-mapping)
 
+## Scripts
+
+Pre-built scripts handle quota extension installation, usage queries, and capacity calculation. Use these instead of constructing commands manually. A single call returns limits, usage, and available capacity.
+
+| Script | Purpose | Usage |
+|--------|---------|-------|
+| `scripts/check-quota.ps1` | Returns limit, usage, and available capacity for all quotas (or a single quota when resource name is provided) | Primary script for quota checks |
+| `scripts/check-quota.sh` | Same as above (bash) | Primary script for quota checks |
+
 ## Core Workflows
 
 ### Workflow 1: Check Quota for a Specific Resource
 
-**Scenario:** Verify quota limit and current usage before deployment
+**Scenario:** Verify quota limits and current usage before deployment
 
+Run the script with the resource provider and region. It returns a table of **all** quotas with their limit, current usage, and available capacity in a single call:
+
+```powershell
+.\scripts\check-quota.ps1 -ResourceProvider <provider> -Region <region>
+```
 ```bash
-# 1. Install quota extension (if not already installed)
-az extension add --name quota
-
-# 2. List all quotas for the provider to find the quota resource name
-az quota list \
-  --scope /subscriptions/<subscription-id>/providers/Microsoft.Compute/locations/eastus
-
-# 3. Show quota limit for a specific resource
-az quota show \
-  --resource-name standardDSv3Family \
-  --scope /subscriptions/<subscription-id>/providers/Microsoft.Compute/locations/eastus
-
-# 4. Show current usage
-az quota usage show \
-  --resource-name standardDSv3Family \
-  --scope /subscriptions/<subscription-id>/providers/Microsoft.Compute/locations/eastus
+./scripts/check-quota.sh <provider> <region>
 ```
 
-**Example Output Analysis:**
-- Quota limit: 350 vCPUs
-- Current usage: 50 vCPUs
-- Available capacity: 300 vCPUs (350 - 50)
+To check a single resource, add the resource name:
+
+```powershell
+.\scripts\check-quota.ps1 -ResourceProvider <provider> -Region <region> -ResourceName <resource-name>
+```
+```bash
+./scripts/check-quota.sh <provider> <region> <resource-name>
+```
+
+**Example:**
+
+```powershell
+.\scripts\check-quota.ps1 -ResourceProvider Microsoft.Compute -Region eastus
+```
+
+**Example Output:**
+
+| Resource | Region | Limit | Usage | Available |
+|----------|--------|-------|-------|-----------|
+| cores | eastus | 100 | 50 | 50 |
+| standardDSv3Family | eastus | 350 | 50 | 300 |
+| virtualMachines | eastus | 25000 | 5 | 24995 |
+| ... | ... | ... | ... | ... |
 
 > **📖 See also:** [az quota show](./references/commands.md#az-quota-show), [az quota usage show](./references/commands.md#az-quota-usage-show)
 

--- a/plugin/skills/azure-quotas/scripts/check-quota.ps1
+++ b/plugin/skills/azure-quotas/scripts/check-quota.ps1
@@ -1,0 +1,95 @@
+<#
+.SYNOPSIS
+    Checks Azure quota limits and current usage for a resource provider.
+.DESCRIPTION
+    Installs the quota CLI extension if needed, then queries quota limits and
+    current usage in a single call. Returns a table with limit, usage, and
+    available capacity for every quota (or a single quota when ResourceName is provided).
+.PARAMETER ResourceProvider
+    Azure resource provider namespace (e.g., "Microsoft.Compute", "Microsoft.Network").
+.PARAMETER Region
+    Azure region to check (e.g., "eastus", "westus2").
+.PARAMETER ResourceName
+    Quota resource name (e.g., "standardDSv3Family"). If omitted, returns all quotas.
+.PARAMETER SubscriptionId
+    Azure subscription ID. Defaults to the current subscription.
+.EXAMPLE
+    .\check-quota.ps1 -ResourceProvider Microsoft.Compute -Region eastus
+    # Shows limit, usage, and available capacity for ALL compute quotas in eastus
+.EXAMPLE
+    .\check-quota.ps1 -ResourceProvider Microsoft.Compute -Region eastus -ResourceName standardDSv3Family
+    # Shows limit, usage, and available capacity for the DSv3 VM family only
+#>
+param(
+    [Parameter(Mandatory)][string]$ResourceProvider,
+    [Parameter(Mandatory)][string]$Region,
+    [string]$ResourceName,
+    [string]$SubscriptionId
+)
+
+$ErrorActionPreference = "Stop"
+
+# Ensure the quota extension is installed
+$ext = az extension list --query "[?name=='quota'].name" -o tsv 2>$null
+if (-not $ext) {
+    Write-Host "Installing quota extension..."
+    az extension add --name quota --yes 2>$null
+}
+
+# Resolve subscription
+if (-not $SubscriptionId) {
+    $SubscriptionId = az account show --query id -o tsv
+}
+
+$scope = "/subscriptions/$SubscriptionId/providers/$ResourceProvider/locations/$Region"
+
+Write-Host "Checking quotas in scope $scope"
+
+if ($ResourceName) {
+    # Single-resource mode
+    Write-Host "Quota for '$ResourceName' ($ResourceProvider, $Region):"
+    Write-Host ""
+
+    $limit = az quota show --resource-name $ResourceName --scope $scope -o json 2>$null | ConvertFrom-Json
+    $usage = az quota usage show --resource-name $ResourceName --scope $scope -o json 2>$null | ConvertFrom-Json
+
+    $limitValue = $limit.properties.limit.value
+    $usageValue = $usage.properties.usages.value
+    $available = $limitValue - $usageValue
+
+    [PSCustomObject]@{
+        Resource  = $ResourceName
+        Region    = $Region
+        Limit     = $limitValue
+        Usage     = $usageValue
+        Available = $available
+    } | Format-Table -AutoSize
+} else {
+    # All-quotas mode: fetch limits and usage, join by name
+    Write-Host "Quotas for $ResourceProvider in ${Region}:"
+    Write-Host ""
+
+    $quotas = az quota list --scope $scope -o json 2>$null | ConvertFrom-Json
+    $usages = az quota usage list --scope $scope -o json 2>$null | ConvertFrom-Json
+
+    $usageLookup = @{}
+    foreach ($u in $usages) {
+        $usageLookup[$u.name] = $u.properties.usages.value
+    }
+
+    $results = foreach ($q in $quotas) {
+        $name = $q.name
+        $limitValue = $q.properties.limit.value
+        $usageValue = if ($usageLookup.ContainsKey($name)) { $usageLookup[$name] } else { 0 }
+        $available = $limitValue - $usageValue
+        [PSCustomObject]@{
+            Resource  = $name
+            Region    = $Region
+            Limit     = $limitValue
+            Usage     = $usageValue
+            Available = $available
+        }
+    }
+
+    $results | Format-Table -AutoSize
+}

--- a/plugin/skills/azure-quotas/scripts/check-quota.sh
+++ b/plugin/skills/azure-quotas/scripts/check-quota.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# check-quota.sh
+# Checks Azure quota limits and current usage for a resource provider.
+# Returns a table with limit, usage, and available capacity for every quota
+# (or a single quota when resource-name is provided).
+#
+# Usage:
+#   ./check-quota.sh <resource-provider> <region> [resource-name] [subscription-id]
+#
+# Examples:
+#   ./check-quota.sh Microsoft.Compute eastus                          # All compute quotas with usage
+#   ./check-quota.sh Microsoft.Compute eastus standardDSv3Family       # Single quota with usage
+
+set -euo pipefail
+
+RESOURCE_PROVIDER="${1:?Usage: $0 <resource-provider> <region> [resource-name] [subscription-id]}"
+REGION="${2:?Usage: $0 <resource-provider> <region> [resource-name] [subscription-id]}"
+RESOURCE_NAME="${3:-}"
+SUBSCRIPTION_ID="${4:-}"
+
+# Ensure the quota extension is installed
+if ! az extension list --query "[?name=='quota'].name" -o tsv 2>/dev/null | grep -q quota; then
+    echo "Installing quota extension..."
+    az extension add --name quota --yes 2>/dev/null
+fi
+
+# Resolve subscription
+if [ -z "$SUBSCRIPTION_ID" ]; then
+    SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+fi
+
+SCOPE="/subscriptions/$SUBSCRIPTION_ID/providers/$RESOURCE_PROVIDER/locations/$REGION"
+
+echo "Checking quotas in scope $SCOPE"
+
+if [ -n "$RESOURCE_NAME" ]; then
+    # Single-resource mode
+    echo "Quota for '$RESOURCE_NAME' ($RESOURCE_PROVIDER, $REGION):"
+    echo ""
+
+    LIMIT=$(az quota show \
+        --resource-name "$RESOURCE_NAME" \
+        --scope "$SCOPE" \
+        --query "properties.limit.value" -o tsv)
+
+    USAGE=$(az quota usage show \
+        --resource-name "$RESOURCE_NAME" \
+        --scope "$SCOPE" \
+        --query "properties.usages.value" -o tsv)
+
+    AVAILABLE=$((LIMIT - USAGE))
+
+    printf "%-30s %-10s %-10s %-10s %-10s\n" "Resource" "Region" "Limit" "Usage" "Available"
+    printf "%-30s %-10s %-10s %-10s %-10s\n" "--------" "------" "-----" "-----" "---------"
+    printf "%-30s %-10s %-10s %-10s %-10s\n" "$RESOURCE_NAME" "$REGION" "$LIMIT" "$USAGE" "$AVAILABLE"
+else
+    # All-quotas mode: fetch limits and usage, join by name
+    echo "Quotas for $RESOURCE_PROVIDER in $REGION:"
+    echo ""
+
+    QUOTAS_JSON=$(az quota list --scope "$SCOPE" -o json 2>/dev/null)
+    USAGES_JSON=$(az quota usage list --scope "$SCOPE" -o json 2>/dev/null)
+
+    printf "%-40s %-10s %-10s %-10s %-10s\n" "Resource" "Region" "Limit" "Usage" "Available"
+    printf "%-40s %-10s %-10s %-10s %-10s\n" "--------" "------" "-----" "-----" "---------"
+
+    echo "$QUOTAS_JSON" | python3 -c "
+import json, sys
+
+quotas = json.load(sys.stdin)
+usages = json.loads('''$USAGES_JSON''')
+
+usage_lookup = {}
+for u in usages:
+    usage_lookup[u['name']] = u.get('properties', {}).get('usages', {}).get('value', 0)
+
+for q in quotas:
+    name = q['name']
+    limit = q.get('properties', {}).get('limit', {}).get('value', 0)
+    used = usage_lookup.get(name, 0)
+    avail = limit - used
+    print(f'{name:<40} $REGION{\"\":<4} {limit:<10} {used:<10} {avail:<10}')
+"
+fi

--- a/tests/azure-quotas/integration.test.ts
+++ b/tests/azure-quotas/integration.test.ts
@@ -101,15 +101,12 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         });
 
         const isSkillUsed = isSkillInvoked(agentMetadata, SKILL_NAME);
-        // Agent may suggest CLI commands in the response or execute them via powershell tool
-        const mentionsQuotaCmd = doesAssistantMessageIncludeKeyword(agentMetadata, "az quota")
-          || doToolCallArgsIncludeKeyword(agentMetadata, "az quota");
-        const mentionsScope = doesAssistantMessageIncludeKeyword(agentMetadata, "/subscriptions/")
-          || doToolCallArgsIncludeKeyword(agentMetadata, "/subscriptions/");
+        // Agent should invoke the check-quota script rather than raw az quota commands
+        const invokesScript = doToolCallArgsIncludeKeyword(agentMetadata, "check-quota.ps1")
+          || doToolCallArgsIncludeKeyword(agentMetadata, "check-quota.sh");
 
         expect(isSkillUsed).toBe(true);
-        expect(mentionsQuotaCmd).toBe(true);
-        expect(mentionsScope).toBe(true);
+        expect(invokesScript).toBe(true);
       });
     });
 


### PR DESCRIPTION
One of the workflows supported by the azure-quotas skill is to verify quota limits and current usage. This workflow has definite, limited inputs and is very regular, with the LM instructed to execute a series of four `az` commands one after the other. In the end, the relevant output is a series of resource names with the current usage and limit for each.

The LM can generally follow this workflow but there are some downsides with this approach. First, each `az` command will produce an "intermediate" output on the way to the final output. We don't really care about these intermediate outputs but they take up space in the token context window.

Second, if one of those intermediate outputs is large (greater than 20KB or so) Copilot won't provide it directly to the LM but will instead put it in a temporary file, and tell the LM to read the file. This requires additional tool invocations and opportunities for things to go wrong.

Third, despite the clarity of the instructions the LM will not always be consistent in which steps it follows, or exactly how it follows them. Related to this, sometimes it will make a mistake and may or may not recover.

To address these issues, this change is an attempt to change this one specific workflow to be implemented as a script. The LM no longer executes individual `az` commands; instead, it runs the script with the necessary inputs. This should be more consistent, faster, and use fewer tokens.

If this change is successful we will move more of these well-defined workflows over to scripts.

## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [X] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills


