### PR TITLE
docs: rename AI Toolkit to Foundry Toolkit for VSCode in microsoft-foundry skill

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
@@ -78,7 +78,7 @@ Use [Foundry Toolkit for VS Code (Formerly AI Toolkit)](https://marketplace.visu
 2. Install `agent-dev-cli` (pre-release) for the `agentdev` command
 3. Key debug tasks: `agentdev run <entrypoint>.py --port 8087` starts the agent HTTP server, `debugpy --listen 127.0.0.1:5679` attaches the debugger, and the `ai-mlstudio.openTestTool` VS Code command opens the Agent Inspector UI
 
-For VS Code `launch.json` and `tasks.json` configuration templates, see [Foundry Toolkit for VS Code (Formerly AI Toolkit) Agent Inspector — Configure debugging manually](https://github.com/microsoft/vscode-ai-toolkit/blob/main/doc/agent-test-tool.md#configure-debugging-manually).
+For VS Code `launch.json` and `tasks.json` configuration templates, see [Foundry Toolkit Agent Inspector — Configure debugging manually](https://github.com/microsoft/vscode-ai-toolkit/blob/main/doc/agent-test-tool.md#configure-debugging-manually).
 
 ## Common Errors
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
@@ -72,13 +72,13 @@ For workflow samples and advanced patterns, search the [Agent Framework GitHub r
 
 ## Debugging
 
-Use [AI Toolkit for VS Code](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) with the `agentdev` CLI tool for interactive debugging:
+Use [Foundry Toolkit for VSCode (Formerly AI Toolkit)](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) with the `agentdev` CLI tool for interactive debugging:
 
 1. Install `debugpy` for VS Code Python Debugger support
 2. Install `agent-dev-cli` (pre-release) for the `agentdev` command
 3. Key debug tasks: `agentdev run <entrypoint>.py --port 8087` starts the agent HTTP server, `debugpy --listen 127.0.0.1:5679` attaches the debugger, and the `ai-mlstudio.openTestTool` VS Code command opens the Agent Inspector UI
 
-For VS Code `launch.json` and `tasks.json` configuration templates, see [AI Toolkit Agent Inspector — Configure debugging manually](https://github.com/microsoft/vscode-ai-toolkit/blob/main/doc/agent-test-tool.md#configure-debugging-manually).
+For VS Code `launch.json` and `tasks.json` configuration templates, see [Foundry Toolkit for VSCode (Formerly AI Toolkit) Agent Inspector — Configure debugging manually](https://github.com/microsoft/vscode-ai-toolkit/blob/main/doc/agent-test-tool.md#configure-debugging-manually).
 
 ## Common Errors
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md
@@ -72,13 +72,13 @@ For workflow samples and advanced patterns, search the [Agent Framework GitHub r
 
 ## Debugging
 
-Use [Foundry Toolkit for VSCode (Formerly AI Toolkit)](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) with the `agentdev` CLI tool for interactive debugging:
+Use [Foundry Toolkit for VS Code (Formerly AI Toolkit)](https://marketplace.visualstudio.com/items?itemName=ms-windows-ai-studio.windows-ai-studio) with the `agentdev` CLI tool for interactive debugging:
 
 1. Install `debugpy` for VS Code Python Debugger support
 2. Install `agent-dev-cli` (pre-release) for the `agentdev` command
 3. Key debug tasks: `agentdev run <entrypoint>.py --port 8087` starts the agent HTTP server, `debugpy --listen 127.0.0.1:5679` attaches the debugger, and the `ai-mlstudio.openTestTool` VS Code command opens the Agent Inspector UI
 
-For VS Code `launch.json` and `tasks.json` configuration templates, see [Foundry Toolkit for VSCode (Formerly AI Toolkit) Agent Inspector — Configure debugging manually](https://github.com/microsoft/vscode-ai-toolkit/blob/main/doc/agent-test-tool.md#configure-debugging-manually).
+For VS Code `launch.json` and `tasks.json` configuration templates, see [Foundry Toolkit for VS Code (Formerly AI Toolkit) Agent Inspector — Configure debugging manually](https://github.com/microsoft/vscode-ai-toolkit/blob/main/doc/agent-test-tool.md#configure-debugging-manually).
 
 ## Common Errors
 


### PR DESCRIPTION
## Summary

Renames the two **AI Toolkit** mentions in the `microsoft-foundry` skill's Agent Framework debugging reference to the new product name **Foundry Toolkit for VSCode (Formerly AI Toolkit)**.

The acronym "AITK" was never used in the skill folder — only the spelled-out "AI Toolkit" appeared, in two link labels.

## Changes

`plugin/skills/microsoft-foundry/foundry-agent/create/references/agentframework.md`:
- Line 75: `[AI Toolkit for VS Code]` → `[Foundry Toolkit for VSCode (Formerly AI Toolkit)]`
- Line 81: `[AI Toolkit Agent Inspector — Configure debugging manually]` → `[Foundry Toolkit for VSCode (Formerly AI Toolkit) Agent Inspector — Configure debugging manually]`

## Intentionally not changed

The `ms-windows-ai-studio.windows-ai-studio` strings inside `vscode://` deeplinks (`foundry-agent/observe/observe.md:80` and `foundry-agent/observe/references/analyze-results.md:102`) are **functional extension IDs** — changing them would break the Data Viewer deeplinks.

The marketplace URL and the `microsoft/vscode-ai-toolkit` GitHub repo URL are unchanged for the same reason.

## Validation

- `cd scripts && npm run references` ✅ passes (`microsoft-foundry` clean)
- `agentframework.md` remains within its 1000-token reference budget