### PR TITLE
feat: add migrated vally eval suites to CI nightly run

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       # Skills that should be tested using vally in a JSON array
-      VALLY_SKILLS: '["azure-ai","azure-aigateway","azure-compliance","azure-diagnostics","azure-kusto","azure-storage","entra-app-registration"]'
+      VALLY_SKILLS: '["azure-ai","azure-aigateway","azure-compliance","azure-diagnostics","azure-kusto","azure-storage","entra-app-registration","azure-messaging","airunway-aks-setup","azure-rbac"]'
       AZURE_CLIENT_ID: ${{ vars.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ vars.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ vars.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Description

Add `azure-messaging`, `airunway-aks-setup`, and `azure-rbac` to the `VALLY_SKILLS` list in the nightly integration test workflow so their newly migrated vally eval suites run in CI.

### Files changed
- `.github/workflows/test-all-integration.yml` — added 3 skills to `VALLY_SKILLS` array

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->