### PR TITLE
chore: Add explicit PR title prefix check

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,7 +43,8 @@ jobs:
                   },
                 });
               } catch (error) {
-                core.warning(`Could not create neutral check run: ${error.message}`);
+                const message = error instanceof Error ? error.message : String(error);
+                core.warning(`Could not create neutral check run: ${message}`);
               }
             }
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -9,6 +9,7 @@ jobs:
     name: Check mandatory PR title prefix
     runs-on: ubuntu-latest
     permissions:
+      checks: write
       pull-requests: read
     steps:
       - name: Validate PR title prefix
@@ -26,6 +27,24 @@ jobs:
 
             if (!isValid) {
               core.warning(`PR title must start with one of the known prefixes. ${validPrefixes.join(', ')}`);
+
+              // Create a neutral check run so the warning is visible in the PR checks panel.
+              try {
+                await github.rest.checks.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'PR title prefix warning',
+                  head_sha: context.payload.pull_request.head.sha,
+                  status: 'completed',
+                  conclusion: 'neutral',
+                  output: {
+                    title: 'PR title prefix does not match convention',
+                    summary: `Expected one of: ${validPrefixes.join(', ')}. Current title: "${title}"`,
+                  },
+                });
+              } catch (error) {
+                core.warning(`Could not create neutral check run: ${error.message}`);
+              }
             }
 
   eslint:


### PR DESCRIPTION
## Description

Add a CI workflow check that validates PR titles include a required prefix (e.g. `feature:`, `eval:`, `chore:`, `misc:`).

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->