### PR TITLE
misc: Remove a workflow input

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -167,7 +167,6 @@ jobs:
       model-override: ${{ inputs.model-override }}
       test-pattern: ${{ needs.resolve-inputs.outputs.deploy-test-pattern }}
       debug: ${{ needs.resolve-inputs.outputs.debug == 'true' }}
-      publish-reports: ${{ github.event_name == 'schedule' }}
     secrets:
       COPILOT_CLI_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
 

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -45,11 +45,6 @@ on:
         required: false
         type: boolean
         default: false
-      publish-reports:
-        description: 'Whether to publish reports to Azure Storage'
-        required: false
-        type: boolean
-        default: false
     secrets:
       COPILOT_CLI_TOKEN:
         required: true
@@ -223,7 +218,7 @@ jobs:
 
       # Note: The managed identity must have write permission to the target storage account
       - name: Publish report to Azure Storage
-        if: always() && inputs.publish-reports && vars.REPORT_STORAGE_ACCOUNT != ''
+        if: always() && vars.REPORT_STORAGE_ACCOUNT != ''
         env:
           RUN_ID: ${{ github.run_id }}
           JOB_ID: ${{ github.job }}
@@ -246,7 +241,7 @@ jobs:
       # "token usage over time" page.
       # Note: The managed identity must have Storage Table Data Contributor on the storage account.
       - name: Upload token usage to table
-        if: always() && inputs.publish-reports && vars.REPORT_STORAGE_ACCOUNT != ''
+        if: always() && vars.REPORT_STORAGE_ACCOUNT != ''
         env:
           TOKEN_USAGE_STORAGE_ACCOUNT: ${{ vars.REPORT_STORAGE_ACCOUNT }}
           TOKEN_USAGE_TABLE_NAME: ${{ vars.TOKEN_USAGE_TABLE || 'integrationtokenusage' }}

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -218,7 +218,7 @@ jobs:
 
       # Note: The managed identity must have write permission to the target storage account
       - name: Publish report to Azure Storage
-        if: always() && vars.REPORT_STORAGE_ACCOUNT != ''
+        if: always() && github.event_name == 'schedule' && vars.REPORT_STORAGE_ACCOUNT != ''
         env:
           RUN_ID: ${{ github.run_id }}
           JOB_ID: ${{ github.job }}
@@ -237,8 +237,30 @@ jobs:
             --auth-mode login \
             --overwrite
 
+      # Publish reports to the same storage account but a separate container for manual runs.
+      # Note: The managed identity must have write permission to the target storage account.
+      - name: Publish report to Azure Storage (manual run)
+        if: always() && github.event_name == 'workflow_dispatch' && vars.REPORT_STORAGE_ACCOUNT != ''
+        env:
+          RUN_ID: ${{ github.run_id }}
+          JOB_ID: ${{ github.job }}
+          STORAGE_ACCOUNT: ${{ vars.REPORT_STORAGE_ACCOUNT }}
+          STORAGE_CONTAINER: ${{ vars.MANUAL_REPORT_STORAGE_CONTAINER || 'manual-integration-reports' }}
+          TEST_GROUP: ${{ matrix.test-group }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          PREFIX="${DATE}/${RUN_ID}/azure-deploy/${TEST_GROUP}/"
+          echo "Uploading reports to ${STORAGE_ACCOUNT}/${STORAGE_CONTAINER}/${PREFIX}"
+          az storage blob upload-batch \
+            --account-name "$STORAGE_ACCOUNT" \
+            --destination "$STORAGE_CONTAINER" \
+            --destination-path "$PREFIX" \
+            --source reports/test-run-azure-deploy \
+            --auth-mode login \
+            --overwrite
+
       # Upload per-test token usage to the Azure Table that powers the dashboard's
-      # "token usage over time" page.
+      # "token usage over time" page. Runs for both scheduled and manual runs.
       # Note: The managed identity must have Storage Table Data Contributor on the storage account.
       - name: Upload token usage to table
         if: always() && vars.REPORT_STORAGE_ACCOUNT != ''

--- a/dashboard/Readme.md
+++ b/dashboard/Readme.md
@@ -101,9 +101,9 @@ Data flow:
 - The integration test pipelines upload that data **directly** to an Azure Table by
   running `npm run upload:token-usage` (`tests/scripts/upload-token-usage.ts`). One
   row is stored **per test, per branch, per run** in the `integrationtokenusage`
-  table on the integration-reports storage account. This runs in
-  `test-all-integration.yml` (scheduled + manual) and in `test-azure-deploy.yml`
-  whenever its `publish-reports` input is `true` (i.e. on scheduled runs).
+  table on the integration-reports storage account. This runs in both
+  `test-all-integration.yml` and `test-azure-deploy.yml` on scheduled and manual
+  runs alike (whenever `REPORT_STORAGE_ACCOUNT` is configured).
 - The frontend never reads the table directly. It calls the Function App API:
   - `GET /api/token-usage` — rows, with optional `skill`, `test`, `branch` filters.
   - `GET /api/token-usage/filters` — distinct skills / tests / branches.


### PR DESCRIPTION
Remove the `publish-reports` input from test-azure-deploy.yml. This would be set to true when test-azure-deploy.yml was kicked off by a _scheduled_ run of test-all-integration.yml, but would be false otherwise. This meant that manually started runs against feature/dev branches wouldn't end up recording their token usage or saving test reports to Azure Storage blobs.

## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [X] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
