### PR TITLE
fix: reduce golden time

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -83,23 +83,17 @@ Each entry has a `manifestUrl` and an `initCommand`. Prefer direct code deploy a
 
 For a generic new hosted agent request, start from the basic sample. Use tool/function-calling samples only when the user explicitly asks for external actions, APIs, tools, connectors, or data lookup.
 
-Python Example:
-```bash
-# New Foundry project
-azd ai agent init --no-prompt \
-  -m "<manifestUrl>" \
-  --deploy-mode code \
-  --runtime python_3_13 \
-  --entry-point main.py
+Python Example (add `--project-id "<resourceId>"` for an existing Foundry project; add `--agent-name <name>` if the user wants a custom name -- omit otherwise to keep the sample default):
 
-# Existing Foundry project
+```bash
 azd ai agent init --no-prompt \
-  --project-id "<resourceId>" \
   -m "<manifestUrl>" \
   --deploy-mode code \
   --runtime python_3_13 \
   --entry-point main.py
 ```
+
+> `--agent-name` at init names both `agent.yaml name:` and `azure.yaml services:<key>:` in one shot; renaming after init requires editing both files.
 
 Do not run `azd env new`, `azd env select`, or `azd env set` before `azd ai agent init` in a new temp/workspace; there is no azd project yet, so those commands fail and waste time. For an existing project, `--project-id` is enough during init. Set endpoint/model values immediately after init, once `azure.yaml` and the azd env exist.
 
@@ -122,7 +116,7 @@ Check the scaffold before local run:
    AZURE_AI_MODEL_DEPLOYMENT_NAME=<model-deployment-name>
    ```
 3. Prefer direct code deployment. Inspect `<service-dir>/agent.yaml`; if `code_configuration:` is missing and the agent does not need a custom Dockerfile or system packages, add it before deployment.
-4. If you rename the agent in `<service-dir>/agent.yaml`, also rename the matching key under `azure.yaml services:` to the same value while preserving its `project:` path.
+4. Prefer `--agent-name` at init time (above). Fallback only: if init already ran without it, rename the agent in `<service-dir>/agent.yaml` AND the matching key under `azure.yaml services:` to the same value, preserving its `project:` path.
 5. If you change CPU or memory, keep `<service-dir>/agent.yaml` and `azure.yaml services.<name>.config.container.resources` aligned because the `azure.yaml` service config can override the agent file.
 
 ### Step 4b -- Brownfield: lift existing code

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/local-run.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/local-run.md
@@ -21,14 +21,15 @@ Use this when iterating on a hosted agent before deploying.
 
 ## Prepare the local environment
 
-For Python agents, prepare the environment from the agent directory before running `azd ai agent run`:
+For Python agents, prepare the environment from the **agent's service source directory** -- the folder that contains `requirements.txt` and `agent.yaml` (typically `<repo>/src/<service-name>/`, not the azd project root). `azd ai agent run` resolves the venv relative to this folder; a `.venv` created in the project root is ignored and azd silently creates a second one without `uv`.
 
-1. Create a venv, for example `python -m venv .venv`.
-2. Activate the venv.
-3. Install `uv` inside the active venv: `python -m pip install uv`.
-4. Run `azd ai agent run`; it installs `requirements.txt` itself and uses `uv` from the project `.venv` for faster Python dependency installation.
+1. `cd` into the service source directory.
+2. Create a venv, for example `python -m venv .venv`.
+3. Activate the venv.
+4. Install `uv` inside the active venv: `python -m pip install uv`.
+5. Run `azd ai agent run` (from any cwd in the project); it installs `requirements.txt` itself and uses `uv` from the service-dir `.venv` for faster Python dependency installation.
 
-> **Important:** Keep the venv active for `azd ai agent run`. Install `uv` before running `azd ai agent run`; otherwise the local run may fall back to slower dependency installation. Do NOT manually install agent packages or run `pip install -r requirements.txt` / `uv pip install -r requirements.txt --prerelease=allow`; let `azd ai agent run` install dependencies.
+> **Important:** The venv must live next to `requirements.txt`, not in the azd project root. Install `uv` before running `azd ai agent run`; otherwise the local run falls back to slower dependency installation. Do NOT manually run `pip install -r requirements.txt` / `uv pip install -r requirements.txt --prerelease=allow`; let `azd ai agent run` install dependencies.
 
 ## Start the agent locally
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.ps1
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.ps1
@@ -81,33 +81,40 @@ if ($LASTEXITCODE -eq 0) {
 }
 
 # 4. Foundry project endpoint (optional at this stage)
-$projectJson = Get-AzdJson @("ai", "project", "show", "--output", "json")
-$endpoint = $null
-if ($projectJson) {
-    foreach ($k in @("endpoint", "projectEndpoint", "aiProjectEndpoint")) {
-        if ($projectJson.PSObject.Properties.Name -contains $k -and $projectJson.$k) {
-            $endpoint = $projectJson.$k
-            break
+# Short-circuit when there's no azd project in cwd: `azd ai project show` / `agent show`
+# would just return nothing after a ~3s subprocess each.
+if (-not (Test-Path "azure.yaml")) {
+    Note-Warn "No Foundry project endpoint set yet. A new project will be created at provision/deploy time, or supply an existing project resource ID."
+    Note-Ok "No agent deployed yet. Proceed with create."
+} else {
+    $projectJson = Get-AzdJson @("ai", "project", "show", "--output", "json")
+    $endpoint = $null
+    if ($projectJson) {
+        foreach ($k in @("endpoint", "projectEndpoint", "aiProjectEndpoint")) {
+            if ($projectJson.PSObject.Properties.Name -contains $k -and $projectJson.$k) {
+                $endpoint = $projectJson.$k
+                break
+            }
         }
     }
-}
-if ($endpoint) {
-    Note-Ok "Foundry project endpoint configured: $endpoint"
-} else {
-    Note-Warn "No Foundry project endpoint set yet. A new project will be created at provision/deploy time, or supply an existing project resource ID."
-}
-
-# 5. Agent deployment status
-$agentJson = Get-AzdJson @("ai", "agent", "show", "--output", "json")
-if ($agentJson) {
-    $status = if ($agentJson.PSObject.Properties.Name -contains "status" -and $agentJson.status) { $agentJson.status } else { "unknown" }
-    switch ($status) {
-        { $_ -in @("active", "deployed") } { Note-Ok "An agent is already deployed (status: $status). Skip to deploy.md to redeploy, or tools to add a tool." }
-        "not_deployed"                     { Note-Ok "No agent deployed yet (status: not_deployed). Proceed with create." }
-        default                            { Note-Warn "Agent status: $status." }
+    if ($endpoint) {
+        Note-Ok "Foundry project endpoint configured: $endpoint"
+    } else {
+        Note-Warn "No Foundry project endpoint set yet. A new project will be created at provision/deploy time, or supply an existing project resource ID."
     }
-} else {
-    Note-Ok "No agent deployed yet. Proceed with create."
+
+    # 5. Agent deployment status
+    $agentJson = Get-AzdJson @("ai", "agent", "show", "--output", "json")
+    if ($agentJson) {
+        $status = if ($agentJson.PSObject.Properties.Name -contains "status" -and $agentJson.status) { $agentJson.status } else { "unknown" }
+        switch ($status) {
+            { $_ -in @("active", "deployed") } { Note-Ok "An agent is already deployed (status: $status). Skip to deploy.md to redeploy, or tools to add a tool." }
+            "not_deployed"                     { Note-Ok "No agent deployed yet (status: not_deployed). Proceed with create." }
+            default                            { Note-Warn "Agent status: $status." }
+        }
+    } else {
+        Note-Ok "No agent deployed yet. Proceed with create."
+    }
 }
 
 Write-Output ""

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.sh
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.sh
@@ -54,10 +54,16 @@ else
 fi
 
 # 4. Foundry project endpoint (optional at this stage)
-PROJECT_JSON="$(azd ai project show --output json 2>/dev/null || echo '')"
-ENDPOINT=""
-if [ -n "$PROJECT_JSON" ]; then
-  ENDPOINT="$(printf '%s' "$PROJECT_JSON" | python3 -c 'import json,sys
+# Short-circuit when there's no azd project in cwd: `azd ai project show` / `agent show`
+# would just return nothing after a ~3s subprocess each.
+if [ ! -f "azure.yaml" ]; then
+  note_warn "No Foundry project endpoint set yet. A new project will be created at provision/deploy time, or supply an existing project resource ID."
+  note_ok "No agent deployed yet. Proceed with create."
+else
+  PROJECT_JSON="$(azd ai project show --output json 2>/dev/null || echo '')"
+  ENDPOINT=""
+  if [ -n "$PROJECT_JSON" ]; then
+    ENDPOINT="$(printf '%s' "$PROJECT_JSON" | python3 -c 'import json,sys
 try:
     d=json.load(sys.stdin)
 except Exception:
@@ -67,29 +73,30 @@ if isinstance(d,dict):
         if d.get(k):
             print(d[k]); break
 ' 2>/dev/null)"
-fi
-if [ -n "$ENDPOINT" ]; then
-  note_ok "Foundry project endpoint configured: ${ENDPOINT}"
-else
-  note_warn "No Foundry project endpoint set yet. A new project will be created at provision/deploy time, or supply an existing project resource ID."
-fi
+  fi
+  if [ -n "$ENDPOINT" ]; then
+    note_ok "Foundry project endpoint configured: ${ENDPOINT}"
+  else
+    note_warn "No Foundry project endpoint set yet. A new project will be created at provision/deploy time, or supply an existing project resource ID."
+  fi
 
-# 5. Agent deployment status
-AGENT_JSON="$(azd ai agent show --output json 2>/dev/null || echo '')"
-if [ -n "$AGENT_JSON" ]; then
-  STATUS="$(printf '%s' "$AGENT_JSON" | python3 -c 'import json,sys
+  # 5. Agent deployment status
+  AGENT_JSON="$(azd ai agent show --output json 2>/dev/null || echo '')"
+  if [ -n "$AGENT_JSON" ]; then
+    STATUS="$(printf '%s' "$AGENT_JSON" | python3 -c 'import json,sys
 try:
     d=json.load(sys.stdin)
 except Exception:
     print("unknown"); raise SystemExit
 print(d.get("status","unknown") if isinstance(d,dict) else "unknown")' 2>/dev/null)"
-  case "$STATUS" in
-    active|deployed) note_ok "An agent is already deployed (status: ${STATUS}). Skip to deploy.md to redeploy, or tools to add a tool." ;;
-    not_deployed)    note_ok "No agent deployed yet (status: not_deployed). Proceed with create." ;;
-    *)               note_warn "Agent status: ${STATUS}." ;;
-  esac
-else
-  note_ok "No agent deployed yet. Proceed with create."
+    case "$STATUS" in
+      active|deployed) note_ok "An agent is already deployed (status: ${STATUS}). Skip to deploy.md to redeploy, or tools to add a tool." ;;
+      not_deployed)    note_ok "No agent deployed yet (status: not_deployed). Proceed with create." ;;
+      *)               note_warn "Agent status: ${STATUS}." ;;
+    esac
+  else
+    note_ok "No agent deployed yet. Proceed with create."
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
## Description

- short-cut env verify if no agent.yaml
- `init --agent-name` instead of renaming later
- correct pre-created venv path

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [x] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
