### PR TITLE
feat: add token usage over time to the dashboard

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -385,3 +385,16 @@ jobs:
             --source reports/test-run-all-integration/ \
             --auth-mode login \
             --overwrite
+
+      # Upload per-test token usage to the Azure Table that powers the dashboard's
+      # "token usage over time" page. Runs for both scheduled and manual runs.
+      # Note: The managed identity must have Storage Table Data Contributor on the storage account.
+      - name: Upload token usage to table
+        if: always() && vars.REPORT_STORAGE_ACCOUNT != ''
+        env:
+          TOKEN_USAGE_STORAGE_ACCOUNT: ${{ vars.REPORT_STORAGE_ACCOUNT }}
+          TOKEN_USAGE_TABLE_NAME: ${{ vars.TOKEN_USAGE_TABLE || 'integrationtokenusage' }}
+          SKILL: ${{ matrix.skill }}
+          BRANCH: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: npm run upload:token-usage

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -241,3 +241,16 @@ jobs:
             --source reports/test-run-azure-deploy \
             --auth-mode login \
             --overwrite
+
+      # Upload per-test token usage to the Azure Table that powers the dashboard's
+      # "token usage over time" page.
+      # Note: The managed identity must have Storage Table Data Contributor on the storage account.
+      - name: Upload token usage to table
+        if: always() && inputs.publish-reports && vars.REPORT_STORAGE_ACCOUNT != ''
+        env:
+          TOKEN_USAGE_STORAGE_ACCOUNT: ${{ vars.REPORT_STORAGE_ACCOUNT }}
+          TOKEN_USAGE_TABLE_NAME: ${{ vars.TOKEN_USAGE_TABLE || 'integrationtokenusage' }}
+          SKILL: azure-deploy
+          BRANCH: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: npm run upload:token-usage

--- a/dashboard/Readme.md
+++ b/dashboard/Readme.md
@@ -112,10 +112,11 @@ Configuration:
 
 - Workflow variables: `REPORT_STORAGE_ACCOUNT` (reused as the table's storage
   account) and optionally `TOKEN_USAGE_TABLE` (defaults to `integrationtokenusage`).
-- RBAC: the workflow's Managed Identity needs **Storage Table Data Contributor** on
-  the storage account (to write rows). The dashboard's Managed Identity is granted
-  **Storage Table Data Reader** on the same account by `infra/modules/storage.bicep`
-  (to read rows).
+- RBAC (provisioned by `infra/modules/storage.bicep`): the dashboard's Managed
+  Identity is granted **Storage Table Data Reader** (to read rows), and the
+  integration test pipeline identity `skillcitestidentity` is granted **Storage
+  Table Data Contributor** (to write rows) via the `ciTestIdentityPrincipalId`
+  parameter.
 - The table itself is provisioned by `infra/modules/storage.bicep`.
 
 ## Overall Health Data

--- a/dashboard/Readme.md
+++ b/dashboard/Readme.md
@@ -88,6 +88,36 @@ You will be prompted to authenticate and select an Azure subscription and locati
 
 Integration test data are published at the end of scheduled integration test runs. See [Integration Test Workflow](../.github/workflows/test-all-integration.yml) for how it's done. You need to configure the `STORAGE_ACCOUNT` and `STORAGE_CONTAINER` environment variable to point the workflow to the target storage account for storing the data and give the Managed Identity used by the workflow the RBAC permission to write to the target storage account. 
 
+## Token Usage Over Time
+
+The **Token Usage** page (`token-usage.html`) charts integration-test token
+consumption over time: total tokens per run plus a trailing rolling average of the
+last five runs. Use the Skill / Test / Branch filters to narrow the view.
+
+Data flow:
+
+- Each integration test already writes per-test token usage to
+  `token-summary.jsonl` (via `tests/utils/agent-runner.ts`).
+- The integration test pipelines upload that data **directly** to an Azure Table by
+  running `npm run upload:token-usage` (`tests/scripts/upload-token-usage.ts`). One
+  row is stored **per test, per branch, per run** in the `integrationtokenusage`
+  table on the integration-reports storage account. This runs in
+  `test-all-integration.yml` (scheduled + manual) and in `test-azure-deploy.yml`
+  whenever its `publish-reports` input is `true` (i.e. on scheduled runs).
+- The frontend never reads the table directly. It calls the Function App API:
+  - `GET /api/token-usage` — rows, with optional `skill`, `test`, `branch` filters.
+  - `GET /api/token-usage/filters` — distinct skills / tests / branches.
+
+Configuration:
+
+- Workflow variables: `REPORT_STORAGE_ACCOUNT` (reused as the table's storage
+  account) and optionally `TOKEN_USAGE_TABLE` (defaults to `integrationtokenusage`).
+- RBAC: the workflow's Managed Identity needs **Storage Table Data Contributor** on
+  the storage account (to write rows). The dashboard's Managed Identity is granted
+  **Storage Table Data Reader** on the same account by `infra/modules/storage.bicep`
+  (to read rows).
+- The table itself is provisioned by `infra/modules/storage.bicep`.
+
 ## Overall Health Data
 
 Overall health data are collected by running scripts locally, which includes running non-integration tests, running evaluation scripts and extracting key metrics from **local** integration test runs. This can be done by running the `dashboard:collect` command at the root of the repository.

--- a/dashboard/api/src/functions/getTokenUsage.ts
+++ b/dashboard/api/src/functions/getTokenUsage.ts
@@ -61,7 +61,7 @@ async function getTokenUsage(request: HttpRequest, context: InvocationContext): 
                 branch: entity.branch,
                 runId: entity.runId,
                 runDate: entity.runDate,
-                timestamp: entity.timestamp,
+                runTimestamp: entity.runTimestamp,
                 model: entity.model,
                 inputTokens: entity.inputTokens,
                 outputTokens: entity.outputTokens,

--- a/dashboard/api/src/functions/getTokenUsage.ts
+++ b/dashboard/api/src/functions/getTokenUsage.ts
@@ -1,0 +1,141 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import { TableClient } from "@azure/data-tables";
+import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
+import { logRequestIdentity } from "../requestIdentity";
+
+const STORAGE_ACCOUNT_NAME = process.env.STORAGE_ACCOUNT_NAME;
+const TOKEN_USAGE_TABLE_NAME = process.env.TOKEN_USAGE_TABLE_NAME;
+
+function getTokenUsageTableClient(): TableClient {
+    if (!STORAGE_ACCOUNT_NAME) {
+        throw new Error("STORAGE_ACCOUNT_NAME environment variable is not set");
+    }
+    if (!TOKEN_USAGE_TABLE_NAME) {
+        throw new Error("TOKEN_USAGE_TABLE_NAME environment variable is not set");
+    }
+    const clientId = process.env.AZURE_CLIENT_ID;
+    const isDevEnvironment = process.env.AZURE_FUNCTIONS_ENVIRONMENT === "Development";
+    const credential = isDevEnvironment ? new AzureCliCredential() : new ManagedIdentityCredential(clientId!);
+    return new TableClient(
+        `https://${STORAGE_ACCOUNT_NAME}.table.core.windows.net`,
+        TOKEN_USAGE_TABLE_NAME,
+        credential
+    );
+}
+
+/** Escape a value for use inside an OData string literal (single quotes are doubled). */
+function odataLiteral(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
+/**
+ * Returns integration-test token usage rows from the table.
+ * GET /api/token-usage
+ * Query params: skill (optional), test (optional), branch (optional)
+ *
+ * Each row represents one test, in one branch, for one run.
+ */
+async function getTokenUsage(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+    logRequestIdentity(request, context, "getTokenUsage");
+
+    const filterSkill = request.query.get("skill") || undefined;
+    const filterTest = request.query.get("test") || undefined;
+    const filterBranch = request.query.get("branch") || undefined;
+
+    try {
+        const tableClient = getTokenUsageTableClient();
+
+        const filters: string[] = [];
+        if (filterSkill) filters.push(`skill eq '${odataLiteral(filterSkill)}'`);
+        if (filterTest) filters.push(`testName eq '${odataLiteral(filterTest)}'`);
+        if (filterBranch) filters.push(`branch eq '${odataLiteral(filterBranch)}'`);
+        const filter = filters.length > 0 ? filters.join(" and ") : undefined;
+
+        const listOptions = filter ? { queryOptions: { filter } } : {};
+        const entities: Record<string, unknown>[] = [];
+
+        for await (const entity of tableClient.listEntities(listOptions)) {
+            entities.push({
+                skill: entity.skill,
+                testName: entity.testName,
+                branch: entity.branch,
+                runId: entity.runId,
+                runDate: entity.runDate,
+                timestamp: entity.timestamp,
+                model: entity.model,
+                inputTokens: entity.inputTokens,
+                outputTokens: entity.outputTokens,
+                cacheReadTokens: entity.cacheReadTokens,
+                cacheWriteTokens: entity.cacheWriteTokens,
+                totalTokens: entity.totalTokens,
+            });
+        }
+
+        return {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(entities),
+        };
+    } catch (err: any) {
+        context.error("Error querying token usage:", err?.message ?? err);
+        return {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ error: "Failed to query token usage" }),
+        };
+    }
+}
+
+/**
+ * Returns distinct skill, test, and branch values from the table.
+ * GET /api/token-usage/filters
+ */
+async function getTokenUsageFilters(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+    logRequestIdentity(request, context, "getTokenUsageFilters");
+
+    try {
+        const tableClient = getTokenUsageTableClient();
+        const skills = new Set<string>();
+        const tests = new Set<string>();
+        const branches = new Set<string>();
+
+        for await (const entity of tableClient.listEntities({
+            queryOptions: { select: ["skill", "testName", "branch"] },
+        })) {
+            if (entity.skill) skills.add(entity.skill as string);
+            if (entity.testName) tests.add(entity.testName as string);
+            if (entity.branch) branches.add(entity.branch as string);
+        }
+
+        return {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                skills: [...skills].sort(),
+                tests: [...tests].sort(),
+                branches: [...branches].sort(),
+            }),
+        };
+    } catch (err: any) {
+        context.error("Error querying token usage filters:", err?.message ?? err);
+        return {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ error: "Failed to query token usage filters" }),
+        };
+    }
+}
+
+app.http("getTokenUsage", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    route: "token-usage",
+    handler: getTokenUsage,
+});
+
+app.http("getTokenUsageFilters", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    route: "token-usage/filters",
+    handler: getTokenUsageFilters,
+});

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -17,6 +17,7 @@
   <nav class="site-nav" role="navigation" aria-label="Main navigation">
     <a href="/" class="site-nav-link active" aria-current="page">Dashboard</a>
     <a href="/integration-tests.html" class="site-nav-link">Integration Tests</a>
+    <a href="/token-usage.html" class="site-nav-link">Token Usage</a>
     <a href="/nightly-runs.html" class="site-nav-link">Nightly Runs</a>
     <a href="/performance-dashboard.html" class="site-nav-link">MSBench Performance Dashboard</a>
     <a href="/msbench-nightly-runs.html" class="site-nav-link">MSBench Nightly Runs</a>

--- a/dashboard/infra/main.bicep
+++ b/dashboard/infra/main.bicep
@@ -21,6 +21,9 @@ param msbenchReportsContainerName string = 'msbench-reports'
 @description('Name of the Azure Table that stores integration-test token usage history.')
 param tokenUsageTableName string = 'integrationtokenusage'
 
+@description('Principal (object) ID of the user-assigned managed identity used by the integration test pipeline to write token usage rows (skillcitestidentity).')
+param ciTestIdentityPrincipalId string = '531282f7-49cb-4149-af74-6c84a5270e87'
+
 var tags = {
   'azd-env-name': environmentName
   skipDelete: true
@@ -48,6 +51,8 @@ module identity './modules/managed-identity.bicep' = {
 //
 // The dashboard MI (identity) is also granted Storage Table Data Reader on the integration-reports
 // storage account (see storage.bicep) so it can read integration-test token usage history.
+// The integration test pipeline identity (ciTestIdentityName) is granted Storage Table Data
+// Contributor on that same account (see storage.bicep) so the pipeline can write token usage rows.
 //
 // The sync MI (syncIdentity) has the following permissions to the msbenchnightlydata storage account:
 // - Storage Blob Data Reader: read blobs in any container (read eval_report.json files for syncing).
@@ -71,6 +76,7 @@ module storage './modules/storage.bicep' = {
     environmentName: environmentName
     principalId: identity.outputs.identityPrincipalId
     tokenUsageTableName: tokenUsageTableName
+    ciTestIdentityPrincipalId: ciTestIdentityPrincipalId
   }
 }
 

--- a/dashboard/infra/main.bicep
+++ b/dashboard/infra/main.bicep
@@ -18,6 +18,9 @@ param msbenchEvalTableName string = 'msbenchevalmetrics'
 @description('Name of the MSBench reports blob container.')
 param msbenchReportsContainerName string = 'msbench-reports'
 
+@description('Name of the Azure Table that stores integration-test token usage history.')
+param tokenUsageTableName string = 'integrationtokenusage'
+
 var tags = {
   'azd-env-name': environmentName
   skipDelete: true
@@ -43,6 +46,9 @@ module identity './modules/managed-identity.bicep' = {
 // - Storage Blob Data Reader: read blobs in any container (read MSBench metrics from eval_report.json).
 // - Storage Table Data Reader: read entities in any table (read MSBench eval metrics from msbenchevalmetrics table).
 //
+// The dashboard MI (identity) is also granted Storage Table Data Reader on the integration-reports
+// storage account (see storage.bicep) so it can read integration-test token usage history.
+//
 // The sync MI (syncIdentity) has the following permissions to the msbenchnightlydata storage account:
 // - Storage Blob Data Reader: read blobs in any container (read eval_report.json files for syncing).
 // - Storage Table Data Contributor: read/write entities in any table (write MSBench eval metrics to msbenchevalmetrics table).
@@ -64,6 +70,7 @@ module storage './modules/storage.bicep' = {
     tags: tags
     environmentName: environmentName
     principalId: identity.outputs.identityPrincipalId
+    tokenUsageTableName: tokenUsageTableName
   }
 }
 
@@ -85,6 +92,7 @@ module functionApp './modules/function-app.bicep' = {
     userAssignedIdentityId: identity.outputs.identityId
     userAssignedIdentityClientId: identity.outputs.identityClientId
     storageAccountName: storage.outputs.storageAccountName
+    tokenUsageTableName: storage.outputs.tokenUsageTableName
     msbenchStorageAccountName: msbenchStorageAccountName
     msbenchEvalTableName: msbenchEvalTableName
     msbenchReportsContainerName: msbenchReportsContainerName

--- a/dashboard/infra/modules/function-app.bicep
+++ b/dashboard/infra/modules/function-app.bicep
@@ -18,6 +18,9 @@ param userAssignedIdentityClientId string
 @description('Name of the storage account for integration reports.')
 param storageAccountName string
 
+@description('Name of the Azure Table that stores integration-test token usage history.')
+param tokenUsageTableName string
+
 @description('Application Insights connection string for monitoring.')
 param appInsightsConnectionString string
 
@@ -114,6 +117,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
         { name: 'AZURE_CLIENT_ID', value: userAssignedIdentityClientId }
         { name: 'STORAGE_ACCOUNT_NAME', value: storageAccountName }
+        { name: 'TOKEN_USAGE_TABLE_NAME', value: tokenUsageTableName }
         { name: 'MSBENCH_STORAGE_ACCOUNT', value: msbenchStorageAccountName }
         { name: 'MSBENCH_REPORTS_CONTAINER', value: msbenchReportsContainerName }
         { name: 'MSBENCH_EVAL_TABLE_NAME', value: msbenchEvalTableName }

--- a/dashboard/infra/modules/storage.bicep
+++ b/dashboard/infra/modules/storage.bicep
@@ -12,9 +12,13 @@ param environmentName string
 @description('Principal ID of the managed identity to assign the Storage Blob Data Reader role.')
 param principalId string
 
+@description('Name of the Azure Table that stores integration-test token usage history.')
+param tokenUsageTableName string = 'integrationtokenusage'
+
 var resourceSuffix = take(uniqueString(subscription().id, resourceGroup().name, environmentName), 6)
 var storagePrefix = take(replace(environmentName, '-', ''), 14)
 var storageBlobDataReaderRoleId = '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
+var storageTableDataReaderRoleId = '76199698-9eea-4c19-bc75-cec21354c6b6'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: 'str${storagePrefix}${resourceSuffix}'
@@ -79,6 +83,16 @@ resource nonIntegrationContainer 'Microsoft.Storage/storageAccounts/blobServices
   name: 'non-integration'
 }
 
+resource tableServices 'Microsoft.Storage/storageAccounts/tableServices@2023-05-01' = {
+  parent: storageAccount
+  name: 'default'
+}
+
+resource tokenUsageTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
+  parent: tableServices
+  name: tokenUsageTableName
+}
+
 resource storageBlobDataReaderRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(storageAccount.id, principalId, storageBlobDataReaderRoleId)
   scope: storageAccount
@@ -89,4 +103,16 @@ resource storageBlobDataReaderRole 'Microsoft.Authorization/roleAssignments@2022
   }
 }
 
+// Allows the dashboard Function App identity to read token-usage entities from the table.
+resource storageTableDataReaderRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, principalId, storageTableDataReaderRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataReaderRoleId)
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 output storageAccountName string = storageAccount.name
+output tokenUsageTableName string = tokenUsageTable.name

--- a/dashboard/infra/modules/storage.bicep
+++ b/dashboard/infra/modules/storage.bicep
@@ -15,10 +15,14 @@ param principalId string
 @description('Name of the Azure Table that stores integration-test token usage history.')
 param tokenUsageTableName string = 'integrationtokenusage'
 
+@description('Principal (object) ID of the user-assigned managed identity used by the integration test pipeline to write token usage rows (skillcitestidentity in the skillcitest resource group, GithubCopilotForAzure-Testing subscription).')
+param ciTestIdentityPrincipalId string = '531282f7-49cb-4149-af74-6c84a5270e87'
+
 var resourceSuffix = take(uniqueString(subscription().id, resourceGroup().name, environmentName), 6)
 var storagePrefix = take(replace(environmentName, '-', ''), 14)
 var storageBlobDataReaderRoleId = '2a2b9908-6ea1-4ae2-8e65-a410df84e7d1'
 var storageTableDataReaderRoleId = '76199698-9eea-4c19-bc75-cec21354c6b6'
+var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
 
 resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
   name: 'str${storagePrefix}${resourceSuffix}'
@@ -110,6 +114,17 @@ resource storageTableDataReaderRole 'Microsoft.Authorization/roleAssignments@202
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataReaderRoleId)
     principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Allows the integration test pipeline identity to write token-usage entities to the table.
+resource storageTableDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, ciTestIdentityPrincipalId, storageTableDataContributorRoleId)
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataContributorRoleId)
+    principalId: ciTestIdentityPrincipalId
     principalType: 'ServicePrincipal'
   }
 }

--- a/dashboard/integration-tests.html
+++ b/dashboard/integration-tests.html
@@ -16,6 +16,7 @@
     <nav class="site-nav" role="navigation" aria-label="Main navigation">
         <a href="/" class="site-nav-link">Dashboard</a>
         <a href="/integration-tests.html" class="site-nav-link active" aria-current="page">Integration Tests</a>
+        <a href="/token-usage.html" class="site-nav-link">Token Usage</a>
         <a href="/nightly-runs.html" class="site-nav-link">Nightly Runs</a>
         <a href="/performance-dashboard.html" class="site-nav-link">MSBench Performance Dashboard</a>
         <a href="/msbench-nightly-runs.html" class="site-nav-link">MSBench Nightly Runs</a>

--- a/dashboard/msbench-nightly-runs.html
+++ b/dashboard/msbench-nightly-runs.html
@@ -16,6 +16,7 @@
     <nav class="site-nav" role="navigation" aria-label="Main navigation">
         <a href="/" class="site-nav-link">Dashboard</a>
         <a href="/integration-tests.html" class="site-nav-link">Integration Tests</a>
+        <a href="/token-usage.html" class="site-nav-link">Token Usage</a>
         <a href="/nightly-runs.html" class="site-nav-link">Nightly Runs</a>
         <a href="/performance-dashboard.html" class="site-nav-link">MSBench Performance Dashboard</a>
         <a href="/msbench-nightly-runs.html" class="site-nav-link active" aria-current="page">MSBench Nightly Runs</a>

--- a/dashboard/performance-dashboard.html
+++ b/dashboard/performance-dashboard.html
@@ -16,6 +16,7 @@
     <nav class="site-nav" role="navigation" aria-label="Main navigation">
         <a href="/" class="site-nav-link">Dashboard</a>
         <a href="/integration-tests.html" class="site-nav-link">Integration Tests</a>
+        <a href="/token-usage.html" class="site-nav-link">Token Usage</a>
         <a href="/nightly-runs.html" class="site-nav-link">Nightly Runs</a>
         <a href="/performance-dashboard.html" class="site-nav-link active" aria-current="page">MSBench Performance Dashboard</a>
         <a href="/msbench-nightly-runs.html" class="site-nav-link">MSBench Nightly Runs</a>

--- a/dashboard/src/token-usage/App.tsx
+++ b/dashboard/src/token-usage/App.tsx
@@ -1,0 +1,286 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+    LineChart,
+    Line,
+    XAxis,
+    YAxis,
+    CartesianGrid,
+    Tooltip,
+    Legend,
+    ResponsiveContainer,
+} from "recharts";
+
+interface TokenUsageRow {
+    skill: string;
+    testName: string;
+    branch: string;
+    runId: string;
+    runDate: string;
+    timestamp: string;
+    model: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+    totalTokens: number;
+}
+
+interface TokenUsageFilters {
+    skills: string[];
+    tests: string[];
+    branches: string[];
+}
+
+interface RunPoint {
+    run: string;
+    timestamp: string;
+    total: number;
+    rollingAvg: number;
+}
+
+/** Window size for the trailing rolling average series. */
+const ROLLING_WINDOW = 5;
+
+/** Short, stable label for a run on the time axis. */
+function runLabel(runDate: string, runId: string): string {
+    const shortId = runId && runId !== "unknown" ? runId.slice(-6) : "";
+    return shortId ? `${runDate} (${shortId})` : runDate;
+}
+
+export default function App() {
+    const [filters, setFilters] = useState<TokenUsageFilters>({ skills: [], tests: [], branches: [] });
+    const [selectedSkill, setSelectedSkill] = useState<string>("");
+    const [selectedTest, setSelectedTest] = useState<string>("");
+    const [selectedBranch, setSelectedBranch] = useState<string>("");
+    const [timeRange, setTimeRange] = useState<string>("30");
+    const [customStart, setCustomStart] = useState<string>("");
+    const [customEnd, setCustomEnd] = useState<string>("");
+    const [rows, setRows] = useState<TokenUsageRow[]>([]);
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState<string | null>(null);
+
+    const loadFilters = () =>
+        fetch("/api/token-usage/filters")
+            .then((res) => {
+                if (!res.ok) throw new Error(`API error: ${res.status}`);
+                return res.json();
+            })
+            .then((data: TokenUsageFilters) => setFilters(data))
+            .catch((err) => setError(err.message));
+
+    const loadRows = () => {
+        setLoading(true);
+        setError(null);
+
+        const params = new URLSearchParams();
+        if (selectedSkill) params.set("skill", selectedSkill);
+        if (selectedTest) params.set("test", selectedTest);
+        if (selectedBranch) params.set("branch", selectedBranch);
+
+        return fetch(`/api/token-usage?${params}`)
+            .then((res) => {
+                if (!res.ok) throw new Error(`API error: ${res.status}`);
+                return res.json();
+            })
+            .then((data: TokenUsageRow[]) => setRows(data))
+            .catch((err) => setError(err.message))
+            .finally(() => setLoading(false));
+    };
+
+    useEffect(() => {
+        loadFilters();
+    }, []);
+
+    useEffect(() => {
+        loadRows();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [selectedSkill, selectedTest, selectedBranch]);
+
+    // Filter rows by the selected time range (based on runDate).
+    const filteredRows = useMemo(() => {
+        if (timeRange === "all") return rows;
+        let startDate: string;
+        let endDate: string;
+        if (timeRange === "custom") {
+            if (!customStart && !customEnd) return rows;
+            startDate = customStart;
+            endDate = customEnd;
+        } else {
+            const days = parseInt(timeRange, 10);
+            const now = new Date();
+            now.setDate(now.getDate() - days);
+            startDate = now.toISOString().slice(0, 10);
+            endDate = "";
+        }
+        return rows.filter((row) => {
+            const date = row.runDate || (row.timestamp ? row.timestamp.slice(0, 10) : "");
+            if (startDate && date < startDate) return false;
+            if (endDate && date > endDate) return false;
+            return true;
+        });
+    }, [rows, timeRange, customStart, customEnd]);
+
+    // Aggregate total tokens per run (across the currently filtered rows),
+    // ordered over time, then compute a trailing rolling average.
+    const chartData = useMemo<RunPoint[]>(() => {
+        const byRun = new Map<string, { total: number; timestamp: string; runDate: string; runId: string }>();
+        for (const row of filteredRows) {
+            const runId = row.runId || "unknown";
+            const runDate = row.runDate || (row.timestamp ? row.timestamp.slice(0, 10) : "");
+            const ts = row.timestamp || `${runDate}T00:00:00.000Z`;
+            const existing = byRun.get(runId);
+            const total = Number(row.totalTokens) || 0;
+            if (existing) {
+                existing.total += total;
+                if (ts < existing.timestamp) existing.timestamp = ts;
+            } else {
+                byRun.set(runId, { total, timestamp: ts, runDate, runId });
+            }
+        }
+
+        const ordered = [...byRun.values()].sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+        return ordered.map((run, i) => {
+            const windowStart = Math.max(0, i - (ROLLING_WINDOW - 1));
+            const window = ordered.slice(windowStart, i + 1);
+            const rollingAvg = window.reduce((sum, r) => sum + r.total, 0) / window.length;
+            return {
+                run: runLabel(run.runDate, run.runId),
+                timestamp: run.timestamp,
+                total: run.total,
+                rollingAvg: Math.round(rollingAvg),
+            };
+        });
+    }, [filteredRows]);
+
+    return (
+        <div className="pd-dashboard" id="main">
+            <header className="pd-header">
+                <h1>Integration Test Token Usage Over Time</h1>
+            </header>
+
+            <div className="pd-filters">
+                <label className="pd-filter">
+                    <span>Skill</span>
+                    <select value={selectedSkill} onChange={(e) => setSelectedSkill(e.target.value)}>
+                        <option value="">All Skills</option>
+                        {filters.skills.map((s) => (
+                            <option key={s} value={s}>
+                                {s}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+
+                <label className="pd-filter">
+                    <span>Test</span>
+                    <select value={selectedTest} onChange={(e) => setSelectedTest(e.target.value)}>
+                        <option value="">All Tests</option>
+                        {filters.tests.map((t) => (
+                            <option key={t} value={t}>
+                                {t}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+
+                <label className="pd-filter">
+                    <span>Branch</span>
+                    <select value={selectedBranch} onChange={(e) => setSelectedBranch(e.target.value)}>
+                        <option value="">All Branches</option>
+                        {filters.branches.map((b) => (
+                            <option key={b} value={b}>
+                                {b}
+                            </option>
+                        ))}
+                    </select>
+                </label>
+
+                <label className="pd-filter">
+                    <span>Time Range</span>
+                    <select value={timeRange} onChange={(e) => setTimeRange(e.target.value)}>
+                        <option value="7">Past 7 days</option>
+                        <option value="14">Past 14 days</option>
+                        <option value="30">Past 30 days</option>
+                        <option value="all">All time</option>
+                        <option value="custom">Custom range</option>
+                    </select>
+                </label>
+
+                {timeRange === "custom" && (
+                    <div className="pd-custom-range">
+                        <label className="pd-filter">
+                            <span>Start</span>
+                            <input
+                                type="date"
+                                className="pd-date-input"
+                                value={customStart}
+                                onChange={(e) => setCustomStart(e.target.value)}
+                            />
+                        </label>
+                        <label className="pd-filter">
+                            <span>End</span>
+                            <input
+                                type="date"
+                                className="pd-date-input"
+                                value={customEnd}
+                                onChange={(e) => setCustomEnd(e.target.value)}
+                            />
+                        </label>
+                    </div>
+                )}
+            </div>
+
+            {error && <p className="pd-error">Error: {error}</p>}
+
+            {loading ? (
+                <p className="pd-loading">Loading token usage…</p>
+            ) : chartData.length === 0 ? (
+                <p className="pd-empty">No token usage data available for the selected filters.</p>
+            ) : (
+                <div className="pd-charts">
+                    <section className="pd-chart-section">
+                        <h2>Total Tokens per Run</h2>
+                        <ResponsiveContainer width="100%" height={400}>
+                            <LineChart data={chartData} margin={{ top: 16, right: 24, bottom: 48, left: 16 }}>
+                                <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                                <XAxis
+                                    dataKey="run"
+                                    angle={-30}
+                                    textAnchor="end"
+                                    height={70}
+                                    tick={{ fontSize: 11 }}
+                                />
+                                <YAxis tick={{ fontSize: 11 }} width={80} />
+                                <Tooltip
+                                    formatter={(value: number, name: string) => [
+                                        value.toLocaleString(),
+                                        name,
+                                    ]}
+                                />
+                                <Legend />
+                                <Line
+                                    type="monotone"
+                                    dataKey="total"
+                                    name="Total Tokens"
+                                    stroke="#3b82f6"
+                                    strokeWidth={2}
+                                    dot={{ r: 2 }}
+                                />
+                                <Line
+                                    type="monotone"
+                                    dataKey="rollingAvg"
+                                    name={`Rolling Avg (last ${ROLLING_WINDOW} runs)`}
+                                    stroke="#f59e0b"
+                                    strokeWidth={2}
+                                    strokeDasharray="6 4"
+                                    dot={false}
+                                />
+                            </LineChart>
+                        </ResponsiveContainer>
+                    </section>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/dashboard/src/token-usage/App.tsx
+++ b/dashboard/src/token-usage/App.tsx
@@ -16,7 +16,7 @@ interface TokenUsageRow {
     branch: string;
     runId: string;
     runDate: string;
-    timestamp: string;
+    runTimestamp: string;
     model: string;
     inputTokens: number;
     outputTokens: number;
@@ -113,7 +113,7 @@ export default function App() {
             endDate = "";
         }
         return rows.filter((row) => {
-            const date = row.runDate || (row.timestamp ? row.timestamp.slice(0, 10) : "");
+            const date = row.runDate || (row.runTimestamp ? row.runTimestamp.slice(0, 10) : "");
             if (startDate && date < startDate) return false;
             if (endDate && date > endDate) return false;
             return true;
@@ -126,8 +126,8 @@ export default function App() {
         const byRun = new Map<string, { total: number; timestamp: string; runDate: string; runId: string }>();
         for (const row of filteredRows) {
             const runId = row.runId || "unknown";
-            const runDate = row.runDate || (row.timestamp ? row.timestamp.slice(0, 10) : "");
-            const ts = row.timestamp || `${runDate}T00:00:00.000Z`;
+            const runDate = row.runDate || (row.runTimestamp ? row.runTimestamp.slice(0, 10) : "");
+            const ts = row.runTimestamp || `${runDate}T00:00:00.000Z`;
             const existing = byRun.get(runId);
             const total = Number(row.totalTokens) || 0;
             if (existing) {

--- a/dashboard/src/token-usage/main.tsx
+++ b/dashboard/src/token-usage/main.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import "../performance-dashboard/performance-dashboard.css";
+import "./token-usage.css";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+    <React.StrictMode>
+        <App />
+    </React.StrictMode>
+);

--- a/dashboard/src/token-usage/token-usage.css
+++ b/dashboard/src/token-usage/token-usage.css
@@ -1,0 +1,9 @@
+/* ── Token Usage page ───────────────────────────────────────────────────── */
+/* Layout and controls are shared with the MSBench Performance Dashboard
+   (pd- classes). This file holds token-usage-specific overrides only. */
+
+.pd-chart-section h2 {
+    margin: 0 0 0.75rem;
+    font-size: 1.1rem;
+    font-weight: 600;
+}

--- a/dashboard/token-usage.html
+++ b/dashboard/token-usage.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy"
         content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; connect-src 'self'">
-    <title>Nightly Runs</title>
+    <title>Integration Test Token Usage</title>
     <link rel="stylesheet" href="assets/style.css">
 </head>
 
@@ -16,14 +16,14 @@
     <nav class="site-nav" role="navigation" aria-label="Main navigation">
         <a href="/" class="site-nav-link">Dashboard</a>
         <a href="/integration-tests.html" class="site-nav-link">Integration Tests</a>
-        <a href="/token-usage.html" class="site-nav-link">Token Usage</a>
-        <a href="/nightly-runs.html" class="site-nav-link active" aria-current="page">Nightly Runs</a>
+        <a href="/token-usage.html" class="site-nav-link active" aria-current="page">Token Usage</a>
+        <a href="/nightly-runs.html" class="site-nav-link">Nightly Runs</a>
         <a href="/performance-dashboard.html" class="site-nav-link">MSBench Performance Dashboard</a>
         <a href="/msbench-nightly-runs.html" class="site-nav-link">MSBench Nightly Runs</a>
     </nav>
 
     <div id="root"></div>
-    <script type="module" src="/src/nightly-runs/main.tsx"></script>
+    <script type="module" src="/src/token-usage/main.tsx"></script>
 
     <noscript>
         <p class="noscript-message">JavaScript is required to render this page.</p>

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
             input: {
                 main: resolve(__dirname, "index.html"),
                 "integration-tests": resolve(__dirname, "integration-tests.html"),
+                "token-usage": resolve(__dirname, "token-usage.html"),
                 "nightly-runs": resolve(__dirname, "nightly-runs.html"),
                 "performance-dashboard": resolve(__dirname, "performance-dashboard.html"),
                 "msbench-nightly-runs": resolve(__dirname, "msbench-nightly-runs.html"),

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -8,6 +8,7 @@
       "name": "azure-copilot-skills-tests",
       "version": "1.0.0",
       "devDependencies": {
+        "@azure/data-tables": "^13.3.2",
         "@azure/identity": "^4.13.1",
         "@eslint/js": "^10.0.0",
         "@github/copilot": "1.0.49",
@@ -81,6 +82,19 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@azure/core-paging": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@azure/core-paging/-/core-paging-1.6.2.tgz",
+      "integrity": "sha512-YKWi9YuCU04B55h25cnOYZHxXYtEvQEbKST5vqRga7hWY9ydd3FZHdeQF8pyh+acWZvppw13M/LMGx0LABUVMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@azure/core-rest-pipeline": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/@azure/core-rest-pipeline/-/core-rest-pipeline-1.22.2.tgz",
@@ -123,6 +137,41 @@
         "@azure/abort-controller": "^2.1.2",
         "@typespec/ts-http-runtime": "^0.3.0",
         "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/core-xml": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@azure/core-xml/-/core-xml-1.5.1.tgz",
+      "integrity": "sha512-xcNRHqCoSp4AunOALEae6A8f3qATb83gSrm31Iqb01OzblvC3/W/bfXozcq78EzIdzZzuH1bZ2NvRR0TdX709w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.9",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@azure/data-tables": {
+      "version": "13.3.2",
+      "resolved": "https://registry.npmjs.org/@azure/data-tables/-/data-tables-13.3.2.tgz",
+      "integrity": "sha512-PZ8e4SnCpTQEbQ1P+CK6NR7Vhb86Jw1S1qJi2IcF1ij4qiPX2b4vIemwNPkYg/gZGMqKbxkPvGRpRmEbBYdXuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@azure/core-auth": "^1.9.0",
+        "@azure/core-client": "^1.9.2",
+        "@azure/core-paging": "^1.6.2",
+        "@azure/core-rest-pipeline": "^1.19.0",
+        "@azure/core-tracing": "^1.2.0",
+        "@azure/core-util": "^1.11.0",
+        "@azure/core-xml": "^1.4.4",
+        "@azure/logger": "^1.1.4",
+        "tslib": "^2.8.1"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1881,6 +1930,19 @@
         "@emnapi/runtime": "^1.4.3",
         "@tybys/wasm-util": "^0.10.0"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.1.tgz",
+      "integrity": "sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@package-json/types": {
       "version": "0.0.12",
@@ -4201,6 +4263,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -6190,6 +6292,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -6855,6 +6973,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -7547,6 +7678,22 @@
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/tests/package.json
+++ b/tests/package.json
@@ -14,6 +14,7 @@
     "test:skill": "node scripts/run-tests.js skill",
     "test:vally": "npx tsx ./run-vally-test.ts",
     "report": "npx tsx scripts/generate-test-reports.ts",
+    "upload:token-usage": "npx tsx scripts/upload-token-usage.ts",
     "results": "node scripts/show-test-results.js",
     "update:mcp-tool-snapshot": "node scripts/update-mcp-tool-snapshot.js",
     "update:snapshots": "node scripts/update-snapshots.js",
@@ -27,6 +28,7 @@
     "node": "^20.19.0 || ^22.13.0 || >=24"
   },
   "devDependencies": {
+    "@azure/data-tables": "^13.3.2",
     "@azure/identity": "^4.13.1",
     "@eslint/js": "^10.0.0",
     "@github/copilot": "1.0.49",

--- a/tests/scripts/upload-token-usage.ts
+++ b/tests/scripts/upload-token-usage.ts
@@ -239,7 +239,7 @@ async function main(): Promise<void> {
         branch,
         runId,
         runDate,
-        timestamp: usage.timestamp,
+        runTimestamp: usage.timestamp,
         model: usage.model,
         inputTokens: usage.inputTokens,
         outputTokens: usage.outputTokens,

--- a/tests/scripts/upload-token-usage.ts
+++ b/tests/scripts/upload-token-usage.ts
@@ -100,6 +100,43 @@ function isPermissionError(err: unknown): boolean {
   return e?.statusCode === 403 || e?.code === "AuthorizationPermissionMismatch";
 }
 
+/**
+ * Render an Azure/REST error with the fields that actually help diagnose it:
+ * the OData error code, HTTP status, and the service message. The Azure SDK
+ * surfaces these as `code` / `statusCode` on the error; the readable message
+ * may live on `.message` or in the parsed `.details` body.
+ */
+function formatAzureError(err: unknown): string {
+  const e = err as {
+    code?: string;
+    statusCode?: number;
+    message?: string;
+    details?: { odataError?: { message?: { value?: string } } };
+  };
+  const parts: string[] = [];
+  if (e?.code) parts.push(`code=${e.code}`);
+  if (typeof e?.statusCode === "number") parts.push(`statusCode=${e.statusCode}`);
+  const serviceMessage = e?.details?.odataError?.message?.value || e?.message;
+  if (serviceMessage) parts.push(`message=${serviceMessage}`);
+  return parts.length > 0 ? parts.join(" ") : String(err);
+}
+
+/**
+ * Validate a name against the Azure Table naming rules and throw an actionable
+ * error if it is invalid. Table names must be alphanumeric only, may not start
+ * with a digit, and must be 3-63 characters long. Violations otherwise surface
+ * from the service as an opaque "InvalidResourceName" error.
+ */
+function assertValidTableName(name: string): void {
+  if (!/^[A-Za-z][A-Za-z0-9]{2,62}$/.test(name)) {
+    throw new Error(
+      `Invalid TOKEN_USAGE_TABLE_NAME '${name}'. Azure Table names must be ` +
+        "alphanumeric only (no hyphens, underscores, or dots), must start with a " +
+        "letter, and be 3-63 characters long (e.g. 'integrationtokenusage').",
+    );
+  }
+}
+
 /** Recursively find all token-summary.jsonl files under a directory. */
 function findTokenSummaryFiles(dir: string): string[] {
   const found: string[] = [];
@@ -191,6 +228,9 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Fail fast with an actionable message rather than an opaque service error.
+  assertValidTableName(tableName);
+
   const files = findTokenSummaryFiles(reportsDir);
   if (files.length === 0) {
     console.log(`No ${TOKEN_SUMMARY_FILENAME} files found under ${reportsDir}; nothing to upload.`);
@@ -209,10 +249,12 @@ async function main(): Promise<void> {
   }
 
   const credential = new DefaultAzureCredential();
-  const tableClient = new TableClient(
-    `https://${storageAccount}.table.core.windows.net`,
-    tableName,
-    credential,
+  const tableEndpoint = `https://${storageAccount}.table.core.windows.net`;
+  const tableClient = new TableClient(tableEndpoint, tableName, credential);
+
+  console.log(
+    `Uploading token usage to ${tableEndpoint} table='${tableName}' ` +
+      `(skill='${skill}', branch='${branch}', run='${runId}', rows=${aggregated.length}).`,
   );
 
   // Ensure the table exists (idempotent; ignores "already exists").
@@ -221,6 +263,7 @@ async function main(): Promise<void> {
   } catch (err) {
     const statusCode = (err as { statusCode?: number })?.statusCode;
     if (statusCode !== 409) {
+      console.error(`createTable failed for table='${tableName}': ${formatAzureError(err)}`);
       throw err;
     }
   }
@@ -229,26 +272,35 @@ async function main(): Promise<void> {
   for (const usage of aggregated) {
     const totalTokens = usage.inputTokens + usage.outputTokens;
     const runDate = usage.timestamp.slice(0, 10);
+    const partitionKey = sanitizeKey(skill);
     const rowKey = buildRowKey(branch, runId, usage.testName);
-    await tableClient.upsertEntity(
-      {
-        partitionKey: sanitizeKey(skill),
-        rowKey,
-        skill,
-        testName: usage.testName,
-        branch,
-        runId,
-        runDate,
-        runTimestamp: usage.timestamp,
-        model: usage.model,
-        inputTokens: usage.inputTokens,
-        outputTokens: usage.outputTokens,
-        cacheReadTokens: usage.cacheReadTokens,
-        cacheWriteTokens: usage.cacheWriteTokens,
-        totalTokens,
-      },
-      "Replace",
-    );
+    try {
+      await tableClient.upsertEntity(
+        {
+          partitionKey,
+          rowKey,
+          skill,
+          testName: usage.testName,
+          branch,
+          runId,
+          runDate,
+          runTimestamp: usage.timestamp,
+          model: usage.model,
+          inputTokens: usage.inputTokens,
+          outputTokens: usage.outputTokens,
+          cacheReadTokens: usage.cacheReadTokens,
+          cacheWriteTokens: usage.cacheWriteTokens,
+          totalTokens,
+        },
+        "Replace",
+      );
+    } catch (err) {
+      console.error(
+        `upsertEntity failed for table='${tableName}' ` +
+          `partitionKey='${partitionKey}' rowKey='${rowKey}': ${formatAzureError(err)}`,
+      );
+      throw err;
+    }
     uploaded++;
   }
 
@@ -267,6 +319,6 @@ main().catch((err) => {
     );
     return;
   }
-  console.error("Failed to upload token usage:", err?.message || err);
+  console.error("Failed to upload token usage:", formatAzureError(err));
   process.exit(1);
 });

--- a/tests/scripts/upload-token-usage.ts
+++ b/tests/scripts/upload-token-usage.ts
@@ -1,0 +1,272 @@
+#!/usr/bin/env tsx
+
+/**
+ * Token Usage Uploader
+ *
+ * Reads the per-test token usage produced by the integration test run
+ * (token-summary.jsonl files under the reports directory) and uploads one
+ * aggregated row per test to an Azure Table. The table provides the durable,
+ * queryable history that powers the dashboard's "token usage over time" page.
+ *
+ * Granularity: one row per test, per branch, per run. Multiple records for the
+ * same test within a run (e.g. retries) are summed into a single row.
+ *
+ * Authentication uses DefaultAzureCredential, which picks up the Azure session
+ * established earlier in the workflow (azure/login / az login).
+ *
+ * Required environment variables:
+ *   TOKEN_USAGE_STORAGE_ACCOUNT  Storage account that hosts the table.
+ *   TOKEN_USAGE_TABLE_NAME       Name of the Azure Table (e.g. integrationtokenusage).
+ *   SKILL                        Skill under test (becomes the PartitionKey).
+ *   BRANCH                       Git branch (e.g. github.ref_name).
+ *   RUN_ID                       Unique run identifier (e.g. github.run_id).
+ *
+ * Optional:
+ *   TOKEN_USAGE_REPORTS_DIR      Reports directory to scan (default: tests/reports).
+ *
+ * The script is a no-op (exit 0) when the storage account/table is not
+ * configured or when no token-summary.jsonl files are found, so it can be wired
+ * unconditionally into pipelines without breaking runs that lack the data.
+ */
+
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { TableClient } from "@azure/data-tables";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TOKEN_SUMMARY_FILENAME = "token-summary.jsonl";
+
+/** A single record as written by agent-runner.ts writeTokenUsageJson. */
+interface TokenSummaryRecord {
+    testName: string;
+    timestamp?: string;
+    model?: string;
+    inputTokens?: number;
+    outputTokens?: number;
+    cacheReadTokens?: number;
+    cacheWriteTokens?: number;
+}
+
+/** One aggregated, table-ready row for a single test within a run. */
+interface AggregatedUsage {
+    testName: string;
+    model: string;
+    timestamp: string;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+}
+
+/**
+ * Sanitize a value for use in an Azure Table key. Table keys cannot contain
+ * the characters / \ # ? or control characters, and are length-limited.
+ */
+function sanitizeKey(value: string): string {
+  let result = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0)!;
+    const isForbidden = ch === "/" || ch === "\\" || ch === "#" || ch === "?";
+    const isControl = code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+    result += isForbidden || isControl ? "-" : ch;
+  }
+  return result.substring(0, 700);
+}
+
+/**
+ * Build a collision-resistant RowKey for a (branch, runId, testName) tuple.
+ * Sanitization can map distinct tuples to the same string (e.g. "a/b" and
+ * "a-b") and long names get truncated, so a short hash of the original,
+ * unsanitized tuple is appended to keep otherwise-colliding rows distinct.
+ */
+function buildRowKey(branch: string, runId: string, testName: string): string {
+  const hash = crypto
+    .createHash("sha256")
+    .update(`${branch}\u0000${runId}\u0000${testName}`)
+    .digest("hex")
+    .slice(0, 16);
+  const prefix = sanitizeKey(`${branch}__${runId}__${testName}`).substring(0, 600);
+  return `${prefix}__${hash}`;
+}
+
+/** True when an Azure error indicates the caller lacks table write permission. */
+function isPermissionError(err: unknown): boolean {
+  const e = err as { statusCode?: number; code?: string };
+  return e?.statusCode === 403 || e?.code === "AuthorizationPermissionMismatch";
+}
+
+/** Recursively find all token-summary.jsonl files under a directory. */
+function findTokenSummaryFiles(dir: string): string[] {
+  const found: string[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...findTokenSummaryFiles(full));
+    } else if (entry.isFile() && entry.name === TOKEN_SUMMARY_FILENAME) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+/** Parse a token-summary.jsonl file into individual records. */
+function parseTokenSummary(filePath: string): TokenSummaryRecord[] {
+  const records: TokenSummaryRecord[] = [];
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return records;
+  }
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const parsed = JSON.parse(line);
+      if (parsed && typeof parsed.testName === "string") {
+        records.push(parsed as TokenSummaryRecord);
+      }
+    } catch {
+      // skip malformed lines
+    }
+  }
+  return records;
+}
+
+/** Sum multiple records per test into a single aggregated row. */
+function aggregateByTest(records: TokenSummaryRecord[]): AggregatedUsage[] {
+  const byTest = new Map<string, AggregatedUsage>();
+  for (const r of records) {
+    const existing = byTest.get(r.testName);
+    const input = Number(r.inputTokens) || 0;
+    const output = Number(r.outputTokens) || 0;
+    const cacheRead = Number(r.cacheReadTokens) || 0;
+    const cacheWrite = Number(r.cacheWriteTokens) || 0;
+    if (existing) {
+      existing.inputTokens += input;
+      existing.outputTokens += output;
+      existing.cacheReadTokens += cacheRead;
+      existing.cacheWriteTokens += cacheWrite;
+      if (r.timestamp && r.timestamp > existing.timestamp) {
+        existing.timestamp = r.timestamp;
+        if (r.model) existing.model = r.model;
+      }
+    } else {
+      byTest.set(r.testName, {
+        testName: r.testName,
+        model: r.model || "unknown",
+        timestamp: r.timestamp || new Date().toISOString(),
+        inputTokens: input,
+        outputTokens: output,
+        cacheReadTokens: cacheRead,
+        cacheWriteTokens: cacheWrite,
+      });
+    }
+  }
+  return [...byTest.values()];
+}
+
+async function main(): Promise<void> {
+  const storageAccount = process.env.TOKEN_USAGE_STORAGE_ACCOUNT;
+  const tableName = process.env.TOKEN_USAGE_TABLE_NAME;
+  const skill = process.env.SKILL || "unknown";
+  const branch = process.env.BRANCH || "unknown";
+  const runId = process.env.RUN_ID || "unknown";
+  const reportsDir = process.env.TOKEN_USAGE_REPORTS_DIR || path.resolve(__dirname, "../reports");
+
+  if (!storageAccount || !tableName) {
+    console.log(
+      "TOKEN_USAGE_STORAGE_ACCOUNT or TOKEN_USAGE_TABLE_NAME not set; skipping token usage upload.",
+    );
+    return;
+  }
+
+  const files = findTokenSummaryFiles(reportsDir);
+  if (files.length === 0) {
+    console.log(`No ${TOKEN_SUMMARY_FILENAME} files found under ${reportsDir}; nothing to upload.`);
+    return;
+  }
+
+  const allRecords: TokenSummaryRecord[] = [];
+  for (const file of files) {
+    allRecords.push(...parseTokenSummary(file));
+  }
+
+  const aggregated = aggregateByTest(allRecords);
+  if (aggregated.length === 0) {
+    console.log("No valid token usage records found; nothing to upload.");
+    return;
+  }
+
+  const credential = new DefaultAzureCredential();
+  const tableClient = new TableClient(
+    `https://${storageAccount}.table.core.windows.net`,
+    tableName,
+    credential,
+  );
+
+  // Ensure the table exists (idempotent; ignores "already exists").
+  try {
+    await tableClient.createTable();
+  } catch (err) {
+    const statusCode = (err as { statusCode?: number })?.statusCode;
+    if (statusCode !== 409) {
+      throw err;
+    }
+  }
+
+  let uploaded = 0;
+  for (const usage of aggregated) {
+    const totalTokens = usage.inputTokens + usage.outputTokens;
+    const runDate = usage.timestamp.slice(0, 10);
+    const rowKey = buildRowKey(branch, runId, usage.testName);
+    await tableClient.upsertEntity(
+      {
+        partitionKey: sanitizeKey(skill),
+        rowKey,
+        skill,
+        testName: usage.testName,
+        branch,
+        runId,
+        runDate,
+        timestamp: usage.timestamp,
+        model: usage.model,
+        inputTokens: usage.inputTokens,
+        outputTokens: usage.outputTokens,
+        cacheReadTokens: usage.cacheReadTokens,
+        cacheWriteTokens: usage.cacheWriteTokens,
+        totalTokens,
+      },
+      "Replace",
+    );
+    uploaded++;
+  }
+
+  console.log(
+    `Uploaded ${uploaded} token usage row(s) for skill='${skill}', branch='${branch}', run='${runId}'.`,
+  );
+}
+
+main().catch((err) => {
+  // Token usage upload is auxiliary telemetry; a missing/incorrect table-write
+  // role assignment should surface a clear warning but must not fail the run.
+  if (isPermissionError(err)) {
+    console.warn(
+      "WARNING: Skipping token usage upload - the workflow identity lacks " +
+        "'Storage Table Data Contributor' on the storage account. Grant the role to enable uploads.",
+    );
+    return;
+  }
+  console.error("Failed to upload token usage:", err?.message || err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds a **Token Usage Over Time** section to the Skill Health Dashboard. Integration-test token consumption is stored in an Azure Table, uploaded directly by the integration test pipelines, exposed via Function App API endpoints, and visualized on a new dedicated dashboard page. The frontend never accesses the table directly.

## Approach

- **Storage**: New Azure Table (`integrationtokenusage`) in the existing integration-reports storage account, mirroring the existing msbench-eval-metrics table pattern.
- **Granularity**: one row **per test, per branch, per run**.
- **Producer**: integration test pipelines upload **directly** to the table via a small tsx script, authenticated through the existing Azure federated login. Token data already exists as `token-summary.jsonl` (written by `tests/utils/agent-runner.ts`).
- **Scope**: `test-all-integration.yml` (scheduled + manual) and `test-azure-deploy.yml` (when `publish-reports` is true).
- **Access**: the dashboard frontend calls new Function App API endpoints, matching the existing `getMsbenchEvalMetrics` pattern.
- **Frontend**: a brand-new dedicated page (`token-usage.html`).
- **Metrics**: total tokens (input+output) as the primary series, plus a rolling average of the last 5 runs.

## Table design

- `PartitionKey` = skill name; `RowKey` = sanitized `branch__runId__testName` plus a short SHA-256 suffix of the unsanitized tuple to guarantee uniqueness.
- Columns: `branch`, `runId`, `timestamp`, `runDate`, `skill`, `testName`, `model`, `inputTokens`, `outputTokens`, `cacheReadTokens`, `cacheWriteTokens`, `totalTokens`.
- Upsert (Replace) so re-runs/retries are idempotent.

## Changes

- **Infra (bicep)**: `storage.bicep` adds the table + `Storage Table Data Reader` role for the dashboard MI + output; `main.bicep` / `function-app.bicep` wire the table-name param and `TOKEN_USAGE_TABLE_NAME` app setting.
- **Pipeline uploader**: `tests/scripts/upload-token-usage.ts` reads `token-summary.jsonl` recursively, aggregates per test, and upserts to the table using `DefaultAzureCredential`. No-ops safely when storage isn't configured or no data exists; a missing table-write role logs a warning instead of failing the run.
- **Workflows**: `test-all-integration.yml` and `test-azure-deploy.yml` gain an "Upload token usage to table" step.
- **API**: `dashboard/api/src/functions/getTokenUsage.ts` exposes `GET /api/token-usage` (skill/test/branch filters) and `GET /api/token-usage/filters`.
- **Frontend**: `token-usage.html` + `src/token-usage/*` recharts page; registered in `vite.config.ts` and cross-linked in nav.
- **Docs**: `dashboard/Readme.md` documents the table, page, uploader step, and required vars/RBAC.

## Validation

- `cd dashboard/api && npm run build` ✓
- `cd dashboard && npm run build` (token-usage page bundles) ✓
- `cd tests && npm run typecheck` + eslint ✓
- `az bicep build dashboard/infra/main.bicep` ✓ (pre-existing warnings only)

## Ops notes

- The pipeline's Managed Identity needs **Storage Table Data Contributor** on the storage account (separate identity, not provisioned by this bicep) — documented in the Readme. New workflow var `TOKEN_USAGE_TABLE` (default `integrationtokenusage`).
- Only agent-runner-based tests emit `token-summary.jsonl` today, so vally-only tests won't contribute rows yet. Historical backfill is out of scope; history accrues from first deploy.
