### PR TITLE
Fix terraform ignore_changes parsing

### DIFF
--- a/tests/utils/__tests__/evaluate.test.ts
+++ b/tests/utils/__tests__/evaluate.test.ts
@@ -249,6 +249,6 @@ describe("extractTerraformListAssignment", () => {
   ignore_changes = [ image ]
 }`;
 
-    expect(extractTerraformListAssignment(lifecycleBlock, "ignore_changes")).toBe(`[ image ]`);
+    expect(extractTerraformListAssignment(lifecycleBlock, "ignore_changes")).toBe("[ image ]");
   });
 });

--- a/tests/utils/__tests__/evaluate.test.ts
+++ b/tests/utils/__tests__/evaluate.test.ts
@@ -251,4 +251,18 @@ describe("extractTerraformListAssignment", () => {
 
     expect(extractTerraformListAssignment(lifecycleBlock, "ignore_changes")).toBe("[ image ]");
   });
+  test("returns the non list value", () => {
+    const lifecycleBlock = `lifecycle {
+  ignore_changes = all
+}`;
+
+    expect(extractTerraformListAssignment(lifecycleBlock, "ignore_changes")).toBe("all");
+  });
+  test("returns undefined", () => {
+    const lifecycleBlock = `lifecycle {
+  unmatched_key = all
+}`;
+
+    expect(extractTerraformListAssignment(lifecycleBlock, "ignore_changes")).toBe(undefined);
+  });
 });

--- a/tests/utils/__tests__/evaluate.test.ts
+++ b/tests/utils/__tests__/evaluate.test.ts
@@ -1,10 +1,8 @@
 /**
- * Tests for evaluate utility — specifically the stripNonExecutableContent function
- * which filters out heredoc bodies, comments, and other non-command content
- * before shell command pattern matching.
+ * Tests for evaluate utility helpers used by integration assertions.
  */
 
-import { stripNonExecutableContent } from "../evaluate";
+import { extractTerraformListAssignment, stripNonExecutableContent } from "../evaluate";
 
 describe("stripNonExecutableContent", () => {
   test("passes through simple commands unchanged", () => {
@@ -229,5 +227,28 @@ azd provision`;
     expect(result).not.toContain("azd up");
     expect(result).not.toContain("azd deploy");
     expect(result).toContain("azd provision");
+  });
+});
+
+describe("extractTerraformListAssignment", () => {
+  test("returns the full top-level ignore_changes list when entries contain index syntax", () => {
+    const lifecycleBlock = `lifecycle {
+  ignore_changes = [
+    template[0].container[0].image,
+    registry,
+  ]
+}`;
+
+    expect(extractTerraformListAssignment(lifecycleBlock, "ignore_changes")).toBe(`[
+    template[0].container[0].image,
+    registry,
+  ]`);
+  });
+  test("returns the simple ignore_changes list", () => {
+    const lifecycleBlock = `lifecycle {
+  ignore_changes = [ image ]
+}`;
+
+    expect(extractTerraformListAssignment(lifecycleBlock, "ignore_changes")).toBe(`[ image ]`);
   });
 });

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -180,7 +180,8 @@ function extractBlocks(content: string, blockStartPattern: RegExp): string[] {
 }
 
 export function extractTerraformListAssignment(block: string, attributeName: string): string | undefined {
-  const assignmentMatch = block.match(new RegExp(`${attributeName}\\s*=\\s*`, "i"));
+  const escapedAttributeName = attributeName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const assignmentMatch = block.match(new RegExp(`(^|\\n)\\s*${escapedAttributeName}\\s*=\\s*`, "i"));
   if (!assignmentMatch || assignmentMatch.index === undefined) {
     return undefined;
   }

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -179,6 +179,33 @@ function extractBlocks(content: string, blockStartPattern: RegExp): string[] {
   return blocks;
 }
 
+export function extractTerraformListAssignment(block: string, attributeName: string): string | undefined {
+  const assignmentMatch = block.match(new RegExp(`${attributeName}\\s*=\\s*`, "i"));
+  if (!assignmentMatch || assignmentMatch.index === undefined) {
+    return undefined;
+  }
+  const valueStart = assignmentMatch.index + assignmentMatch[0].length;
+  const valueText = block.slice(valueStart).trimStart();
+
+  if (!valueText.startsWith("[")) {
+    return valueText.match(/^[^\n]+/)?.[0]?.trim();
+  }
+
+  let depth = 0;
+  for (let index = 0; index < valueText.length; index++) {
+    if (valueText[index] === "[") {
+      depth += 1;
+    } else if (valueText[index] === "]") {
+      depth -= 1;
+      if (depth === 0) {
+        return valueText.slice(0, index + 1);
+      }
+    }
+  }
+
+  return undefined;
+}
+
 /**
  * Checks that generated Bicep provisions Container Apps with a public MCR placeholder image.
  * This verifies the deployment behavior instead of a specific parameter name/default spelling.
@@ -259,7 +286,7 @@ export function doesTerraformContainerAppIgnoreImageChanges(workspace: string): 
     for (const containerAppBlock of containerAppBlocks) {
       const lifecycleBlocks = extractBlocks(containerAppBlock, /lifecycle\s*{/gi);
       for (const lifecycleBlock of lifecycleBlocks) {
-        const ignoreChanges = lifecycleBlock.match(/ignore_changes\s*=\s*(\[[\s\S]*?\]|[^\n]+)/i)?.[1];
+        const ignoreChanges = extractTerraformListAssignment(lifecycleBlock, "ignore_changes");
         if (ignoreChanges && /\b(image|all)\b/i.test(ignoreChanges)) {
           return true;
         }

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -179,6 +179,13 @@ function extractBlocks(content: string, blockStartPattern: RegExp): string[] {
   return blocks;
 }
 
+/**
+ * Extract the body of a terraform list assignment.
+ * @param block A text block that contains one list assignment.
+ * @param attributeName The attribute name of the list.
+ * @returns the body of the list, or the original text in the assignment if it's not a list.
+ * @example "ignore_changes = [ value[0], value[1] ]" => "[ value[0], value[2] ]"
+ */
 export function extractTerraformListAssignment(block: string, attributeName: string): string | undefined {
   const escapedAttributeName = attributeName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const assignmentMatch = block.match(new RegExp(`(^|\\n)\\s*${escapedAttributeName}\\s*=\\s*`, "i"));


### PR DESCRIPTION
## Description

Resolves the failure pattern found in https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/2347 and linked issues.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
