### PR TITLE
Resolve failing nightly benchmark run

### DIFF
--- a/pipelines/scripts/Invoke-RunBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-RunBenchmarks.ps1
@@ -119,7 +119,7 @@
     }
 
     Write-Host "Installing/upgrading MSBench CLI"
-    python -m pip install msbench-cli msbench-benchmarks<0.0.39 --no-input
+    python -m pip install msbench-cli --no-input
     if ($LASTEXITCODE -ne 0) {
         throw "pip install msbench-cli failed with exit code $LASTEXITCODE"
     }
@@ -184,6 +184,10 @@
             "--tag", "org=CoreAI Cloud and Tools",
             "--no-wait"
         )
+
+        if ($env:SYSTEM_DEBUG -eq "true") {
+            $runArgs += "--verbose"
+        }
 
         Write-Host "Running: msbench-cli $($runArgs -join ' ')"
         $cmdOutput = & 'msbench-cli' @runArgs 2>&1

--- a/pipelines/scripts/Invoke-RunBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-RunBenchmarks.ps1
@@ -119,7 +119,7 @@
     }
 
     Write-Host "Installing/upgrading MSBench CLI"
-    python -m pip install msbench-cli msbench-benchmarks>=0.0.38,<0.0.39 --no-input
+    python -m pip install msbench-cli msbench-benchmarks<0.0.39 --no-input
     if ($LASTEXITCODE -ne 0) {
         throw "pip install msbench-cli failed with exit code $LASTEXITCODE"
     }

--- a/pipelines/scripts/Invoke-RunBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-RunBenchmarks.ps1
@@ -191,12 +191,9 @@
         }
 
         Write-Host "Running: msbench-cli $($runArgs -join ' ')"
-        $cmdOutput = @()
-        & 'msbench-cli' @runArgs 2>&1 | ForEach-Object {
-            Write-Host $_
-            $cmdOutput += $_
-        }
+        $cmdOutput = & 'msbench-cli' @runArgs 2>&1
         $msbenchExitCode = $LASTEXITCODE
+        $cmdOutput | ForEach-Object { Write-Host $_ }
 
         if ($msbenchExitCode -ne 0) {
             Write-Warning "msbench-cli run failed for model '$m' with exit code $msbenchExitCode"

--- a/pipelines/scripts/Invoke-RunBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-RunBenchmarks.ps1
@@ -182,7 +182,8 @@
             "--env", "GITHUB_MCP_SERVER_TOKEN CAPI_INTEGRATION_ID CAPI_HMAC_KEY USE_COPILOT_CLI_VERSION",
             "--dataset", (Join-Path $targetDir "metadata.csv"),
             "--tag", "org=CoreAI Cloud and Tools",
-            "--no-wait"
+            "--no-wait",
+            "--confirm"
         )
 
         if ($env:SYSTEM_DEBUG -eq "true") {

--- a/pipelines/scripts/Invoke-RunBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-RunBenchmarks.ps1
@@ -119,7 +119,7 @@
     }
 
     Write-Host "Installing/upgrading MSBench CLI"
-    python -m pip install msbench-cli --no-input
+    python -m pip install msbench-cli msbench-benchmarks>=0.0.38,<0.0.39 --no-input
     if ($LASTEXITCODE -ne 0) {
         throw "pip install msbench-cli failed with exit code $LASTEXITCODE"
     }

--- a/pipelines/scripts/Invoke-RunBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-RunBenchmarks.ps1
@@ -190,9 +190,12 @@
         }
 
         Write-Host "Running: msbench-cli $($runArgs -join ' ')"
-        $cmdOutput = & 'msbench-cli' @runArgs 2>&1
+        $cmdOutput = @()
+        & 'msbench-cli' @runArgs 2>&1 | ForEach-Object {
+            Write-Host $_
+            $cmdOutput += $_
+        }
         $msbenchExitCode = $LASTEXITCODE
-        $cmdOutput | ForEach-Object { Write-Host $_ }
 
         if ($msbenchExitCode -ne 0) {
             Write-Warning "msbench-cli run failed for model '$m' with exit code $msbenchExitCode"


### PR DESCRIPTION
If we can get [this](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=6393971&view=results) nightly build off the floor we should. 

- the only difference in the failure above is that we were using version `0.0.38` of `msbench-benchmarks`, failures occurred on `0.0.39`
- The changes from `0.0.38` -> `0.0.39` added additional instances to existing benchmarks
- msbench-cli has a "wait hold up you are triggering over 50 instances"[prompt(https://dev.azure.com/devdiv/InternalTools/_git/MicrosoftSweBench?path=/msbench/config.py&version=GBmain&line=75&lineEnd=76&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents) waits for user confirmation
- this user input prompt was hidden from you in pipeline run because we are just collecting stdout and never echoing

The solution is to provide `--config` in the arguments to msbench, so that the instances queue properly.

