### PR TITLE
feat: replace azd provision/deploy sequence with script

### DIFF
--- a/plugin/skills/azure-prepare/references/scripts/azd-provision-deploy.ps1
+++ b/plugin/skills/azure-prepare/references/scripts/azd-provision-deploy.ps1
@@ -1,0 +1,77 @@
+# Initialize an AZD template, set location, then provision and deploy.
+#
+# USAGE:
+#   .\azd-provision-deploy.ps1 -Template <template> -Region <region> [-EnvName <env-name>] [-UseUp] [-InitOnly]
+#
+# ARGUMENTS:
+#   Template   AZD template name or repository.
+#   Region     Azure region for AZURE_LOCATION.
+#   EnvName    Optional AZD environment name. Defaults to <cwd-slug>-dev.
+#   UseUp      Use azd up --no-prompt instead of provision, wait, deploy.
+#   InitOnly   Initialize the template and exit.
+
+param(
+    [Parameter(Mandatory = $true, Position = 0)]
+    [string]$Template,
+
+    [Parameter(Mandatory = $true, Position = 1)]
+    [string]$Region,
+
+    [Parameter(Position = 2)]
+    [string]$EnvName,
+
+    [switch]$UseUp,
+
+    [switch]$InitOnly
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $EnvName) {
+    $slug = (Split-Path -Leaf (Get-Location)).ToLower() -replace '[ _]', '-'
+    $EnvName = "$slug-dev"
+}
+
+if ($InitOnly) {
+    $mode = 'init-only'
+    $phases = 'init'
+} elseif ($UseUp) {
+    $mode = 'up'
+    $phases = 'init,env-set,up'
+} else {
+    $mode = 'provision-deploy'
+    $phases = 'init,env-set,provision,wait,deploy'
+}
+
+Write-Host "env_name=$EnvName"
+Write-Host "template=$Template"
+Write-Host "region=$Region"
+Write-Host "mode=$mode"
+Write-Host "phases=$phases"
+
+if (Test-Path 'azure.yaml') {
+    Write-Host 'init=skipped-existing-azure-yaml'
+} else {
+    azd init -t $Template -e $EnvName --no-prompt
+    Write-Host 'init=completed'
+}
+
+if ($InitOnly) {
+    Write-Host 'result=initialized'
+    Write-Host "Initialized '$EnvName' from '$Template'."
+    exit 0
+}
+
+azd env set AZURE_LOCATION $Region
+
+if ($UseUp) {
+    azd up --no-prompt
+    Write-Host 'result=deployed-with-azd-up'
+    Write-Host "Initialized and deployed '$EnvName' in '$Region' with azd up."
+} else {
+    azd provision --no-prompt
+    Start-Sleep -Seconds 60
+    azd deploy --no-prompt
+    Write-Host 'result=provisioned-then-deployed'
+    Write-Host "Provisioned then deployed '$EnvName' in '$Region'."
+}

--- a/plugin/skills/azure-prepare/references/scripts/azd-provision-deploy.sh
+++ b/plugin/skills/azure-prepare/references/scripts/azd-provision-deploy.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Initialize an AZD template, set location, then provision and deploy.
+#
+# USAGE:
+#   ./azd-provision-deploy.sh <template> <region> [env-name] [--up] [--init-only]
+#
+# ARGUMENTS:
+#   template   AZD template name or repository.
+#   region     Azure region for AZURE_LOCATION.
+#   env-name   Optional AZD environment name. Defaults to <cwd-slug>-dev.
+#   --up       Use azd up --no-prompt instead of provision, wait, deploy.
+#   --init-only Initialize the template and exit.
+
+set -euo pipefail
+
+usage() {
+  echo "usage=azd-provision-deploy.sh <template> <region> [env-name] [--up] [--init-only]"
+  exit 2
+}
+
+USE_UP=false
+INIT_ONLY=false
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --up) USE_UP=true ;;
+    --init-only) INIT_ONLY=true ;;
+    -h|--help) usage ;;
+    *) ARGS+=("$arg") ;;
+  esac
+done
+
+if [ "${#ARGS[@]}" -lt 2 ] || [ "${#ARGS[@]}" -gt 3 ]; then
+  usage
+fi
+
+TEMPLATE="${ARGS[0]}"
+REGION="${ARGS[1]}"
+ENV_NAME="${ARGS[2]:-$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')-dev}"
+
+if [ "$INIT_ONLY" = true ]; then
+  MODE="init-only"
+  PHASES="init"
+elif [ "$USE_UP" = true ]; then
+  MODE="up"
+  PHASES="init,env-set,up"
+else
+  MODE="provision-deploy"
+  PHASES="init,env-set,provision,wait,deploy"
+fi
+
+echo "env_name=$ENV_NAME"
+echo "template=$TEMPLATE"
+echo "region=$REGION"
+echo "mode=$MODE"
+echo "phases=$PHASES"
+
+if [ -f "azure.yaml" ]; then
+  echo "init=skipped-existing-azure-yaml"
+else
+  azd init -t "$TEMPLATE" -e "$ENV_NAME" --no-prompt
+  echo "init=completed"
+fi
+
+if [ "$INIT_ONLY" = true ]; then
+  echo "result=initialized"
+  echo "Initialized '$ENV_NAME' from '$TEMPLATE'."
+  exit 0
+fi
+
+azd env set AZURE_LOCATION "$REGION"
+
+if [ "$USE_UP" = true ]; then
+  azd up --no-prompt
+  echo "result=deployed-with-azd-up"
+  echo "Initialized and deployed '$ENV_NAME' in '$REGION' with azd up."
+else
+  azd provision --no-prompt
+  sleep 60
+  azd deploy --no-prompt
+  echo "result=provisioned-then-deployed"
+  echo "Provisioned then deployed '$ENV_NAME' in '$REGION'."
+fi

--- a/plugin/skills/azure-prepare/references/services/app-service/templates/recipes/README.md
+++ b/plugin/skills/azure-prepare/references/services/app-service/templates/recipes/README.md
@@ -33,10 +33,7 @@ Base Template (per language/scenario, from AZD gallery)
 
 ### Step 1: Fetch Base Template
 
-```bash
-# Pick template by language + scenario (see selection.md)
-azd init -t <template> -e "$ENV_NAME" --no-prompt
-```
+Init: [sh](../../../../scripts/azd-provision-deploy.sh)/[ps1](../../../../scripts/azd-provision-deploy.ps1), `--init-only`.
 
 ### Step 2: Apply Recipe
 
@@ -54,12 +51,7 @@ The skill reads the recipe's README.md for:
 
 ### Step 4: Deploy
 
-```bash
-azd env set AZURE_LOCATION eastus2
-azd provision --no-prompt
-sleep 60
-azd deploy --no-prompt
-```
+Example: `./azd-provision-deploy.sh <template> eastus2 [env-name] [--up]`.
 
 ## Design Principles
 

--- a/plugin/skills/azure-prepare/references/services/app-service/templates/recipes/composition.md
+++ b/plugin/skills/azure-prepare/references/services/app-service/templates/recipes/composition.md
@@ -25,12 +25,9 @@ IF scenario == 'web-api':
   TEMPLATE = web_api_templates[language]    # See web-api.md
 ELSE IF scenario == 'web-app':
   TEMPLATE = web_app_templates[language]    # See web-app.md
-
-# Non-interactive init
-ENV_NAME="$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')-dev"
-# PowerShell: $ENV_NAME = "$(Split-Path -Leaf (Get-Location) | ForEach-Object { $_.ToLower() -replace '[ _]','-' })-dev"
-azd init -t $TEMPLATE -e "$ENV_NAME" --no-prompt
 ```
+
+Init helper: [sh](../../../../scripts/azd-provision-deploy.sh)/[ps1](../../../../scripts/azd-provision-deploy.ps1). Example: `./azd-provision-deploy.sh "$TEMPLATE" eastus2 [env-name] --init-only`.
 
 ### Step 2: Check if Recipe Needed
 
@@ -115,17 +112,9 @@ hooks:
 
 ### Step 7: Validate and Deploy
 
-**Required Environment Setup:**
-```bash
-azd env set AZURE_LOCATION eastus2
-```
-
 **Deployment (two-phase recommended):**
-```bash
-azd provision --no-prompt     # Create resources + RBAC assignments
-sleep 60                       # Wait for RBAC propagation
-azd deploy --no-prompt        # Deploy code (RBAC now active)
-```
+
+Run the same helper without `--init-only`; it skips `azd init` when `azure.yaml` exists. Add `--up`/`-UseUp` only for shorthand.
 
 > **CRITICAL: Never store database passwords in app settings.**
 > The correct approach is managed identity with passwordless connections.

--- a/plugin/skills/azure-prepare/references/services/app-service/templates/web-api.md
+++ b/plugin/skills/azure-prepare/references/services/app-service/templates/web-api.md
@@ -159,20 +159,7 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
 
 ## Deployment
 
-```bash
-ENV_NAME="$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')-dev"
-azd init -t <template> -e "$ENV_NAME" --no-prompt
-azd env set AZURE_LOCATION eastus2
-azd up --no-prompt
-```
-
-**PowerShell:**
-```powershell
-$ENV_NAME = "$(Split-Path -Leaf (Get-Location) | ForEach-Object { $_.ToLower() -replace '[ _]','-' })-dev"
-azd init -t <template> -e $ENV_NAME --no-prompt
-azd env set AZURE_LOCATION eastus2
-azd up --no-prompt
-```
+Helper: [sh](../../../scripts/azd-provision-deploy.sh)/[ps1](../../../scripts/azd-provision-deploy.ps1). Example: `./azd-provision-deploy.sh <template> eastus2 [env-name] [--up]`.
 
 ## References
 

--- a/plugin/skills/azure-prepare/references/services/app-service/templates/web-app.md
+++ b/plugin/skills/azure-prepare/references/services/app-service/templates/web-app.md
@@ -159,20 +159,7 @@ resource webApp 'Microsoft.Web/sites@2023-12-01' = {
 
 ## Deployment
 
-```bash
-ENV_NAME="$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')-dev"
-azd init -t <template> -e "$ENV_NAME" --no-prompt
-azd env set AZURE_LOCATION eastus2
-azd up --no-prompt
-```
-
-**PowerShell:**
-```powershell
-$ENV_NAME = "$(Split-Path -Leaf (Get-Location) | ForEach-Object { $_.ToLower() -replace '[ _]','-' })-dev"
-azd init -t <template> -e $ENV_NAME --no-prompt
-azd env set AZURE_LOCATION eastus2
-azd up --no-prompt
-```
+Helper: [sh](../../../scripts/azd-provision-deploy.sh)/[ps1](../../../scripts/azd-provision-deploy.ps1). Example: `./azd-provision-deploy.sh <template> eastus2 [env-name] [--up]`.
 
 ## References
 

--- a/plugin/skills/azure-prepare/references/services/functions/templates/README.md
+++ b/plugin/skills/azure-prepare/references/services/functions/templates/README.md
@@ -76,10 +76,7 @@ Each array entry contains `{ path, content }`. For every entry in BOTH arrays:
 
 ### Step 5: Deploy
 
-```bash
-azd env set AZURE_LOCATION <region>
-azd up --no-prompt
-```
+[sh](../../../scripts/azd-provision-deploy.sh)/[ps1](../../../scripts/azd-provision-deploy.ps1): `./azd-provision-deploy.sh <template> <region> [env-name] [--up]`.
 
 ---
 
@@ -113,9 +110,8 @@ GET https://cdn.functions.azure.com/public/templates-manifest/manifest.json
 ```
 
 > ⚠️ **If manifest fetch fails** (any error):
-> 1. Fall back to the source manifest at `https://github.com/Azure/azure-functions-templates/blob/dev/Functions.Templates/Template-Manifest/manifest.json`
-> 2. If both sources are unreachable, fall back to known-good repos: `Azure-Samples/functions-quickstart-*` keyed by language + resource (e.g., `functions-quickstart-python-http-azd`)
-> 3. If all fallbacks fail, report the error to the user and ask them to retry later
+> 1. Try source manifest: `https://github.com/Azure/azure-functions-templates/blob/dev/Functions.Templates/Template-Manifest/manifest.json`
+> 2. Then known-good `Azure-Samples/functions-quickstart-*` repos by language/resource; if all fail, ask user to retry.
 
 ### Step 2: Filter Templates
 
@@ -165,9 +161,7 @@ The downloaded content is the **same** as MCP `functionFiles[]` + `projectFiles[
 
 ### Step 4: Deploy
 
-```bash
-azd up --no-prompt
-```
+Use Step 5 helper.
 
 ---
 

--- a/plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md
+++ b/plugin/skills/azure-prepare/references/services/functions/templates/recipes/composition.md
@@ -201,19 +201,7 @@ appSettings: {
 
 ## Deployment Strategy
 
-**Option A: Single command** (fast, may fail on first deploy due to RBAC propagation)
-
-```bash
-azd up --no-prompt
-```
-
-**Option B: Two-phase** (recommended for reliability)
-
-```bash
-azd provision --no-prompt     # Create resources + RBAC assignments
-sleep 60                       # Wait for RBAC propagation (Azure AD needs 30-60s)
-azd deploy --no-prompt        # Deploy code (RBAC now active)
-```
+[sh](../../../../scripts/azd-provision-deploy.sh)/[ps1](../../../../scripts/azd-provision-deploy.ps1): `./azd-provision-deploy.sh <template> eastus2 [env-name] [--up]`; no `--up` = provision→60s→deploy.
 
 ## Terraform-Specific Requirements
 


### PR DESCRIPTION
## Summary
- Add reusable bash and PowerShell azd provision/deploy helpers for azure-prepare templates
- Replace duplicated inline azd init/location/provision/deploy snippets with relative script references
- Preserve optional azd up shorthand support and RBAC wait guidance

Fixes #2496