### PR TITLE
feature: support viewing integration test result from custom container in the dasboard

### DIFF
--- a/dashboard/api/src/blobEnumerator.ts
+++ b/dashboard/api/src/blobEnumerator.ts
@@ -2,7 +2,11 @@ import { BlobServiceClient, ContainerClient } from "@azure/storage-blob";
 import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
 import type { BlobEntry, BlobTree, BlobTreeNode } from "./shared/blobTree";
 
-const INTEGRATION_REPORTS_CONTAINER_NAME = process.env.INTEGRATION_REPORTS_CONTAINER_NAME || "integration-reports";
+const DEFAULT_CONTAINER_NAME = "integration-reports";
+
+function resolveContainerName(override?: string): string {
+    return override || process.env.INTEGRATION_REPORTS_CONTAINER_NAME || DEFAULT_CONTAINER_NAME;
+}
 
 const EXCLUDED_FILENAMES = new Set(["token-usage.json", "agent-metadata.json"]);
 
@@ -122,20 +126,20 @@ export async function downloadBlobContent(containerClient: ContainerClient, blob
 
 // --- Integration-reports-specific wrappers ---
 
-export async function listDates(): Promise<string[]> {
-    return listDatePrefixes(getContainerClient(INTEGRATION_REPORTS_CONTAINER_NAME));
+export async function listDates(containerName?: string): Promise<string[]> {
+    return listDatePrefixes(getContainerClient(resolveContainerName(containerName)));
 }
 
-export async function enumerateBlobs(prefix?: string): Promise<BlobTree> {
-    return enumerateBlobTree(getContainerClient(INTEGRATION_REPORTS_CONTAINER_NAME), prefix);
+export async function enumerateBlobs(prefix?: string, containerName?: string): Promise<BlobTree> {
+    return enumerateBlobTree(getContainerClient(resolveContainerName(containerName)), prefix);
 }
 
-export async function getBlobContent(blobPath: string): Promise<string> {
-    return downloadBlobContent(getContainerClient(INTEGRATION_REPORTS_CONTAINER_NAME), blobPath);
+export async function getBlobContent(blobPath: string, containerName?: string): Promise<string> {
+    return downloadBlobContent(getContainerClient(resolveContainerName(containerName)), blobPath);
 }
 
-export async function getBlobBuffer(blobPath: string): Promise<Buffer> {
-    return downloadBlobBuffer(getContainerClient(INTEGRATION_REPORTS_CONTAINER_NAME), blobPath);
+export async function getBlobBuffer(blobPath: string, containerName?: string): Promise<Buffer> {
+    return downloadBlobBuffer(getContainerClient(resolveContainerName(containerName)), blobPath);
 }
 
 const azureDeploySkillName = "azure-deploy";

--- a/dashboard/api/src/functions/downloadBlob.ts
+++ b/dashboard/api/src/functions/downloadBlob.ts
@@ -19,8 +19,10 @@ async function downloadBlob(request: HttpRequest, context: InvocationContext): P
         return { status: 400, body: "Invalid path" };
     }
 
+    const container = request.query.get("container") || undefined;
+
     try {
-        const content = await getBlobContent(blobPath);
+        const content = await getBlobContent(blobPath, container);
         const rawFileName = blobPath.split("/").pop() ?? "download";
         const fileName = rawFileName.replace(/[\r\n"\\]/g, "_");
 

--- a/dashboard/api/src/functions/fetchBlob.ts
+++ b/dashboard/api/src/functions/fetchBlob.ts
@@ -20,8 +20,10 @@ async function fetchBlob(request: HttpRequest, context: InvocationContext): Prom
         return { status: 400, body: "Invalid path" };
     }
 
+    const container = request.query.get("container") || undefined;
+
     try {
-        const buffer = await getBlobBuffer(blobPath);
+        const buffer = await getBlobBuffer(blobPath, container);
         return {
             status: 200,
             headers: {

--- a/dashboard/api/src/functions/getData.ts
+++ b/dashboard/api/src/functions/getData.ts
@@ -40,7 +40,8 @@ async function getData(request: HttpRequest, context: InvocationContext): Promis
         return { status: 400, body: "Missing date parameter" };
     }
 
-    const root = await enumerateBlobs(`${date}/`);
+    const container = request.query.get("container") || undefined;
+    const root = await enumerateBlobs(`${date}/`, container);
 
     return {
         status: 200,

--- a/dashboard/api/src/functions/getDates.ts
+++ b/dashboard/api/src/functions/getDates.ts
@@ -9,7 +9,8 @@ import { logRequestIdentity } from "../requestIdentity";
 async function getDates(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
     logRequestIdentity(request, context, "getDates");
 
-    const dates = await listDates();
+    const container = request.query.get("container") || undefined;
+    const dates = await listDates(container);
 
     return {
         status: 200,

--- a/dashboard/api/src/functions/getReports.ts
+++ b/dashboard/api/src/functions/getReports.ts
@@ -32,7 +32,8 @@ async function getReports(request: HttpRequest, context: InvocationContext): Pro
         return { status: 400, body: "Missing date parameter" };
     }
 
-    const tree: BlobTree = await enumerateBlobs(`${date}/`);
+    const container = request.query.get("container") || undefined;
+    const tree: BlobTree = await enumerateBlobs(`${date}/`, container);
     const dateNode = tree[date];
     if (!dateNode) {
         return { status: 404, body: `No reports found for date: ${date}` };
@@ -47,7 +48,7 @@ async function getReports(request: HttpRequest, context: InvocationContext): Pro
 
     const sections: string[] = [];
     for (const path of reportPaths) {
-        const content = await getBlobContent(path);
+        const content = await getBlobContent(path, container);
         sections.push(content);
     }
 

--- a/dashboard/api/src/functions/getTestResults.ts
+++ b/dashboard/api/src/functions/getTestResults.ts
@@ -341,7 +341,8 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
         return { status: 400, body: "Missing date parameter" };
     }
 
-    const tree: BlobTree = await enumerateBlobs(`${date}/`);
+    const container = request.query.get("container") || undefined;
+    const tree: BlobTree = await enumerateBlobs(`${date}/`, container);
     const dateNode = tree[date];
     if (!dateNode) {
         return { status: 404, body: `No data found for date: ${date}` };
@@ -375,7 +376,7 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
         rawBySkill.set(skillName, []);
         for (const blobPath of paths.sort()) {
             fetchTasks.push(
-                getBlobContent(blobPath).then((raw) => {
+                getBlobContent(blobPath, container).then((raw) => {
                     try {
                         const parsed: RawTestResults = JSON.parse(raw);
                         rawBySkill.get(skillName)!.push(parsed);
@@ -396,7 +397,7 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
         confidenceBySkill.set(skillName, []);
         for (const blobPath of paths) {
             reportFetchTasks.push(
-                getBlobContent(blobPath).then((raw) => {
+                getBlobContent(blobPath, container).then((raw) => {
                     const conf = extractAverageConfidence(raw);
                     if (conf !== null) {
                         confidenceBySkill.get(skillName)!.push(conf);
@@ -413,7 +414,7 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
     for (const [testCaseName, paths] of agentMetadataPathsByTestCase) {
         for (const blobPath of paths) {
             retryFetchTasks.push(
-                getBlobContent(blobPath).then((raw) => {
+                getBlobContent(blobPath, container).then((raw) => {
                     const retries = countDeployRetries(raw);
                     if (retries === null) return; // invalid/unreadable — don't skew the average
                     deployRetryTotals.set(
@@ -436,7 +437,7 @@ async function getTestResults(request: HttpRequest, context: InvocationContext):
         tokenRecordsBySkill.set(skillName, []);
         for (const blobPath of paths) {
             tokenFetchTasks.push(
-                getBlobContent(blobPath).then((raw) => {
+                getBlobContent(blobPath, container).then((raw) => {
                     const records = parseTokenSummaryJsonl(raw);
                     tokenRecordsBySkill.get(skillName)!.push(...records);
                 }).catch(() => { /* skip unreadable files */ }),

--- a/dashboard/assets/nav-container.js
+++ b/dashboard/assets/nav-container.js
@@ -1,0 +1,12 @@
+// Preserves the "container" query parameter across site-nav links.
+(function () {
+    const container = new URLSearchParams(window.location.search).get("container");
+    if (!container) return;
+
+    document.querySelectorAll(".site-nav-link").forEach(function (link) {
+        const href = link.getAttribute("href");
+        if (!href) return;
+        const separator = href.includes("?") ? "&" : "?";
+        link.setAttribute("href", href + separator + "container=" + encodeURIComponent(container));
+    });
+})();

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -22,6 +22,7 @@
     <a href="/performance-dashboard.html" class="site-nav-link">MSBench Performance Dashboard</a>
     <a href="/msbench-nightly-runs.html" class="site-nav-link">MSBench Nightly Runs</a>
   </nav>
+  <script src="assets/nav-container.js"></script>
 
   <header class="dashboard-header">
     <h1>Repository Health Dashboard</h1>

--- a/dashboard/integration-tests.html
+++ b/dashboard/integration-tests.html
@@ -21,6 +21,7 @@
         <a href="/performance-dashboard.html" class="site-nav-link">MSBench Performance Dashboard</a>
         <a href="/msbench-nightly-runs.html" class="site-nav-link">MSBench Nightly Runs</a>
     </nav>
+    <script src="assets/nav-container.js"></script>
 
     <div id="root"></div>
     <script type="module" src="/src/integration-tests/main.tsx"></script>

--- a/dashboard/msbench-nightly-runs.html
+++ b/dashboard/msbench-nightly-runs.html
@@ -21,6 +21,7 @@
         <a href="/performance-dashboard.html" class="site-nav-link">MSBench Performance Dashboard</a>
         <a href="/msbench-nightly-runs.html" class="site-nav-link active" aria-current="page">MSBench Nightly Runs</a>
     </nav>
+    <script src="assets/nav-container.js"></script>
 
     <div id="root"></div>
     <script type="module" src="/src/msbench-nightly-runs/main.tsx"></script>

--- a/dashboard/nightly-runs.html
+++ b/dashboard/nightly-runs.html
@@ -21,6 +21,7 @@
         <a href="/performance-dashboard.html" class="site-nav-link">MSBench Performance Dashboard</a>
         <a href="/msbench-nightly-runs.html" class="site-nav-link">MSBench Nightly Runs</a>
     </nav>
+    <script src="assets/nav-container.js"></script>
 
     <div id="root"></div>
     <script type="module" src="/src/nightly-runs/main.tsx"></script>

--- a/dashboard/performance-dashboard.html
+++ b/dashboard/performance-dashboard.html
@@ -21,6 +21,7 @@
         <a href="/performance-dashboard.html" class="site-nav-link active" aria-current="page">MSBench Performance Dashboard</a>
         <a href="/msbench-nightly-runs.html" class="site-nav-link">MSBench Nightly Runs</a>
     </nav>
+    <script src="assets/nav-container.js"></script>
 
     <div id="root"></div>
     <script type="module" src="/src/performance-dashboard/main.tsx"></script>

--- a/dashboard/src/image-viewer/main.ts
+++ b/dashboard/src/image-viewer/main.ts
@@ -1,3 +1,5 @@
+import { apiUrl } from "../shared/apiUrl";
+
 const params = new URLSearchParams(window.location.search);
 const path = params.get("path");
 const container = document.getElementById("container") as HTMLDivElement;
@@ -19,7 +21,7 @@ if (!path) {
     const img = document.createElement("img");
     img.className = "iv-image";
     img.alt = fileName;
-    img.src = `/api/fetch?path=${encodeURIComponent(path)}`;
+    img.src = apiUrl(`/api/fetch?path=${encodeURIComponent(path)}`);
     img.onerror = () => {
         img.remove();
         showError("Failed to load image.");

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { BlobTree, BlobTreeNode } from "../shared/blobTree";
+import { apiUrl, pageUrl } from "../shared/apiUrl";
 
 interface TestCase {
     testName: string;
@@ -17,7 +18,7 @@ function fetchBlobTree(date: string): Promise<BlobTree> {
     const key = encodeURIComponent(date);
     let cached = blobTreeCache.get(key);
     if (!cached) {
-        cached = fetch(`/api/data/${key}`)
+        cached = fetch(apiUrl(`/api/data/${key}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json() as Promise<BlobTree>;
@@ -67,7 +68,7 @@ async function openAgentMetadataLinks(date: string, testName: string): Promise<v
         // to open the new page after the first one.
         // The user may unblock pop ups from this website or open them individually.
         window.open(
-            `/nightly-runs.html?file=${encodeURIComponent(blobName)}`,
+            pageUrl(`/nightly-runs.html?file=${encodeURIComponent(blobName)}`),
             "_blank",
             "noopener,noreferrer",
         );
@@ -103,7 +104,7 @@ function formatRate(rate: number | null): string {
 }
 
 function formatTestName(name: string): string {
-    return name.replace(/\s+/g, "_").replace(/_+/g, "_");
+    return name.replace(/\s+/g, "_");
 }
 
 function App() {
@@ -117,7 +118,7 @@ function App() {
 
     // Fetch available dates on mount
     useEffect(() => {
-        fetch("/api/dates")
+        fetch(apiUrl("/api/dates"))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();
@@ -141,7 +142,7 @@ function App() {
         setTestResults(null);
         setDetailsPanelSkill(null);
 
-        fetch(`/api/test-results/${encodeURIComponent(selectedDate)}`)
+        fetch(apiUrl(`/api/test-results/${encodeURIComponent(selectedDate)}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();
@@ -273,7 +274,7 @@ function App() {
                                     <li key={idx} className="it-failed-item">
                                         <a
                                             className="it-failed-name"
-                                            href={`/nightly-runs.html?date=${encodeURIComponent(selectedDate!)}#${encodeURIComponent(formatTestName(ft.testName))}`}
+                                            href={pageUrl(`/nightly-runs.html?date=${encodeURIComponent(selectedDate!)}#${encodeURIComponent(formatTestName(ft.testName))}`)}
                                             target="_blank"
                                             rel="noopener noreferrer"
                                         >
@@ -313,7 +314,7 @@ function App() {
                                     <li key={idx} className="it-passed-item">
                                         <a
                                             className="it-passed-name"
-                                            href={`/nightly-runs.html?date=${encodeURIComponent(selectedDate!)}#${encodeURIComponent(formatTestName(pt.testName))}`}
+                                            href={pageUrl(`/nightly-runs.html?date=${encodeURIComponent(selectedDate!)}#${encodeURIComponent(formatTestName(pt.testName))}`)}
                                             target="_blank"
                                             rel="noopener noreferrer"
                                         >
@@ -408,8 +409,8 @@ function AppSnapshotPreview({ date, testName }: { date: string; testName: string
         );
     }
 
-    const url = `/api/fetch?path=${encodeURIComponent(blobName)}`;
-    const viewerUrl = `/image-viewer.html?path=${encodeURIComponent(blobName)}`;
+    const url = apiUrl(`/api/fetch?path=${encodeURIComponent(blobName)}`);
+    const viewerUrl = pageUrl(`/image-viewer.html?path=${encodeURIComponent(blobName)}`);
     return (
         <div className="it-app-snapshot">
             <a

--- a/dashboard/src/msbench-nightly-runs/App.tsx
+++ b/dashboard/src/msbench-nightly-runs/App.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import FileViewer from "./FileViewer";
 import type { BlobEntry, BlobTree, BlobTreeNode } from "../shared/blobTree";
+import { apiUrl } from "../shared/apiUrl";
 
 /**
  * Recursively collect all .md files from a blob tree node.
@@ -51,7 +52,7 @@ function Dashboard() {
 
     // Fetch available dates on mount
     useEffect(() => {
-        fetch("/api/msbench-dates")
+        fetch(apiUrl("/api/msbench-dates"))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();
@@ -78,7 +79,7 @@ function Dashboard() {
         setSelectedReport(null);
         setReportMarkdown("");
 
-        fetch(`/api/msbench-data/${encodeURIComponent(selectedDate)}`)
+        fetch(apiUrl(`/api/msbench-data/${encodeURIComponent(selectedDate)}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();
@@ -105,7 +106,7 @@ function Dashboard() {
         }
 
         setLoadingReport(true);
-        fetch(`/api/msbench-download?path=${encodeURIComponent(selectedReport.blobName)}`)
+        fetch(apiUrl(`/api/msbench-download?path=${encodeURIComponent(selectedReport.blobName)}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`Failed to load report: ${res.status}`);
                 return res.text();

--- a/dashboard/src/msbench-nightly-runs/FileViewer.tsx
+++ b/dashboard/src/msbench-nightly-runs/FileViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { apiUrl } from "../shared/apiUrl";
 
 interface FileViewerProps {
     blobPath: string;
@@ -19,7 +20,7 @@ function FileViewer({ blobPath }: FileViewerProps) {
         setError(null);
         setContent("");
 
-        fetch(`/api/msbench-download?path=${encodeURIComponent(blobPath)}`)
+        fetch(apiUrl(`/api/msbench-download?path=${encodeURIComponent(blobPath)}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`Failed to load file: ${res.status}`);
                 return res.text();
@@ -30,7 +31,7 @@ function FileViewer({ blobPath }: FileViewerProps) {
     }, [blobPath]);
 
     const handleDownload = () => {
-        window.open(`/api/msbench-download?path=${encodeURIComponent(blobPath)}`, "_blank");
+        window.open(apiUrl(`/api/msbench-download?path=${encodeURIComponent(blobPath)}`), "_blank");
     };
 
     const handleBack = () => {

--- a/dashboard/src/nightly-runs/App.tsx
+++ b/dashboard/src/nightly-runs/App.tsx
@@ -129,7 +129,12 @@ function Dashboard() {
     }, [selectedDate]);
 
     const handleDownload = useCallback((blobName: string) => {
-        const viewerUrl = `${window.location.origin}${window.location.pathname}?file=${encodeURIComponent(blobName)}`;
+        const params = new URLSearchParams({ file: blobName });
+        const container = new URLSearchParams(window.location.search).get("container");
+        if (container) {
+            params.set("container", container);
+        }
+        const viewerUrl = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
         window.open(viewerUrl, "_blank");
     }, []);
 

--- a/dashboard/src/nightly-runs/App.tsx
+++ b/dashboard/src/nightly-runs/App.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import FileViewer from "./FileViewer";
 import type { BlobEntry, BlobTree, BlobTreeNode } from "../shared/blobTree";
-import { apiUrl } from "../shared/apiUrl";
+import { apiUrl, pageUrl } from "../shared/apiUrl";
 
 interface FileSection {
     label: string;
@@ -129,12 +129,7 @@ function Dashboard() {
     }, [selectedDate]);
 
     const handleDownload = useCallback((blobName: string) => {
-        const params = new URLSearchParams({ file: blobName });
-        const container = new URLSearchParams(window.location.search).get("container");
-        if (container) {
-            params.set("container", container);
-        }
-        const viewerUrl = `${window.location.origin}${window.location.pathname}?${params.toString()}`;
+        const viewerUrl = pageUrl(`${window.location.pathname}?file=${encodeURIComponent(blobName)}`);
         window.open(viewerUrl, "_blank");
     }, []);
 

--- a/dashboard/src/nightly-runs/App.tsx
+++ b/dashboard/src/nightly-runs/App.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import FileViewer from "./FileViewer";
 import type { BlobEntry, BlobTree, BlobTreeNode } from "../shared/blobTree";
+import { apiUrl } from "../shared/apiUrl";
 
 interface FileSection {
     label: string;
@@ -76,7 +77,7 @@ function Dashboard() {
 
     // Fetch available dates on mount
     useEffect(() => {
-        fetch("/api/dates")
+        fetch(apiUrl("/api/dates"))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();
@@ -103,7 +104,7 @@ function Dashboard() {
         setFileSections([]);
         setReportMarkdown("");
 
-        fetch(`/api/data/${encodeURIComponent(selectedDate)}`)
+        fetch(apiUrl(`/api/data/${encodeURIComponent(selectedDate)}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();
@@ -117,7 +118,7 @@ function Dashboard() {
             .catch((err) => setError(err.message))
             .finally(() => setLoadingData(false));
 
-        fetch(`/api/reports/${encodeURIComponent(selectedDate)}`)
+        fetch(apiUrl(`/api/reports/${encodeURIComponent(selectedDate)}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`Failed to load reports: ${res.status}`);
                 return res.text();

--- a/dashboard/src/nightly-runs/FileViewer.tsx
+++ b/dashboard/src/nightly-runs/FileViewer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { apiUrl } from "../shared/apiUrl";
 
 interface FileViewerProps {
     blobPath: string;
@@ -23,7 +24,7 @@ function FileViewer({ blobPath }: FileViewerProps) {
         setError(null);
         setContent("");
 
-        fetch(`/api/download?path=${encodeURIComponent(blobPath)}`)
+        fetch(apiUrl(`/api/download?path=${encodeURIComponent(blobPath)}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`Failed to load file: ${res.status}`);
                 return res.text();
@@ -34,7 +35,7 @@ function FileViewer({ blobPath }: FileViewerProps) {
     }, [blobPath]);
 
     const handleDownload = () => {
-        window.open(`/api/download?path=${encodeURIComponent(blobPath)}`, "_blank");
+        window.open(apiUrl(`/api/download?path=${encodeURIComponent(blobPath)}`), "_blank");
     };
 
     const handleBack = () => {

--- a/dashboard/src/nightly-runs/FileViewer.tsx
+++ b/dashboard/src/nightly-runs/FileViewer.tsx
@@ -14,6 +14,15 @@ function FileViewer({ blobPath }: FileViewerProps) {
 
     const fileName = blobPath.split("/").pop() ?? "file";
     const extension = fileName.split(".").pop()?.toLowerCase() ?? "";
+    const container = new URLSearchParams(window.location.search).get("container");
+
+    const buildDownloadUrl = (path: string) => {
+        const params = new URLSearchParams({ path });
+        if (container) {
+            params.set("container", container);
+        }
+        return apiUrl(`/api/download?${params.toString()}`);
+    };
 
     useEffect(() => {
         document.title = fileName;
@@ -24,7 +33,7 @@ function FileViewer({ blobPath }: FileViewerProps) {
         setError(null);
         setContent("");
 
-        fetch(apiUrl(`/api/download?path=${encodeURIComponent(blobPath)}`))
+        fetch(buildDownloadUrl(blobPath))
             .then((res) => {
                 if (!res.ok) throw new Error(`Failed to load file: ${res.status}`);
                 return res.text();
@@ -35,7 +44,7 @@ function FileViewer({ blobPath }: FileViewerProps) {
     }, [blobPath]);
 
     const handleDownload = () => {
-        window.open(apiUrl(`/api/download?path=${encodeURIComponent(blobPath)}`), "_blank");
+        window.open(buildDownloadUrl(blobPath), "_blank");
     };
 
     const handleBack = () => {

--- a/dashboard/src/nightly-runs/FileViewer.tsx
+++ b/dashboard/src/nightly-runs/FileViewer.tsx
@@ -14,15 +14,6 @@ function FileViewer({ blobPath }: FileViewerProps) {
 
     const fileName = blobPath.split("/").pop() ?? "file";
     const extension = fileName.split(".").pop()?.toLowerCase() ?? "";
-    const container = new URLSearchParams(window.location.search).get("container");
-
-    const buildDownloadUrl = (path: string) => {
-        const params = new URLSearchParams({ path });
-        if (container) {
-            params.set("container", container);
-        }
-        return apiUrl(`/api/download?${params.toString()}`);
-    };
 
     useEffect(() => {
         document.title = fileName;
@@ -33,7 +24,7 @@ function FileViewer({ blobPath }: FileViewerProps) {
         setError(null);
         setContent("");
 
-        fetch(buildDownloadUrl(blobPath))
+        fetch(apiUrl(`/api/download?path=${encodeURIComponent(blobPath)}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`Failed to load file: ${res.status}`);
                 return res.text();
@@ -44,7 +35,7 @@ function FileViewer({ blobPath }: FileViewerProps) {
     }, [blobPath]);
 
     const handleDownload = () => {
-        window.open(buildDownloadUrl(blobPath), "_blank");
+        window.open(apiUrl(`/api/download?path=${encodeURIComponent(blobPath)}`), "_blank");
     };
 
     const handleBack = () => {

--- a/dashboard/src/performance-dashboard/App.tsx
+++ b/dashboard/src/performance-dashboard/App.tsx
@@ -8,6 +8,7 @@ import {
     Tooltip,
     ResponsiveContainer,
 } from "recharts";
+import { apiUrl } from "../shared/apiUrl";
 
 interface EvalMetricRow {
     date: string;
@@ -75,7 +76,7 @@ export default function App() {
     );
 
     const loadFilters = () =>
-        fetch("/api/msbench-eval-metrics/filters")
+        fetch(apiUrl("/api/msbench-eval-metrics/filters"))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();
@@ -92,7 +93,7 @@ export default function App() {
         if (selectedModel) params.set("model", selectedModel);
         if (selectedResolved) params.set("resolved", selectedResolved);
 
-        return fetch(`/api/msbench-eval-metrics?${params}`)
+        return fetch(apiUrl(`/api/msbench-eval-metrics?${params}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();

--- a/dashboard/src/shared/apiUrl.ts
+++ b/dashboard/src/shared/apiUrl.ts
@@ -1,0 +1,48 @@
+/**
+ * Builds an API URL by merging the page's current query parameters into the
+ * given path. Path-level params take precedence over page-level params, so
+ * explicit caller values are never overwritten.
+ *
+ * Example: page URL is /?container=abc, path is /api/dates
+ * → returns /api/dates?container=abc
+ *
+ * Example: page URL is /?container=abc, path is /api/token-usage?skill=foo
+ * → returns /api/token-usage?container=abc&skill=foo
+ */
+export function apiUrl(path: string): string {
+    const qIdx = path.indexOf("?");
+    const base = qIdx === -1 ? path : path.slice(0, qIdx);
+    const existingSearch = qIdx === -1 ? "" : path.slice(qIdx + 1);
+
+    const params = new URLSearchParams(window.location.search);
+
+    // Path-level params override page-level params
+    if (existingSearch) {
+        for (const [key, value] of new URLSearchParams(existingSearch)) {
+            params.set(key, value);
+        }
+    }
+
+    const qs = params.toString();
+    return qs ? `${base}?${qs}` : base;
+}
+
+/**
+ * Appends the current page's `container` query parameter to a page navigation
+ * URL, if one is present. Handles URLs with fragments correctly by inserting
+ * the param before the `#`.
+ *
+ * Example: page URL is /?container=abc, path is /nightly-runs.html?date=2024-01-01#test
+ * → returns /nightly-runs.html?date=2024-01-01&container=abc#test
+ */
+export function pageUrl(path: string): string {
+    const container = new URLSearchParams(window.location.search).get("container");
+    if (!container) return path;
+
+    const hashIdx = path.indexOf("#");
+    const fragment = hashIdx === -1 ? "" : path.slice(hashIdx);
+    const pathWithoutFragment = hashIdx === -1 ? path : path.slice(0, hashIdx);
+
+    const separator = pathWithoutFragment.includes("?") ? "&" : "?";
+    return `${pathWithoutFragment}${separator}container=${encodeURIComponent(container)}${fragment}`;
+}

--- a/dashboard/src/token-usage/App.tsx
+++ b/dashboard/src/token-usage/App.tsx
@@ -9,6 +9,7 @@ import {
     Legend,
     ResponsiveContainer,
 } from "recharts";
+import { apiUrl } from "../shared/apiUrl";
 
 interface TokenUsageRow {
     skill: string;
@@ -70,7 +71,7 @@ export default function App() {
     const [filtersReady, setFiltersReady] = useState(false);
 
     const loadFilters = () =>
-        fetch("/api/token-usage/filters")
+        fetch(apiUrl("/api/token-usage/filters"))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();
@@ -91,7 +92,7 @@ export default function App() {
         if (selectedTest) params.set("test", selectedTest);
         if (selectedBranch) params.set("branch", selectedBranch);
 
-        return fetch(`/api/token-usage?${params}`)
+        return fetch(apiUrl(`/api/token-usage?${params}`))
             .then((res) => {
                 if (!res.ok) throw new Error(`API error: ${res.status}`);
                 return res.json();

--- a/dashboard/token-usage.html
+++ b/dashboard/token-usage.html
@@ -21,6 +21,7 @@
         <a href="/performance-dashboard.html" class="site-nav-link">MSBench Performance Dashboard</a>
         <a href="/msbench-nightly-runs.html" class="site-nav-link">MSBench Nightly Runs</a>
     </nav>
+    <script src="assets/nav-container.js"></script>
 
     <div id="root"></div>
     <script type="module" src="/src/token-usage/main.tsx"></script>


### PR DESCRIPTION
## Description

The change would allow us to do the following:

1. Create an ad-hoc container to store some test results
2. Compose a link like `<endpoint-to-hosted-dashboard>/integration-tests.html?container=<the ad-hoc container name>`
3. Share the link with the skill owner to review the results and figure out resolutions

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
