### PR TITLE
fix: reduce OIDC token refresh interval from 300s to 240s

### DIFF
--- a/.github/workflows/deploy-dashboard.yml
+++ b/.github/workflows/deploy-dashboard.yml
@@ -67,7 +67,9 @@ jobs:
       # If a deployment takes long enough and the token expires, requests will fail with authentication errors.
       # This step runs code to refresh the cached OIDC access token periodically to ensure the deployment always have a valid access token.
       # Learn more at https://github.com/Azure/login/issues/372
-      - name: Fetch OIDC token every 300 seconds
+      # Refresh interval is sub-5-minutes because the OIDC token's lifetime is
+      # 5 minutes. Using 240s avoids seeing invalid tokens due to clock skew.
+      - name: Fetch OIDC token every 240 seconds
         shell: bash
         env:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
@@ -76,7 +78,7 @@ jobs:
           while true; do
             token=$(curl -s -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange" | jq .value -r)
             az login --service-principal -u $AZURE_CLIENT_ID -t $AZURE_TENANT_ID --federated-token $token --output none
-            sleep 300
+            sleep 240
           done &
 
       - name: Install azd

--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -221,7 +221,9 @@ jobs:
       # If a test starts after the token expires, it will fail with authentication errors.
       # This step runs code to refresh the cached OIDC access token periodically to ensure all tests have a valid access token.
       # Learn more at https://github.com/Azure/login/issues/372
-      - name: Fetch OIDC token every 300 seconds
+      # Refresh interval is sub-5-minutes because the OIDC token's lifetime is
+      # 5 minutes. Using 240s avoids seeing invalid tokens due to clock skew.
+      - name: Fetch OIDC token every 240 seconds
         shell: bash
         env:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
@@ -230,7 +232,7 @@ jobs:
           while true; do
             token=$(curl -s -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange" | jq .value -r)
             az login --service-principal -u $AZURE_CLIENT_ID -t $AZURE_TENANT_ID --federated-token $token --output none
-            sleep 300
+            sleep 240
           done &
 
       - name: Setup Node.js

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -126,7 +126,9 @@ jobs:
       # If a test starts after the token expires, it will fail with authentication errors.
       # This step runs code to refresh the cached OIDC access token periodically to ensure all tests have a valid access token.
       # Learn more at https://github.com/Azure/login/issues/372
-      - name: Fetch OIDC token every 300 seconds
+      # Refresh interval is sub-5-minutes because the OIDC token's lifetime is
+      # 5 minutes. Using 240s avoids seeing invalid tokens due to clock skew.
+      - name: Fetch OIDC token every 240 seconds
         shell: bash
         env:
           AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
@@ -135,7 +137,7 @@ jobs:
           while true; do
             token=$(curl -s -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange" | jq .value -r)
             az login --service-principal -u $AZURE_CLIENT_ID -t $AZURE_TENANT_ID --federated-token $token --output none
-            sleep 300
+            sleep 240
           done &
 
       - name: Setup Node.js


### PR DESCRIPTION
## Description

Reduce the OIDC token refresh interval from 300 seconds to 240 seconds in all workflow files that use the background token refresh loop.

The OIDC token lifetime is 5 minutes. Refreshing at exactly 300s risks using expired tokens due to clock skew. Using 240s provides a safe margin to ensure tokens are always valid.

### Files changed
- `.github/workflows/test-azure-deploy.yml`
- `.github/workflows/test-all-integration.yml`
- `.github/workflows/deploy-dashboard.yml`

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->