### PR TITLE
test: Add "cost" tag.

### DIFF
--- a/evals/azure-compute/eval.yaml
+++ b/evals/azure-compute/eval.yaml
@@ -86,6 +86,7 @@ stimuli:
       tier: smoke
       area: behavior
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -132,6 +133,7 @@ stimuli:
       tier: smoke
       area: behavior
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -178,6 +180,7 @@ stimuli:
       tier: smoke
       area: behavior
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -225,6 +228,7 @@ stimuli:
       tier: smoke
       area: behavior
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -267,6 +271,7 @@ stimuli:
       tier: smoke
       area: behavior
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -311,6 +316,7 @@ stimuli:
       tier: full
       area: behavior
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -359,6 +365,7 @@ stimuli:
       tier: full
       area: output
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -408,6 +415,7 @@ stimuli:
       tier: full
       area: output
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -452,6 +460,7 @@ stimuli:
       tier: full
       area: output
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -497,6 +506,7 @@ stimuli:
       tier: full
       area: output
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -548,6 +558,7 @@ stimuli:
       tier: full
       area: output
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -593,6 +604,7 @@ stimuli:
       tier: full
       area: output
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -645,6 +657,7 @@ stimuli:
       tier: full
       area: behavior
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -695,6 +708,7 @@ stimuli:
       tier: full
       area: output
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -746,6 +760,7 @@ stimuli:
       tier: full
       area: output
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:
@@ -800,6 +815,7 @@ stimuli:
       tier: full
       area: behavior
       skill: azure-compute
+      cost: llm
     constraints:
       max_turns: 40
     graders:


### PR DESCRIPTION
Add the "cost" tag to all the stimuli in evals/azure-compute/eval.yaml. Without these, the `src/vally/cli.ts validate-stimulus` check will fail.

## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
