### PR TITLE
feat: replace PAT secrets with GitHub App tokens for cross-repo sync

### DIFF
--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -35,9 +35,19 @@ jobs:
           npm ci --ignore-scripts
           npm run build
 
+      # Generate a short-lived token from the GitHub App for microsoft/skills
+      - name: Generate token for microsoft/skills
+        id: skills-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
+          private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}
+          owner: microsoft
+          repositories: skills
+
       - name: Clone microsoft/skills and create feature branch
         env:
-          GH_TOKEN: ${{ secrets.SKILLS_REPO_PAT }} # A PAT that has content: write and pull-request: write permissions to the microsoft/skills repo
+          GH_TOKEN: ${{ steps.skills-token.outputs.token }}
         run: |
           gh repo clone microsoft/skills target-repo -- --branch main --single-branch
 
@@ -66,7 +76,7 @@ jobs:
         id: commit
         working-directory: target-repo
         env:
-          GH_TOKEN: ${{ secrets.SKILLS_REPO_PAT }} # A PAT that has content: write and pull-request: write permissions to the microsoft/skills repo
+          GH_TOKEN: ${{ steps.skills-token.outputs.token }}
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"
@@ -85,7 +95,7 @@ jobs:
       - name: Create Pull Request
         if: steps.commit.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.SKILLS_REPO_PAT }} # A PAT that has content: write and pull-request: write permissions to the microsoft/skills repo
+          GH_TOKEN: ${{ steps.skills-token.outputs.token }}
         run: |
           cd target-repo
           gh pr create \
@@ -121,9 +131,19 @@ jobs:
           npm ci --ignore-scripts
           npm run build
 
+      # Generate a short-lived token from the GitHub App for microsoft/azure-skills
+      - name: Generate token for microsoft/azure-skills
+        id: azure-skills-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
+          private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}
+          owner: microsoft
+          repositories: azure-skills
+
       - name: Clone microsoft/azure-skills and create feature branch
         env:
-          GH_TOKEN: ${{ secrets.AZURE_SKILLS_REPO_PAT }} # A PAT that has content: write and pull-request: write permissions to the microsoft/azure-skills repo
+          GH_TOKEN: ${{ steps.azure-skills-token.outputs.token }}
         run: |
           gh repo clone microsoft/azure-skills target-repo -- --branch main --single-branch
 
@@ -183,7 +203,7 @@ jobs:
         id: commit
         working-directory: target-repo
         env:
-          GH_TOKEN: ${{ secrets.AZURE_SKILLS_REPO_PAT }} # A PAT that has content: write and pull-request: write permissions to the microsoft/azure-skills repo
+          GH_TOKEN: ${{ steps.azure-skills-token.outputs.token }}
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"
@@ -202,7 +222,7 @@ jobs:
       - name: Create Pull Request
         if: steps.commit.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.AZURE_SKILLS_REPO_PAT }} # A PAT that has content: write and pull-request: write permissions to the microsoft/azure-skills repo
+          GH_TOKEN: ${{ steps.azure-skills-token.outputs.token }}
         run: |
           cd target-repo
           gh pr create \

--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -38,7 +38,7 @@ jobs:
       # Generate a short-lived token from the GitHub App for microsoft/skills
       - name: Generate token for microsoft/skills
         id: skills-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
           private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}
@@ -134,7 +134,7 @@ jobs:
       # Generate a short-lived token from the GitHub App for microsoft/azure-skills
       - name: Generate token for microsoft/azure-skills
         id: azure-skills-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
           private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}

--- a/.github/workflows/sync-to-azure-mcp.yml
+++ b/.github/workflows/sync-to-azure-mcp.yml
@@ -40,10 +40,19 @@ jobs:
         working-directory: source-repo/scripts
         run: npm run generateMcpAllowlists -- ../plugin/skills ${{ github.workspace }}
 
-      # 3. Clone microsoft/mcp and create feature branch
+      # 3. Generate a short-lived token from the GitHub App for microsoft/mcp
+      - name: Generate token for microsoft/mcp
+        id: mcp-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
+          private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}
+          owner: microsoft
+          repositories: mcp
+
       - name: Clone microsoft/mcp and create feature branch
         env:
-          GH_TOKEN: ${{ secrets.MCP_REPO_PAT }} # A PAT with content: write and pull-requests: write permissions to the microsoft/mcp repo
+          GH_TOKEN: ${{ steps.mcp-token.outputs.token }}
         run: |
           gh repo clone microsoft/mcp mcp-repo -- --branch main --single-branch
 
@@ -64,7 +73,7 @@ jobs:
         id: commit
         working-directory: mcp-repo
         env:
-          GH_TOKEN: ${{ secrets.MCP_REPO_PAT }} # A PAT with content: write and pull-requests: write permissions to the microsoft/mcp repo
+          GH_TOKEN: ${{ steps.mcp-token.outputs.token }}
         run: |
           gh auth setup-git
           git config user.name "github-actions[bot]"
@@ -86,7 +95,7 @@ jobs:
       - name: Create or update Pull Request
         if: steps.commit.outputs.has_changes == 'true'
         env:
-          GH_TOKEN: ${{ secrets.MCP_REPO_PAT }} # A PAT with content: write and pull-requests: write permissions to the microsoft/mcp repo
+          GH_TOKEN: ${{ steps.mcp-token.outputs.token }}
         run: |
           cd mcp-repo
           PR_TITLE="Sync skill references from GitHub-Copilot-for-Azure"

--- a/.github/workflows/sync-to-azure-mcp.yml
+++ b/.github/workflows/sync-to-azure-mcp.yml
@@ -43,7 +43,7 @@ jobs:
       # 3. Generate a short-lived token from the GitHub App for microsoft/mcp
       - name: Generate token for microsoft/mcp
         id: mcp-token
-        uses: actions/create-github-app-token@c98839d38bc9b0e26b2731d5df0dd42c64dc6cf8 # v2.0.0
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
           app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
           private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}

--- a/.github/workflows/sync-to-azure-mcp.yml
+++ b/.github/workflows/sync-to-azure-mcp.yml
@@ -43,7 +43,7 @@ jobs:
       # 3. Generate a short-lived token from the GitHub App for microsoft/mcp
       - name: Generate token for microsoft/mcp
         id: mcp-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@c98839d38bc9b0e26b2731d5df0dd42c64dc6cf8 # v2.0.0
         with:
           app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
           private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
 Migrate publish-to-marketplace and sync-to-azure-mcp workflows from manually-rotated PATs to actions/create-github-app-token@v2, generating short-lived (1-hour) installation tokens at runtime.
 
STEPS COMPLETED:
- In the workflow, pinned actions/create-github-app-token to SHA (v2.2.2) for supply chain hardening - https://github.com/actions/create-github-app-token/compare/v2.2.1...v2.2.2
- Created Github App -https://github.com/apps/ghcp4a-bot
- PR merged and the apps should now be installed - https://github.com/microsoft/github-operations/pull/1437
- validated app has been installed in azure-skills repo. I am sure it's installed at other places as well after checking the respective team member who approved & merged my PR.
- Added secrets in repo - GHCP4A_BOT_APP_ID and GHCP4A_BOT_PRIVATE_KEY


FOLLOW-UP/ UPCOMING WORK: 
- move app owned by me to Microsoft managed apps as a follow-up task
 