### PR TITLE
fix: Update links to Vally documentation

### DIFF
--- a/.github/skills/vally-eval/SKILL.md
+++ b/.github/skills/vally-eval/SKILL.md
@@ -15,7 +15,7 @@ Skills in the azure-skills plugin are required to have integration tests that ru
 
 Vally eval suites are written as yaml documents. All eval suites share eval spec.
 
-Refer to the official documentation on the schema of the spec and the schema of the eval suites [writing-eval-specs](https://literate-engine-r3wnl4v.pages.github.io/guides/writing-eval-specs/).
+Refer to the official documentation on the schema of the spec and the schema of the eval suites [writing-eval-specs](https://microsoft.github.io/vally/guides/writing-eval-specs/).
 
 Vally eval suites for azure-skills plugin have the following file layout. The shared eval spec is located at `<repo-root>/.vally.yaml`. The eval suites are categorized by skills. The eval suites for each skill are located at `<repo-root>/evals/<skill-name>/eval.yaml`, e.g. `<repo-root>/evals/azure-ai/eval.yaml`. If a skill needs fixture files for its eval suites, it should organize such fixture files in a `fixture` directory under its directory, e.g. `<repo-root>/evals/azure-ai/fixture/`.
 
@@ -23,7 +23,7 @@ Vally eval suites for azure-skills plugin have the following file layout. The sh
 
 azure-skills plugin have implemented JavaScript integration test using Jest as the underlying test runner. All such integration tests are under `tests/**/integration.test.ts` files.
 
-To migrate integration test for a skill to vally suites, create its eval suite spec at `<repo-root>/evals/<skill-name>/eval.yaml`, add a suite that runs the same prompt and uses vally's built-in graders to grade the trajectory of the agent run. If the integration test grades the agent run in a way that vally's built-in graders don't support, refer to the official documentation on how to create a custom grader [writing-custom-grader](https://literate-engine-r3wnl4v.pages.github.io/guides/writing-custom-graders/).
+To migrate integration test for a skill to vally suites, create its eval suite spec at `<repo-root>/evals/<skill-name>/eval.yaml`, add a suite that runs the same prompt and uses vally's built-in graders to grade the trajectory of the agent run. If the integration test grades the agent run in a way that vally's built-in graders don't support, refer to the official documentation on how to create a custom grader [writing-custom-grader](https://microsoft.github.io/vally/guides/writing-custom-graders/).
 
 ## Why is there a custom executor
 

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -8,7 +8,7 @@ When a user asks to scaffold, create, or add tests for a skill, follow these ste
 
 ### Step 1: Read the vally-eval skill
 
-Skills in azure-skills plugin use [vally](https://literate-engine-r3wnl4v.pages.github.io/get-started/) to run integration tests that run prompts against an LLM Agent and evaluate the outcome. The vally-eval skill provides the knowledge on where to add the test code, how to run the tests and where to collect the test results. Combine the instructions in vally-eval skill, the official documentation of vally and the rest of the instructions in this file to learn how to write vally eval suites for azure-skills plugin. 
+Skills in azure-skills plugin use [vally](https://microsoft.github.io/vally/get-started/) to run integration tests that run prompts against an LLM Agent and evaluate the outcome. The vally-eval skill provides the knowledge on where to add the test code, how to run the tests and where to collect the test results. Combine the instructions in vally-eval skill, the official documentation of vally and the rest of the instructions in this file to learn how to write vally eval suites for azure-skills plugin. 
 
 ### Step 2: Read the skill's SKILL.md
 Load the file at `plugin/skills/{skill-name}/SKILL.md` to understand:
@@ -28,7 +28,7 @@ Follow the vally documentation to write the eval suite for each test case. Each 
 
 1. The environment in which the user prompts the agent. This can include source code in the local workspace, access to local CLI tools, access to Cloud resources, etc. For example, if the user prompt asks the agent to deploy an app to Azure, the workspace should already have the source code of the app.
 2. The user prompt that triggers the agent to do work. The user prompt should imitate what a reasonable user would submit in practice. Avoid giving too little or too much details in the test user prompt. If a test case naturally requires multi-turn agent interaction, such as user confirmation, it can specify follow up prompts to simulate multi-turn interactions with the agent.
-3. The pass/fail criterion for the outcome. For example, a test case can expect the agent to load a certain skill, emit certain tokens to the user as assistant messages, not emit certain tokens, etc. See [vally-graders-catalog](https://literate-engine-r3wnl4v.pages.github.io/reference/graders/) to learn what graders are supported.
+3. The pass/fail criterion for the outcome. For example, a test case can expect the agent to load a certain skill, emit certain tokens to the user as assistant messages, not emit certain tokens, etc. See [vally-graders-catalog](https://microsoft.github.io/vally/reference/graders/) to learn what graders are supported.
 
 ### Step 4: Run and verify locally
 


### PR DESCRIPTION
## Description

The links to the Vally documentation are outdated

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
