### PR TITLE
eval: add custom json grader

### DIFF
--- a/.github/skills/vally-eval/SKILL.md
+++ b/.github/skills/vally-eval/SKILL.md
@@ -59,6 +59,10 @@ npm run test:vally -- --skill $SKILL
 
 `--eval-spec ../evals/<skill-name>/eval.yaml` tells vally which eval spec to run. The path is relative to the current working directory of the process running the command. `--output-dir ./results` tells vally to write its output to a `results/` directory relative to the current working directory of the process running the command. `--executor-plugin ../../tests/vally/vally-executor.ts` tells vally to load and execute the code in this module, which registers the custom executor used by azure-skill vally eval suites. Note that this path is relative to the parent directory of the eval spec to run. For example, if the eval spec to run is `<repo-root>/evals/azure-ai/eval.yaml`, resolving this relative path ends at `<repo-root>/tests/vally/vally-executor.ts`.
 
+## Extend with custom grader
+
+Custom graders can be added to grade trajectories in ways built-in graders don't support. To add a custom grader, follow the examples in the official vally documentation to create a `tests/vally/<custom-name>-grader.ts` module and register the new custom grader in `tests/vally/vally-graders.ts`. The `npm run test:vally` command internally loads all the custom graders when testing skills.
+
 ## Re-grade an existing trajectory
 
 Test authors commonly need to fine-tune grader configurations to reduce result flakiness. Vally supports re-grading an existing trajectory using a command like this:
@@ -68,7 +72,9 @@ Test authors commonly need to fine-tune grader configurations to reduce result f
 npx @microsoft/vally-cli grade --eval-spec ../evals/<skill-name>/eval.yaml --verbose < results/<test-run-name>/results.jsonl
 ```
 
- You can keep tuning the grader config in `eval.yaml` and re-grade the trajectory until the results meet your expectations.
+You can keep tuning the grader config in `eval.yaml` and re-grade the trajectory until the results meet your expectations.
+
+If your skill uses a custom grader, add `--grader-plugin ./tests/vally/vally-graders.ts` to load the custom graders.
 
 ### Collect test results
 

--- a/.github/skills/vally-eval/SKILL.md
+++ b/.github/skills/vally-eval/SKILL.md
@@ -15,7 +15,7 @@ Skills in the azure-skills plugin are required to have integration tests that ru
 
 Vally eval suites are written as yaml documents. All eval suites share eval spec.
 
-Refer to the official documentation on the schema of the spec and the schema of the eval suites [writing-eval-specs](https://literate-engine-r3wnl4v.pages.github.io/guides/writing-eval-specs/).
+Refer to the official documentation on the schema of the spec and the schema of the eval suites [writing-eval-specs](https://microsoft.github.io/vally/guides/writing-eval-specs/).
 
 Vally eval suites for azure-skills plugin have the following file layout. The shared eval spec is located at `<repo-root>/.vally.yaml`. The eval suites are categorized by skills. The eval suites for each skill are located at `<repo-root>/evals/<skill-name>/eval.yaml`, e.g. `<repo-root>/evals/azure-ai/eval.yaml`. If a skill needs fixture files for its eval suites, it should organize such fixture files in a `fixture` directory under its directory, e.g. `<repo-root>/evals/azure-ai/fixture/`.
 
@@ -23,7 +23,7 @@ Vally eval suites for azure-skills plugin have the following file layout. The sh
 
 azure-skills plugin have implemented JavaScript integration test using Jest as the underlying test runner. All such integration tests are under `tests/**/integration.test.ts` files.
 
-To migrate integration test for a skill to vally suites, create its eval suite spec at `<repo-root>/evals/<skill-name>/eval.yaml`, add a suite that runs the same prompt and uses vally's built-in graders to grade the trajectory of the agent run. If the integration test grades the agent run in a way that vally's built-in graders don't support, refer to the official documentation on how to create a custom grader [writing-custom-grader](https://literate-engine-r3wnl4v.pages.github.io/guides/writing-custom-graders/).
+To migrate integration test for a skill to vally suites, create its eval suite spec at `<repo-root>/evals/<skill-name>/eval.yaml`, add a suite that runs the same prompt and uses vally's built-in graders to grade the trajectory of the agent run. If the integration test grades the agent run in a way that vally's built-in graders don't support, refer to the official documentation on how to create a custom grader [writing-custom-grader](https://microsoft.github.io/vally/guides/writing-custom-graders/).
 
 ## Why is there a custom executor
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -50,7 +50,7 @@ jobs:
           npm run vally validate-stimulus
 
       - name: Lint skill and eval specs
-        run: npx --yes @microsoft/vally-cli@^0.5.0 lint plugin/skills/ --eval-spec evals/ --strict
+        run: npx --yes @microsoft/vally-cli@^0.5.0 lint plugin/skills/ --eval-spec evals/ --strict --grader-plugin ./tests/vally/vally-graders.ts
 
       - name: Determine suite
         if: github.event_name != 'pull_request'

--- a/evals/azure-enterprise-infra-planner/eval.yaml
+++ b/evals/azure-enterprise-infra-planner/eval.yaml
@@ -865,10 +865,6 @@ stimuli:
           required: ["azure-enterprise-infra-planner"]
       # File paths use `**/...` globs because the agent non-deterministically
       # writes plan files either at workspace root or in a skill-named subdir.
-      - type: json-object-rules
-        config:
-          path: "\\.azure/infrastructure-plan.json"
-          rules: '{"type":"has-property","key":"plan.resources"}'
       - type: file-exists
         config:
           path: "**/.azure/insights.json"
@@ -876,38 +872,26 @@ stimuli:
         config:
           path: "**/.azure/infrastructure-plan.json"
       # Plan-level required fields (Jest: expect(plan.meta|inputs|plan).toHaveProperty)
-      - type: file-matches
+      - type: json-object-rules
         config:
-          path: "**/.azure/infrastructure-plan.json"
-          pattern: '(?s)"meta".*"planId"'
-      - type: file-matches
-        config:
-          path: "**/.azure/infrastructure-plan.json"
-          pattern: '(?s)"meta".*"status"'
-      - type: file-matches
-        config:
-          path: "**/.azure/infrastructure-plan.json"
-          pattern: '(?s)"meta".*"version"'
-      - type: file-matches
-        config:
-          path: "**/.azure/infrastructure-plan.json"
-          pattern: '(?s)"inputs".*"userGoal"'
-      - type: file-matches
-        config:
-          path: "**/.azure/infrastructure-plan.json"
-          pattern: '(?s)"inputs".*"insightsApplied"'
-      - type: file-matches
-        config:
-          path: "**/.azure/infrastructure-plan.json"
-          pattern: '(?s)"plan".*"resources"'
-      - type: file-matches
-        config:
-          path: "**/.azure/infrastructure-plan.json"
-          pattern: '(?s)"plan".*"overallReasoning"'
-      - type: file-matches
-        config:
-          path: "**/.azure/infrastructure-plan.json"
-          pattern: '(?s)"plan".*"validation"'
+          path: "\\.azure/infrastructure-plan.json"
+          rules:
+            - type: has-property
+              key: meta.planId
+            - type: has-property
+              key: meta.status
+            - type: has-property
+              key: meta.version
+            - type: has-property
+              key: inputs.userGoal
+            - type: has-property
+              key: inputs.insightsApplied
+            - type: has-property
+              key: plan.resources
+            - type: has-property
+              key: plan.overallReasoning
+            - type: has-property
+              key: plan.validation
       # Per-resource required fields (Jest: for (const resource of plan.plan.resources) ...)
       - type: file-matches
         config:

--- a/evals/azure-enterprise-infra-planner/eval.yaml
+++ b/evals/azure-enterprise-infra-planner/eval.yaml
@@ -874,7 +874,7 @@ stimuli:
       # Plan-level required fields (Jest: expect(plan.meta|inputs|plan).toHaveProperty)
       - type: json-object-rules
         config:
-          path: "\\.azure/infrastructure-plan.json"
+          path: "**/.azure/infrastructure-plan.json"
           rules:
             - type: has-property
               key: meta.planId

--- a/evals/azure-enterprise-infra-planner/eval.yaml
+++ b/evals/azure-enterprise-infra-planner/eval.yaml
@@ -865,6 +865,10 @@ stimuli:
           required: ["azure-enterprise-infra-planner"]
       # File paths use `**/...` globs because the agent non-deterministically
       # writes plan files either at workspace root or in a skill-named subdir.
+      - type: json-object-rules
+        config:
+          path: "\\.azure/infrastructure-plan.json"
+          rules: '{"type":"has-property","key":"plan.resources"}'
       - type: file-exists
         config:
           path: "**/.azure/insights.json"
@@ -875,52 +879,52 @@ stimuli:
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"meta\".*\"planId\""
+          pattern: '(?s)"meta".*"planId"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"meta\".*\"status\""
+          pattern: '(?s)"meta".*"status"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"meta\".*\"version\""
+          pattern: '(?s)"meta".*"version"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"inputs\".*\"userGoal\""
+          pattern: '(?s)"inputs".*"userGoal"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"inputs\".*\"insightsApplied\""
+          pattern: '(?s)"inputs".*"insightsApplied"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"plan\".*\"resources\""
+          pattern: '(?s)"plan".*"resources"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"plan\".*\"overallReasoning\""
+          pattern: '(?s)"plan".*"overallReasoning"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"plan\".*\"validation\""
+          pattern: '(?s)"plan".*"validation"'
       # Per-resource required fields (Jest: for (const resource of plan.plan.resources) ...)
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"resources\".*\"name\""
+          pattern: '(?s)"resources".*"name"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"resources\".*\"type\""
+          pattern: '(?s)"resources".*"type"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"resources\".*\"location\""
+          pattern: '(?s)"resources".*"location"'
       - type: file-matches
         config:
           path: "**/.azure/infrastructure-plan.json"
-          pattern: "(?s)\"resources\".*\"reasoning\""
+          pattern: '(?s)"resources".*"reasoning"'
       # hasNetworking + hasCompute (Jest: resourceTypes.some(...))
       - type: file-matches
         config:

--- a/scripts/src/vally/validate-stimulus.ts
+++ b/scripts/src/vally/validate-stimulus.ts
@@ -19,6 +19,7 @@ type Stimuli = {
   name?: string;
   graders?: Array<{
     type?: string;
+    config?: unknown;
   }>;
   tags?: {
     type?: string;
@@ -87,6 +88,103 @@ function validateJsonObjectTag(
     `tags.${tagName} must be parsable JSON`,
   );
   return false;
+}
+
+function validateJsonObjectRulesGrader(
+  displayPath: string,
+  stimulusIndex: number,
+  stimulusName: string | undefined,
+  grader: { type?: string; config?: unknown },
+): boolean {
+  if (grader.type !== "json-object-rules") {
+    return true;
+  }
+
+  if (!isPlainObject(grader.config)) {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      "graders.json-object-rules must define a config object with path and rules",
+    );
+    return false;
+  }
+
+  const { path, rules } = grader.config;
+  if (typeof path !== "string" || path.trim().length === 0) {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      "graders.json-object-rules.config.path must be a non-empty string",
+    );
+    return false;
+  }
+
+  if (typeof rules !== "string") {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      "graders.json-object-rules.config.rules must be a JSON string",
+    );
+    return false;
+  }
+
+  let parsedRules: unknown;
+  try {
+    parsedRules = JSON.parse(rules);
+  } catch {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      "graders.json-object-rules.config.rules must be valid JSON",
+    );
+    return false;
+  }
+
+  if (!isPlainObject(parsedRules)) {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      "graders.json-object-rules.config.rules must parse to an object",
+    );
+    return false;
+  }
+
+  if (parsedRules.type !== "has-property") {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      "graders.json-object-rules.config.rules.type must be 'has-property'",
+    );
+    return false;
+  }
+
+  if (typeof parsedRules.key !== "string" || parsedRules.key.trim().length === 0) {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      "graders.json-object-rules.config.rules.key must be a non-empty string",
+    );
+    return false;
+  }
+
+  if (parsedRules.value !== undefined && typeof parsedRules.value !== "string") {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      "graders.json-object-rules.config.rules.value must be undefined or a string",
+    );
+    return false;
+  }
+
+  return true;
 }
 
 function validateFollowUpTag(
@@ -236,6 +334,19 @@ export function validateStimulus(rootDir: string, _args: string[]): void {
         typedStimulus.tags?.takeScreenshot,
       )) {
         fileHasErrors = true;
+      }
+
+      if (Array.isArray(typedStimulus.graders)) {
+        for (const grader of typedStimulus.graders) {
+          if (!validateJsonObjectRulesGrader(
+            displayPath,
+            stimulusIndex,
+            typedStimulus.name,
+            grader,
+          )) {
+            fileHasErrors = true;
+          }
+        }
       }
 
       if (typedStimulus.tags?.earlyTerminate && hasCompletedGrader(typedStimulus)) {

--- a/scripts/src/vally/validate-stimulus.ts
+++ b/scripts/src/vally/validate-stimulus.ts
@@ -127,13 +127,15 @@ function validateSingleRule(
     return false;
   }
 
-  if (rule.value !== undefined && typeof rule.value !== "string") {
-    reportValidationError(
-      displayPath,
-      stimulusIndex,
-      stimulusName,
-      `${ruleLabel}.value must be undefined or a string`,
-    );
+  if (rule.value !== undefined) {
+    if (rule.value !== "string" && rule.value !== "number") {
+      reportValidationError(
+        displayPath,
+        stimulusIndex,
+        stimulusName,
+        `${ruleLabel}.value must be undefined or a string or a number`,
+      );
+    }
     return false;
   }
 

--- a/scripts/src/vally/validate-stimulus.ts
+++ b/scripts/src/vally/validate-stimulus.ts
@@ -90,6 +90,56 @@ function validateJsonObjectTag(
   return false;
 }
 
+function validateSingleRule(
+  displayPath: string,
+  stimulusIndex: number,
+  stimulusName: string | undefined,
+  rule: unknown,
+  ruleLabel: string,
+): boolean {
+  if (!isPlainObject(rule)) {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      `${ruleLabel} must be an object`,
+    );
+    return false;
+  }
+
+  if (rule.type !== "has-property") {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      `${ruleLabel}.type must be 'has-property'`,
+    );
+    return false;
+  }
+
+  if (typeof rule.key !== "string" || rule.key.trim().length === 0) {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      `${ruleLabel}.key must be a non-empty string`,
+    );
+    return false;
+  }
+
+  if (rule.value !== undefined && typeof rule.value !== "string") {
+    reportValidationError(
+      displayPath,
+      stimulusIndex,
+      stimulusName,
+      `${ruleLabel}.value must be undefined or a string`,
+    );
+    return false;
+  }
+
+  return true;
+}
+
 function validateJsonObjectRulesGrader(
   displayPath: string,
   stimulusIndex: number,
@@ -121,70 +171,59 @@ function validateJsonObjectRulesGrader(
     return false;
   }
 
-  if (typeof rules !== "string") {
-    reportValidationError(
-      displayPath,
-      stimulusIndex,
-      stimulusName,
-      "graders.json-object-rules.config.rules must be a JSON string",
-    );
-    return false;
+  const ruleLabel = "graders.json-object-rules.config.rules";
+
+  // rules as a JSON string (single rule object serialized)
+  if (typeof rules === "string") {
+    let parsedRules: unknown;
+    try {
+      parsedRules = JSON.parse(rules);
+    } catch {
+      reportValidationError(
+        displayPath,
+        stimulusIndex,
+        stimulusName,
+        `${ruleLabel} must be valid JSON`,
+      );
+      return false;
+    }
+
+    return validateSingleRule(displayPath, stimulusIndex, stimulusName, parsedRules, ruleLabel);
   }
 
-  let parsedRules: unknown;
-  try {
-    parsedRules = JSON.parse(rules);
-  } catch {
-    reportValidationError(
-      displayPath,
-      stimulusIndex,
-      stimulusName,
-      "graders.json-object-rules.config.rules must be valid JSON",
-    );
-    return false;
+  // rules as an array of rule objects
+  if (Array.isArray(rules)) {
+    if (rules.length === 0) {
+      reportValidationError(
+        displayPath,
+        stimulusIndex,
+        stimulusName,
+        `${ruleLabel} must not be an empty array`,
+      );
+      return false;
+    }
+
+    let valid = true;
+    for (const [ruleIndex, rule] of rules.entries()) {
+      if (!validateSingleRule(displayPath, stimulusIndex, stimulusName, rule, `${ruleLabel}[${ruleIndex}]`)) {
+        valid = false;
+      }
+    }
+    return valid;
   }
 
-  if (!isPlainObject(parsedRules)) {
-    reportValidationError(
-      displayPath,
-      stimulusIndex,
-      stimulusName,
-      "graders.json-object-rules.config.rules must parse to an object",
-    );
-    return false;
+  // rules as a single inline object
+  if (isPlainObject(rules)) {
+    return validateSingleRule(displayPath, stimulusIndex, stimulusName, rules, ruleLabel);
   }
 
-  if (parsedRules.type !== "has-property") {
-    reportValidationError(
-      displayPath,
-      stimulusIndex,
-      stimulusName,
-      "graders.json-object-rules.config.rules.type must be 'has-property'",
-    );
-    return false;
-  }
-
-  if (typeof parsedRules.key !== "string" || parsedRules.key.trim().length === 0) {
-    reportValidationError(
-      displayPath,
-      stimulusIndex,
-      stimulusName,
-      "graders.json-object-rules.config.rules.key must be a non-empty string",
-    );
-    return false;
-  }
-
-  if (parsedRules.value !== undefined && typeof parsedRules.value !== "string") {
-    reportValidationError(
-      displayPath,
-      stimulusIndex,
-      stimulusName,
-      "graders.json-object-rules.config.rules.value must be undefined or a string",
-    );
-    return false;
-  }
-
-  return true;
+  reportValidationError(
+    displayPath,
+    stimulusIndex,
+    stimulusName,
+    `${ruleLabel} must be a JSON string, an object, or an array of objects`,
+  );
+  return false;
 }
 
 function validateFollowUpTag(

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,7 +26,7 @@ Add new test coverage as Vally eval suites in [../evals](../evals).
 
 Typical locations:
 
-- Skill-specific suite: [../evals](../evals)/<skill-name>/eval.yaml
+- Skill-specific suite: [../evals](../evals)/\<skill-name\>/eval.yaml
 - Shared building blocks: [../evals/_base](../evals/_base)
 
 ## Authoring and Running Vally Tests

--- a/tests/run-vally-test.ts
+++ b/tests/run-vally-test.ts
@@ -279,7 +279,7 @@ async function main(): Promise<void> {
   // default options
   forwardedArgs.splice(0, 0, "--output-dir", "./results");
   forwardedArgs.splice(0, 0, "--executor-plugin", path.join(__dirname, "vally", "vally-executor.ts"));
-
+  forwardedArgs.splice(0, 0, "--grader-plugin", path.join(__dirname, "vally", "vally-graders.ts"));
   if (options.skill) {
     forwardedArgs.splice(0, 0, "--eval-spec", `../evals/${options.skill}/eval.yaml`);
   }

--- a/tests/vally/json-grader.ts
+++ b/tests/vally/json-grader.ts
@@ -1,0 +1,175 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { Grader, GraderInput, GraderMetadata, GraderResult } from "@microsoft/vally";
+
+type JsonGraderRule = {
+  /**
+   * Checks if the JSON object has a property at given key.
+   */
+  type: "has-property";
+
+  /**
+   * Dot delimited property key path starting from the root.
+   * @example "a.b" means there is a top level property "a" whose value is an object and has a nested property "b".
+   */
+  key: string;
+
+  /**
+   * Optional. Required value of the property to check.
+   * When specified, the grader will fail if the actual value of the property doesn't equal to the specified value.
+   * When not specified, the grader will pass as long as the property exist.
+   */
+  value?: string | number;
+};
+
+type JsonGraderConfig = {
+  /**
+   * Regex pattern for the json document to look for.
+   */
+  path: string;
+
+  rules: JsonGraderRule | JsonGraderRule[];
+};
+
+function findMatchingPaths(workDir: string, pattern: RegExp): string[] {
+  const matches = new Set<string>();
+
+  function walk(currentDir: string): void {
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+
+    for (const entry of entries) {
+      const fullPath = path.join(currentDir, entry.name);
+      const normalizedFullPath = fullPath.replace(/\\/g, "/");
+      const relativePath = path.relative(workDir, fullPath).replace(/\\/g, "/");
+
+      const candidatePattern = new RegExp(pattern.source, pattern.flags);
+      if (candidatePattern.test(relativePath) || candidatePattern.test(normalizedFullPath)) {
+        matches.add(path.resolve(fullPath));
+      }
+      candidatePattern.lastIndex = 0;
+
+      if (entry.isDirectory()) {
+        walk(fullPath);
+      }
+    }
+  }
+
+  walk(workDir);
+  return Array.from(matches).sort((a, b) => a.localeCompare(b));
+}
+
+function hasProperty(value: unknown, keyPath: string, expectedValue?: string | number): boolean {
+  const keys = keyPath.split(".");
+  let current: unknown = value;
+
+  for (const key of keys) {
+    if (typeof current !== "object" || current === null || !(key in current)) {
+      return false;
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+
+  if (expectedValue === undefined) {
+    return true;
+  }
+
+  return current === expectedValue;
+}
+
+export class JsonGrader implements Grader {
+  metadata: GraderMetadata = {
+    name: "json-object-rules",
+    description: "Checks if a json files satisfies the given rules",
+    behavior: { execution: "single" },
+    costProfile: "free",
+    portability: "t1-universal",
+    reference: "reference-free",
+    temporalScope: "trajectory-level",
+    determinism: "static"
+  };
+
+  async grade(input: GraderInput): Promise<GraderResult> {
+    if (!input.trajectory) {
+      throw new Error("Missing trajectory");
+    }
+    console.log("input.config", input.config);
+
+    if (!input.config || typeof input.config !== "object") {
+      throw new Error(`Invalid ${this.metadata.name} grader config`);
+    }
+
+    const rawPath = input.config.path;
+    const rawRules = input.config.rules;
+    console.log("rawPath", rawPath);
+    console.log("rawRules", rawRules);
+
+    if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
+      throw new Error(`Invalid ${this.metadata.name} grader config. path is not a string`);
+    }
+    if (rawRules === undefined || rawRules === null) {
+      throw new Error(`Invalid ${this.metadata.name} grader config. rules is not a JSON string.`);
+    }
+
+    if (input.trajectory.workspaceStatus === "remote") {
+      throw new Error("Workspace not materialized");
+    }
+
+    const workDir = input.trajectory.workDir;
+    const config = {
+      path: rawPath,
+      rules: typeof rawRules === "string" ? JSON.parse(rawRules) : rawRules,
+    } as JsonGraderConfig;
+
+    let pattern: RegExp;
+    try {
+      pattern = new RegExp(config.path);
+    } catch {
+      throw new Error(`Invalid ${this.metadata.name} grader config. path is not a valid regex`);
+    }
+    const matchedPaths = findMatchingPaths(workDir, pattern);
+
+    const rules = Array.isArray(config.rules) ? config.rules : [config.rules];
+    const hasExactSingleMatch = matchedPaths.length === 1;
+    let passed = false;
+    let evidence!: string;
+
+    if (!hasExactSingleMatch) {
+      evidence = `Expected exactly one match, but found ${matchedPaths.length} candidate path(s).`;
+    } else {
+      const [matchedPath] = matchedPaths;
+      const content = fs.readFileSync(matchedPath, "utf8");
+      const parsed = JSON.parse(content) as unknown;
+
+      passed = true;
+
+      for (const rule of rules) {
+        if (rule.type !== "has-property") {
+          passed = false;
+          break;
+        }
+
+        passed = hasProperty(parsed, rule.key, rule.value);
+        if (!passed) {
+          break;
+        }
+      }
+
+      evidence = passed
+        ? "Exactly one matching path was found and the JSON rules passed."
+        : "The unique matching file was found, but it did not satisfy the configured JSON rules.";
+    }
+
+    return {
+      name: this.metadata.name,
+      kind: "code",
+      passed,
+      score: passed ? 1 : 0,
+      evidence,
+      label: passed ? "correct" : "incorrect",
+      metadata: {
+        matchedPaths,
+        pattern: config.path,
+      },
+    };
+  }
+}

--- a/tests/vally/json-grader.ts
+++ b/tests/vally/json-grader.ts
@@ -24,14 +24,14 @@ type JsonGraderRule = {
 
 type JsonGraderConfig = {
   /**
-   * Regex pattern for the json document to look for.
+  * Glob pattern for the json document to look for.
    */
   path: string;
 
   rules: JsonGraderRule | JsonGraderRule[];
 };
 
-function findMatchingPaths(workDir: string, pattern: RegExp): string[] {
+function findMatchingPaths(workDir: string, globPattern: string): string[] {
   const matches = new Set<string>();
 
   function walk(currentDir: string): void {
@@ -42,11 +42,9 @@ function findMatchingPaths(workDir: string, pattern: RegExp): string[] {
       const normalizedFullPath = fullPath.replace(/\\/g, "/");
       const relativePath = path.relative(workDir, fullPath).replace(/\\/g, "/");
 
-      const candidatePattern = new RegExp(pattern.source, pattern.flags);
-      if (candidatePattern.test(relativePath) || candidatePattern.test(normalizedFullPath)) {
+      if (path.matchesGlob(relativePath, globPattern) || path.matchesGlob(normalizedFullPath, globPattern)) {
         matches.add(path.resolve(fullPath));
       }
-      candidatePattern.lastIndex = 0;
 
       if (entry.isDirectory()) {
         walk(fullPath);
@@ -79,7 +77,7 @@ function hasProperty(value: unknown, keyPath: string, expectedValue?: string | n
 export class JsonGrader implements Grader {
   metadata: GraderMetadata = {
     name: "json-object-rules",
-    description: "Checks if a json files satisfies the given rules",
+    description: "Checks whether a JSON file satisfies the given rules",
     behavior: { execution: "single" },
     costProfile: "free",
     portability: "t1-universal",
@@ -117,13 +115,15 @@ export class JsonGrader implements Grader {
       rules: typeof rawRules === "string" ? JSON.parse(rawRules) : rawRules,
     } as JsonGraderConfig;
 
-    let pattern: RegExp;
+    const globPattern = config.path.replace(/\\/g, "/");
     try {
-      pattern = new RegExp(config.path);
+      // Validate glob syntax up front.
+      path.matchesGlob("", globPattern);
     } catch {
-      throw new Error(`Invalid ${this.metadata.name} grader config. path is not a valid regex`);
+      throw new Error(`Invalid ${this.metadata.name} grader config. path is not a valid glob pattern`);
     }
-    const matchedPaths = findMatchingPaths(workDir, pattern);
+
+    const matchedPaths = findMatchingPaths(workDir, globPattern);
 
     const rules = Array.isArray(config.rules) ? config.rules : [config.rules];
     const hasExactSingleMatch = matchedPaths.length === 1;
@@ -165,7 +165,7 @@ export class JsonGrader implements Grader {
       label: passed ? "correct" : "incorrect",
       metadata: {
         matchedPaths,
-        pattern: config.path,
+        pattern: globPattern
       },
     };
   }

--- a/tests/vally/json-grader.ts
+++ b/tests/vally/json-grader.ts
@@ -92,7 +92,6 @@ export class JsonGrader implements Grader {
     if (!input.trajectory) {
       throw new Error("Missing trajectory");
     }
-    console.log("input.config", input.config);
 
     if (!input.config || typeof input.config !== "object") {
       throw new Error(`Invalid ${this.metadata.name} grader config`);
@@ -100,8 +99,6 @@ export class JsonGrader implements Grader {
 
     const rawPath = input.config.path;
     const rawRules = input.config.rules;
-    console.log("rawPath", rawPath);
-    console.log("rawRules", rawRules);
 
     if (typeof rawPath !== "string" || rawPath.trim().length === 0) {
       throw new Error(`Invalid ${this.metadata.name} grader config. path is not a string`);

--- a/tests/vally/json-grader.ts
+++ b/tests/vally/json-grader.ts
@@ -39,14 +39,15 @@ function findMatchingPaths(workDir: string, globPattern: string): string[] {
 
     for (const entry of entries) {
       const fullPath = path.join(currentDir, entry.name);
-      const normalizedFullPath = fullPath.replace(/\\/g, "/");
-      const relativePath = path.relative(workDir, fullPath).replace(/\\/g, "/");
+      if (!entry.isDirectory()) {
+        const normalizedFullPath = fullPath.replace(/\\/g, "/");
 
-      if (path.matchesGlob(relativePath, globPattern) || path.matchesGlob(normalizedFullPath, globPattern)) {
-        matches.add(path.resolve(fullPath));
-      }
+        const relativePath = path.relative(workDir, fullPath).replace(/\\/g, "/");
 
-      if (entry.isDirectory()) {
+        if (path.matchesGlob(relativePath, globPattern) || path.matchesGlob(normalizedFullPath, globPattern)) {
+          matches.add(path.resolve(fullPath));
+        }
+      } else {
         walk(fullPath);
       }
     }

--- a/tests/vally/vally-graders.ts
+++ b/tests/vally/vally-graders.ts
@@ -1,6 +1,6 @@
 import type { GraderRegistry } from "@microsoft/vally";
 import { JsonGrader } from "./json-grader.ts";
 
-export function registerGraders(registry: GraderRegistry) {
+export function registerGraders(registry: GraderRegistry): void {
   registry.register(new JsonGrader());
 }

--- a/tests/vally/vally-graders.ts
+++ b/tests/vally/vally-graders.ts
@@ -1,0 +1,6 @@
+import type { GraderRegistry } from "@microsoft/vally";
+import { JsonGrader } from "./json-grader.ts";
+
+export function registerGraders(registry: GraderRegistry) {
+  registry.register(new JsonGrader());
+}


### PR DESCRIPTION
## Description

Add a custom JSON grader for eval test suites and use it to add back graders in old jest tests in enterprise-infra-planner tests.

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (`npm run test:skills:integration -- <skill>`)
- [ ] **If modifying skill `USE FOR` / `DO NOT USE FOR` / `PREFER OVER` clauses:** confirmed no routing regressions for competing skills

## Related Issues

