### PR TITLE
Use skill.invoked event to detect skill invocation

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -425,22 +425,21 @@ function generateMarkdownReport(config: AgentRunConfig, agentMetadata: AgentMeta
         break;
       }
 
+      case "skill.invoked": {
+        const skillName = event.data.name;
+        lines.push("```");
+        lines.push(`skill: ${skillName}`);
+        lines.push("```");
+        break;
+      }
+
       case "tool.execution_start": {
         const toolName = event.data.toolName as string;
         const toolCallId = event.data.toolCallId as string;
         const args = event.data.arguments;
 
-        // Check if this is a skill invocation
-        if (toolName === "skill") {
-          const argsStr = JSON.stringify(args);
-          // Extract skill name from arguments
-          const skillMatch = argsStr.match(/"skill"\s*:\s*"([^"]+)"/);
-          const skillName = skillMatch ? skillMatch[1] : "unknown";
-          lines.push("```");
-          lines.push(`skill: ${skillName}`);
-          lines.push("```");
-        } else {
-          // Regular tool call
+        // Exclude skill invocation call and log it on skill.invoked event.
+        if (toolName !== "skill") {
           let argsJson: string;
           try {
             argsJson = JSON.stringify(args, null, 2);

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -414,12 +414,8 @@ export function expectFiles(
  */
 export function isSkillInvoked(metadata: AgentMetadata, skillName: string): boolean {
   return metadata.events
-    .filter(event => event.type === "tool.execution_start")
-    .filter(event => event.data.toolName === "skill")
-    .some(event => {
-      const args = event.data.arguments;
-      return JSON.stringify(args).includes(skillName);
-    });
+    .filter(event => event.type === "skill.invoked")
+    .some(event => event.data.name === skillName);
 }
 
 /**


### PR DESCRIPTION
## Description

Using the dedicated event is more intuitive and requires less code.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
