### PR TITLE
chore: Add PR check to recommend title prefix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -47,7 +47,7 @@ This repo uses **Nerdbank.GitVersioning (NBGV)**. Versions are computed automati
 - Source files must always use `"0.0.0-placeholder"` — the build stamps real versions
 - Each skill has its own `version.json` with `pathFilters: ["."]`; only commits touching that skill's directory increment its version
 - For skills outside `plugin/` (e.g., `.github/skills/`), set a real semver version and bump it in the same PR that modifies the skill
-- Use conventional commit-style PR titles (`feat:`, `fix:`, `feature:`) — the build generates `CHANGELOG.md` from these
+- Use conventional commit-style PR titles (e.g. `feat:`, `fix:`, `feature:`) — the build generates `CHANGELOG.md` from these
 
 ## Validating Changes
 

--- a/.github/workflows/pr-plugin-version-check.yml
+++ b/.github/workflows/pr-plugin-version-check.yml
@@ -2,11 +2,11 @@ name: PR Plugin Version Check
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-      - 'plugin/.plugin/plugin.json'
-      - 'plugin/.claude-plugin/plugin.json'
-      - 'plugin/.cursor-plugin/plugin.json'
+      - "plugin/.plugin/plugin.json"
+      - "plugin/.claude-plugin/plugin.json"
+      - "plugin/.cursor-plugin/plugin.json"
 
 permissions:
   contents: read
@@ -16,18 +16,18 @@ jobs:
   check-plugin-modifications:
     runs-on: ubuntu-latest
     name: Check Plugin Version Not Modified
-    
+
     steps:
       - name: Checkout PR head
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
-          
+
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
+          node-version: "24"
 
       - name: Install dependencies for plugin checks
         run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,28 @@ on:
     branches: [main]
 
 jobs:
+  pr-title-prefix:
+    name: Check mandatory PR title prefix
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Validate PR title prefix
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        with:
+          script: |
+            const title = context.payload.pull_request.title;
+            const validPrefixes = ['feat:', 'fix:', 'feature:', 'chore:', 'misc:', 'test:', 'eval:'];
+
+            // Check if title starts with any valid prefix (case-sensitive)
+            const isValid = validPrefixes.some(prefix =>
+              title.startsWith(prefix.toLowerCase())
+            );
+
+            if (!isValid) {
+              core.warning(`PR title must start with one of the known prefixes. ${validPrefixes.join(', ')}`);
+            }
+
   eslint:
     name: ESLint
     runs-on: ubuntu-latest
@@ -15,12 +37,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0  # Full history for comparison
+          fetch-depth: 0 # Full history for comparison
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
           cache-dependency-path: tests/package.json
 
       - name: Install tests dependencies
@@ -55,18 +77,18 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
-          fetch-depth: 0  # Full history for comparison
+          fetch-depth: 0 # Full history for comparison
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "24"
+          cache: "npm"
           cache-dependency-path: scripts/package.json
 
       - name: Install scripts dependencies
@@ -115,7 +137,7 @@ jobs:
 
           COMPARE_OUTPUT=$(npm run tokens -- compare --base "origin/${BASE_REF}" --head HEAD --markdown 2>&1)
           echo "$COMPARE_OUTPUT" > ../compare-report.md
-          
+
           TOTAL_DIFF=$(echo "$COMPARE_OUTPUT" | grep -oP 'Total Change.*?\*\*\K[^*]+' | head -1 || echo "0 tokens")
           echo "diff=$TOTAL_DIFF" >> $GITHUB_OUTPUT
 
@@ -158,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -184,8 +206,8 @@ jobs:
         if: steps.changed-plugin-skills.outputs.any_changed == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
           cache-dependency-path: |
             package-lock.json
             scripts/package-lock.json
@@ -212,7 +234,7 @@ jobs:
         run: |
           echo "## Skill Validation" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          
+
           # Map changed plugin/skills paths to built output/skills paths so we
           # validate the version-stamped copies. .github/skills are unchanged.
           SKILL_FILES=""
@@ -224,7 +246,7 @@ jobs:
               SKILL_FILES="$SKILL_FILES ../$file"
             fi
           done
-          
+
           # Run frontmatter spec validation
           if OUTPUT=$(npm run frontmatter -- $SKILL_FILES 2>&1); then
             echo "$OUTPUT"
@@ -307,7 +329,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -325,8 +347,8 @@ jobs:
         if: steps.changed-markdown.outputs.any_changed == 'true'
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
           cache-dependency-path: |
             package-lock.json
             scripts/package-lock.json

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,9 +18,10 @@ jobs:
             const title = context.payload.pull_request.title;
             const validPrefixes = ['feat:', 'fix:', 'feature:', 'chore:', 'misc:', 'test:', 'eval:'];
 
-            // Check if title starts with any valid prefix (case-sensitive)
+            // Check if title starts with any valid prefix (case-insensitive to match changelog filter)
+            const lowerTitle = title.toLowerCase();
             const isValid = validPrefixes.some(prefix =>
-              title.startsWith(prefix.toLowerCase())
+              lowerTitle.startsWith(prefix)
             );
 
             if (!isValid) {

--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -2,7 +2,7 @@ name: Publish to marketplace repos
 
 on:
   schedule:
-    - cron: '0 11 * * 1-5'
+    - cron: "0 11 * * 1-5"
   workflow_dispatch:
 
 permissions:
@@ -19,14 +19,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: source-repo
-          fetch-depth: 0  # Full history required for NBGV version computation
+          fetch-depth: 0 # Full history required for NBGV version computation
 
       # 2. Build the plugin (stamps NBGV versions into output/)
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
           cache-dependency-path: source-repo/package-lock.json
 
       - name: Build plugin
@@ -115,14 +115,14 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           path: source-repo
-          fetch-depth: 0  # Full history required for NBGV version computation
+          fetch-depth: 0 # Full history required for NBGV version computation
 
       # 2. Build the plugin (stamps NBGV versions into output/)
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '22'
-          cache: 'npm'
+          node-version: "22"
+          cache: "npm"
           cache-dependency-path: source-repo/package-lock.json
 
       - name: Build plugin
@@ -184,12 +184,14 @@ jobs:
           rm -f "target-repo/copilot-hooks.json"
 
       # 6. Replace repository URLs in synced files
+      # CHANGELOG.md file contains links to PRs in the GitHub-Copilot-for-Azure repo. These links should not be replaced.
+      # Otherwise they will all get 404.
       - name: Replace repository URLs
         run: |
           TARGET_DIRS=("target-repo/.github/plugins/azure-skills/" "target-repo/skills/" "target-repo/hooks/" "target-repo/plugin.json" "target-repo/.mcp.json" "target-repo/.claude-plugin/plugin.json" "target-repo/gemini-extension.json")
           for target in "${TARGET_DIRS[@]}"; do
             if [ -e "$target" ]; then
-              if matches=$(grep -rli --include='*.md' --include='*.json' 'https://github.com/microsoft/github-copilot-for-azure' "$target"); then
+              if matches=$(grep -rli --exclude='CHANGELOG.md' --include='*.md' --include='*.json' 'https://github.com/microsoft/github-copilot-for-azure' "$target"); then
                 echo "$matches" | while IFS= read -r file; do
                   sed -i 's|https://github.com/microsoft/GitHub-Copilot-for-Azure|https://github.com/microsoft/azure-skills|g' "$file"
                   sed -i 's|https://github.com/microsoft/github-copilot-for-azure|https://github.com/microsoft/azure-skills|g' "$file"

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -21,7 +21,7 @@ The following files have their versions automatically stamped at build time:
 
 The `CHANGELOG.md` is automatically generated at build time by the Gulp pipeline. It includes merged PRs that:
 - Touch the `plugin/` directory
-- Have titles starting with `fix:`, `feat:`, or `feature:`
+- Have titles starting with `fix:`, `feat:`, or `feature:`, etc. See [gulpfile](../gulpfile.ts) for the exhaustive list of supported prefixes.
 
 Each entry is associated with the NBGV height-based version (`{major}.{minor}.{height}`) of the commit that introduced it.
 

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -128,7 +128,7 @@ function build() {
 
 /**
  * Generates a CHANGELOG.md in the output directory based on merged PRs
- * that touch plugin/ and have titles starting with fix:, feat:, or feature:.
+ * that touch plugin/ and have titles starting with fix:, feat:, feature:, chore:, misc:, test:, or eval:.
  * Each version corresponds to a single first-parent commit touching plugin/
  * since the NBGV baseline commit (when plugin/version.json was introduced).
  */
@@ -166,8 +166,8 @@ function generateChangelog(): void {
     return { hash, subject, height: index + 1 };
   });
 
-  // Filter to only include PRs with fix:/feat:/feature: prefixes.
-  const prefixRe = /^(fix|feat|feature)(\(.+?\))?:/i;
+  // Filter to only include PRs with fix:/feat:/feature:/chore:/misc:/test:/eval: prefixes.
+  const prefixRe = /^(fix|feat|feature|chore|misc|test|eval)(\(.+?\))?:/i;
   const filtered = commits.filter((c) => prefixRe.test(c.subject));
 
   // Determine the repository URL for PR links. Prefer the "upstream" remote


### PR DESCRIPTION
## Description

Add a PR check that recommends using a conventional commit-style title prefix (e.g. `feat:`, `fix:`, `feature:`) on pull requests.

This PR also fixes the issue where PR links in CHANGELOG incorrectly use the azure-skills repo.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

Fixes #2423