### PR TITLE
bump actions/create-github-app-token to latest

### DIFF
--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -38,7 +38,7 @@ jobs:
       # Generate a short-lived token from the GitHub App for microsoft/skills
       - name: Generate token for microsoft/skills
         id: skills-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
           private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}
@@ -134,7 +134,7 @@ jobs:
       # Generate a short-lived token from the GitHub App for microsoft/azure-skills
       - name: Generate token for microsoft/azure-skills
         id: azure-skills-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
           private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}

--- a/.github/workflows/sync-to-azure-mcp.yml
+++ b/.github/workflows/sync-to-azure-mcp.yml
@@ -43,7 +43,7 @@ jobs:
       # 3. Generate a short-lived token from the GitHub App for microsoft/mcp
       - name: Generate token for microsoft/mcp
         id: mcp-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.GHCP4A_BOT_APP_ID }}
           private-key: ${{ secrets.GHCP4A_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
Good to pin to latest SHA version under v3.2.0 instead of v2.2.2.

Github App is working as expected - https://github.com/microsoft/GitHub-Copilot-for-Azure/actions/runs/26605617571. the node.js warning should be fixed by pointing to latest SHA version.

Submitted this request - https://github.com/microsoft/github-operations/issues/1438 and initiated app transfer request from my account to microsoft org - https://docs.github.com/en/apps/maintaining-github-apps/transferring-ownership-of-a-github-app#transferring-a-github-app-registration