### PR TITLE
Remove unwanted grader

### DIFF
--- a/evals/azure-aigateway/eval.yaml
+++ b/evals/azure-aigateway/eval.yaml
@@ -46,8 +46,6 @@ stimuli:
         config:
           required:
             - azure-aigateway
-      # Global: has_output
-      - type: completed
       # Global: no_runtime_failure
       - type: output-not-matches
         config:


### PR DESCRIPTION
## Description

This grader is generates false positive failure.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
