### PR TITLE
eval: Clean up test console output

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -665,6 +665,15 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
         cliArgs.push(buildTestCaseDirPath(getTestName()));
       }
 
+      // Copilot CLI emits lots of warnings about experimental features which clutters the console output so we suppress them.
+      const existingNodeOptions = process.env.NODE_OPTIONS;
+      const envVar: Record<string, string> = {
+        SKILLS_INSTRUCTIONS: "true",
+        SKILL_CHAR_BUDGET: "20000",
+        NODE_OPTIONS: existingNodeOptions ? `${existingNodeOptions} --no-warnings`
+          : "--no-warnings"
+      };
+
       const client = new CopilotClient({
         logLevel: process.env.DEBUG ? "all" : "error",
         cwd: testWorkspace,
@@ -672,8 +681,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
         cliPath: getBundledCliPath(),
         env: {
           ...process.env,
-          SKILLS_INSTRUCTIONS: "true",
-          SKILL_CHAR_BUDGET: "20000"
+          ...envVar
         }
       }) as CopilotClient;
       entry.client = client;
@@ -795,15 +803,6 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
       const { toolCounts, skillFiles } = computeToolAndSkillStats(agentMetadata.events, skillDirectory);
       agentMetadata.toolCounts = toolCounts;
       agentMetadata.skillFiles = skillFiles;
-
-      // Log token usage summary
-      if (tokenUsage.apiCallCount > 0) {
-        console.log(
-          `\n📊 Token Usage: ${tokenUsage.inputTokens.toLocaleString()} in / ${tokenUsage.outputTokens.toLocaleString()} out | ` +
-          `${tokenUsage.apiCallCount} API calls | ` +
-          `Duration: ${(tokenUsage.totalApiDurationMs / 1000).toFixed(1)}s\n`
-        );
-      }
 
       if (config.takeScreenshot && config.takeScreenshot.predicate(agentMetadata)) {
         // Resume the session so it can take a different set of skills and mcp servers.

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -670,8 +670,9 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
       const envVar: Record<string, string> = {
         SKILLS_INSTRUCTIONS: "true",
         SKILL_CHAR_BUDGET: "20000",
-        NODE_OPTIONS: existingNodeOptions ? `${existingNodeOptions} --no-warnings`
-          : "--no-warnings"
+        NODE_OPTIONS: existingNodeOptions
+          ? `${existingNodeOptions} --disable-warning=ExperimentalWarning`
+          : "--disable-warning=ExperimentalWarning"
       };
 
       const client = new CopilotClient({


### PR DESCRIPTION
## Description

Reduces noise in test console output by:
- Suppressing Node.js experimental feature warnings via `NODE_OPTIONS=--no-warnings`
- Removing the token usage summary log that cluttered test output

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->