### PR TITLE
Fix: hard gate deployment phase for infra-planner skill

### DIFF
--- a/plugin/skills/azure-enterprise-infra-planner/references/phases/7-deploy.md
+++ b/plugin/skills/azure-enterprise-infra-planner/references/phases/7-deploy.md
@@ -1,6 +1,12 @@
 # Phase 7: Deployment
 
-> Important: Before continuing this phase, `meta.status` must be set to `approved` as required by Phase 5. Destructive actions require explicit user confirmation.
+## Destructive Action Gate
+
+This phase is destructive and has irreversible effects. Explicitly confirm with the user whether to deploy, and mention the risks of altering live environments. Never accept implicit or vague intent; only continue if they confirm "I understand the risks, continue with deployment" verbatim in a reply sent *after* you present the risks — the original task prompt never satisfies this gate, even if it says "deploy" or "run all phases". Stop if no input is received. Do not accept vague statements such as: "continue", "yes", "deploy now" (without risk acceptance), "go ahead".
+
+---
+
+> Important: Before continuing this phase, `meta.status` must be set to `approved` as required by Phase 5. Each destructive action requires explicit user confirmation.
 
 Refer to [deployment.md](../deployment.md) for executing deployment commands.
 

--- a/plugin/skills/azure-enterprise-infra-planner/references/phases/7-deploy.md
+++ b/plugin/skills/azure-enterprise-infra-planner/references/phases/7-deploy.md
@@ -2,7 +2,7 @@
 
 ## Destructive Action Gate
 
-This phase is destructive and has irreversible effects. Explicitly confirm with the user whether to deploy, and mention the risks of altering live environments. Never accept implicit or vague intent; only continue if they confirm "I understand the risks, continue with deployment" verbatim in a reply sent *after* you present the risks — the original task prompt never satisfies this gate, even if it says "deploy" or "run all phases". Stop if no input is received. Do not accept vague statements such as: "continue", "yes", "deploy now" (without risk acceptance), "go ahead".
+This phase is destructive and has irreversible effects. Explicitly confirm with the user whether to deploy, and mention the risks of altering live environments. Never accept implicit or vague intent; only continue if the user acknowledges the risks and instructs you to proceed (e.g. "I understand the risks, continue with deployment") in a reply sent *after* you have presented the risks. The original task prompt never satisfies this gate, even if it says "deploy" or "run all phases". Stop if no such reply is received. Do not accept vague statements such as "continue", "yes", "deploy now" (without risk acknowledgement), or "go ahead".
 
 ---
 

--- a/tests/azure-enterprise-infra-planner/integration.test.ts
+++ b/tests/azure-enterprise-infra-planner/integration.test.ts
@@ -209,6 +209,14 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
         // Verify plan file was created
         expect(testWorkspacePath).toBeDefined();
+
+        // Verify that no Bicep or Terraform was generated
+        const allFiles = listFilesRecursive(testWorkspacePath!);
+        const bicepFiles = allFiles.filter(f => f.endsWith(".bicep"));
+        const terraformFiles = allFiles.filter(f => f.endsWith(".tf") || f.endsWith(".tfvars"));
+        expect(bicepFiles).toEqual([]);
+        expect(terraformFiles).toEqual([]);
+
         const planPath = path.join(testWorkspacePath!, ".azure", "infrastructure-plan.json");
         expect(fs.existsSync(planPath)).toBe(true);
 


### PR DESCRIPTION
## Description

This PR strengthens the gate conditions for the deployment phase (phase 7) of the infra-planner skill, requiring explicit user confirmation including acknowledgement of risks to continue. If no inputs are provided, the phase will not be executed. 

This fix mostly targets autopilot/integration tests scenarios where user input is not available and/or lower reasoning models are used.

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

Fixes [Issue 2425](https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/2425)
