### PR TITLE
eval: Enforce required skills in test harness

### DIFF
--- a/evals/azure-ai/eval.yaml
+++ b/evals/azure-ai/eval.yaml
@@ -39,6 +39,8 @@ stimuli:
       tier: smoke
       cost: llm
       area: routing
+      requiredSkills:
+        - azure-ai
       earlyTerminate: '[{"type":"skill-call","skill":"azure-ai"},{"type":"tool-call-count","count":3}]'
     graders:
       - type: skill-invocation
@@ -60,6 +62,8 @@ stimuli:
       tier: full
       cost: llm
       area: routing
+      requiredSkills:
+        - azure-ai
       earlyTerminate: '[{"type":"skill-call","skill":"azure-ai"},{"type":"tool-call-count","count":3}]'
     graders:
       - type: skill-invocation

--- a/scripts/src/vally/validate-stimulus.ts
+++ b/scripts/src/vally/validate-stimulus.ts
@@ -27,9 +27,10 @@ type Stimuli = {
     cost?: string;
     area?: string;
     earlyTerminate?: string;
-    followUp?: string[] | string;
+    followUp?: string[];
     systemPrompt?: string;
     takeScreenshot?: string;
+    requiredSkills?: string[];
   };
 };
 
@@ -251,6 +252,29 @@ function validateFollowUpTag(
   return false;
 }
 
+function validateRequiredSkillsTag(
+  displayPath: string,
+  stimulusIndex: number,
+  stimulusName: string | undefined,
+  value: string[] | string | undefined,
+): boolean {
+  if (value === undefined) {
+    return true;
+  }
+
+  if (Array.isArray(value) && value.every((entry) => typeof entry === "string")) {
+    return true;
+  }
+
+  reportValidationError(
+    displayPath,
+    stimulusIndex,
+    stimulusName,
+    "tags.requiredSkills must be a string array",
+  );
+  return false;
+}
+
 function reportValidationError(
   displayPath: string,
   stimulusIndex: number,
@@ -353,6 +377,15 @@ export function validateStimulus(rootDir: string, _args: string[]): void {
         stimulusIndex,
         typedStimulus.name,
         typedStimulus.tags?.followUp,
+      )) {
+        fileHasErrors = true;
+      }
+
+      if (!validateRequiredSkillsTag(
+        displayPath,
+        stimulusIndex,
+        typedStimulus.name,
+        typedStimulus.tags?.requiredSkills
       )) {
         fileHasErrors = true;
       }

--- a/tests/utils/__tests__/char-budget.test.ts
+++ b/tests/utils/__tests__/char-budget.test.ts
@@ -7,80 +7,79 @@ import { jest } from "@jest/globals";
 type CharBudgetModule = typeof import("../char-budget.ts");
 
 async function importCharBudgetWithMocks(
-    skills: string[],
-    descriptions: Record<string, string>
+  skills: string[],
+  descriptions: Record<string, string>
 ): Promise<CharBudgetModule> {
-    jest.resetModules();
+  jest.resetModules();
 
-    await jest.unstable_mockModule("../skill-loader.ts", () => ({
-        listSkills: () => skills,
-        loadSkill: async (skillName: string) => {
-            const description = descriptions[skillName];
-            if (description === undefined) {
-                throw new Error(`Missing mocked description for skill: ${skillName}`);
-            }
-            return {
-                metadata: {
-                    name: skillName,
-                    description,
-                },
-            };
+  jest.unstable_mockModule("../skill-loader.ts", () => ({
+    listSkills: () => skills,
+    loadSkill: async (skillName: string) => {
+      const description = descriptions[skillName];
+      if (description === undefined) {
+        throw new Error(`Missing mocked description for skill: ${skillName}`);
+      }
+      return {
+        metadata: {
+          name: skillName,
+          description,
         },
-    }));
+      };
+    },
+  }));
 
-    return import("../char-budget.ts");
+  return import("../char-budget.ts");
 }
 
 describe("truncateSkills", () => {
-    afterEach(() => {
-        jest.restoreAllMocks();
-        jest.resetModules();
-    });
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+  });
 
-    test("throws when requiredSkills contains an invalid skill", async () => {
-        const { truncateSkills } = await importCharBudgetWithMocks(
-            ["azure-ai", "azure-storage"],
-            {
-                "azure-ai": "Azure AI skill",
-                "azure-storage": "Azure Storage skill",
-            }
-        );
+  test("throws when requiredSkills contains an invalid skill", async () => {
+    const { truncateSkills } = await importCharBudgetWithMocks(
+      ["azure-ai", "azure-storage"],
+      {
+        "azure-ai": "Azure AI skill",
+        "azure-storage": "Azure Storage skill",
+      }
+    );
 
-        await expect(truncateSkills(["azure-ai", "not-a-skill"], 20000)).rejects.toThrow(
-            "Invalid requiredSkills"
-        );
-    });
+    await expect(truncateSkills(["azure-ai", "not-a-skill"], 20000)).rejects.toThrow(
+      "Invalid requiredSkills"
+    );
+  });
 
-    test("throws when required skills alone exceed char budget", async () => {
-        const { truncateSkills } = await importCharBudgetWithMocks(
-            ["azure-ai"],
-            {
-                "azure-ai": "x".repeat(200),
-            }
-        );
+  test("throws when required skills alone exceed char budget", async () => {
+    const { truncateSkills } = await importCharBudgetWithMocks(
+      ["azure-ai"],
+      {
+        "azure-ai": "x".repeat(200),
+      }
+    );
 
-        await expect(truncateSkills(["azure-ai"], 20)).rejects.toThrow(
-            "requiredSkills exceed SKILL_CHAR_BUDGET (20)"
-        );
-    });
+    await expect(truncateSkills(["azure-ai"], 20)).rejects.toThrow(
+      "requiredSkills exceed SKILL_CHAR_BUDGET (20)"
+    );
+  });
 
-    test("disables a non-required skill when total equals budget (>= cutoff)", async () => {
-        const descriptions = {
-            required: "required desc",
-            edge: "edge desc",
-        };
-        const { truncateSkills, getFormattedSkillDescription } = await importCharBudgetWithMocks(
-            ["required", "edge"],
-            descriptions
-        );
+  test("disables a non-required skill when total equals budget (>= cutoff)", async () => {
+    const descriptions = {
+      required: "required desc",
+      edge: "edge desc",
+    };
+    const { truncateSkills, getFormattedSkillDescription } = await importCharBudgetWithMocks(
+      ["required", "edge"],
+      descriptions
+    );
 
-        const requiredLen = (await getFormattedSkillDescription("required", descriptions.required)).length;
-        const edgeLen = (await getFormattedSkillDescription("edge", descriptions.edge)).length;
-        const equalBudget = requiredLen + 1 + edgeLen + 1;
+    const requiredLen = (await getFormattedSkillDescription("required", descriptions.required)).length;
+    const edgeLen = (await getFormattedSkillDescription("edge", descriptions.edge)).length;
+    const equalBudget = requiredLen + 1 + edgeLen + 1;
 
-        const disabled = await truncateSkills(["required"], equalBudget);
+    const disabled = await truncateSkills(["required"], equalBudget);
 
-        expect(disabled).toEqual(["edge"]);
-    });
+    expect(disabled).toEqual(["edge"]);
+  });
 });
-

--- a/tests/utils/__tests__/char-budget.test.ts
+++ b/tests/utils/__tests__/char-budget.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Tests for char-budget helpers used for enforcing required skills.
+ */
+
+import { jest } from "@jest/globals";
+
+type CharBudgetModule = typeof import("../char-budget.ts");
+
+async function importCharBudgetWithMocks(
+    skills: string[],
+    descriptions: Record<string, string>
+): Promise<CharBudgetModule> {
+    jest.resetModules();
+
+    await jest.unstable_mockModule("../skill-loader.ts", () => ({
+        listSkills: () => skills,
+        loadSkill: async (skillName: string) => {
+            const description = descriptions[skillName];
+            if (description === undefined) {
+                throw new Error(`Missing mocked description for skill: ${skillName}`);
+            }
+            return {
+                metadata: {
+                    name: skillName,
+                    description,
+                },
+            };
+        },
+    }));
+
+    return import("../char-budget.ts");
+}
+
+describe("truncateSkills", () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+        jest.resetModules();
+    });
+
+    test("throws when requiredSkills contains an invalid skill", async () => {
+        const { truncateSkills } = await importCharBudgetWithMocks(
+            ["azure-ai", "azure-storage"],
+            {
+                "azure-ai": "Azure AI skill",
+                "azure-storage": "Azure Storage skill",
+            }
+        );
+
+        await expect(truncateSkills(["azure-ai", "not-a-skill"], 20000)).rejects.toThrow(
+            "Invalid requiredSkills"
+        );
+    });
+
+    test("throws when required skills alone exceed char budget", async () => {
+        const { truncateSkills } = await importCharBudgetWithMocks(
+            ["azure-ai"],
+            {
+                "azure-ai": "x".repeat(200),
+            }
+        );
+
+        await expect(truncateSkills(["azure-ai"], 20)).rejects.toThrow(
+            "requiredSkills exceed SKILL_CHAR_BUDGET (20)"
+        );
+    });
+
+    test("disables a non-required skill when total equals budget (>= cutoff)", async () => {
+        const descriptions = {
+            required: "required desc",
+            edge: "edge desc",
+        };
+        const { truncateSkills, getFormattedSkillDescription } = await importCharBudgetWithMocks(
+            ["required", "edge"],
+            descriptions
+        );
+
+        const requiredLen = (await getFormattedSkillDescription("required", descriptions.required)).length;
+        const edgeLen = (await getFormattedSkillDescription("edge", descriptions.edge)).length;
+        const equalBudget = requiredLen + 1 + edgeLen + 1;
+
+        const disabled = await truncateSkills(["required"], equalBudget);
+
+        expect(disabled).toEqual(["edge"]);
+    });
+});
+

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -677,7 +677,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
       const existingNodeOptions = process.env.NODE_OPTIONS;
       const envVar: Record<string, string> = {
         SKILLS_INSTRUCTIONS: "true",
-        SKILL_CHAR_BUDGET: "20000",
+        SKILL_CHAR_BUDGET: `${DEFAULT_SKILL_CHAR_BUDGET}`,
         NODE_OPTIONS: existingNodeOptions
           ? `${existingNodeOptions} --disable-warning=ExperimentalWarning`
           : "--disable-warning=ExperimentalWarning"

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -19,6 +19,7 @@ import { fileURLToPath } from "url";
 import { type CopilotSession, CopilotClient, type SessionEvent, approveAll, type SystemMessageConfig } from "@github/copilot-sdk";
 import { redactSecrets } from "./redact.ts";
 import { listSkills } from "./skill-loader.ts";
+import { DEFAULT_SKILL_CHAR_BUDGET, truncateSkills } from "./char-budget.ts";
 
 // Re-export for backward compatibility (consumers still import from agent-runner)
 export { getAllAssistantMessages } from "./evaluate.ts";
@@ -131,6 +132,7 @@ export interface AgentRunConfig {
   /**
    * Skills to include for the agent run.
    * If undefined, all the skills in azure plugin will be included.
+   * If specified, only the skills in this array will be included. This option overrides the required skills specified in the {@link requiredSkills}.
    */
   includeSkills?: string[];
 
@@ -147,6 +149,12 @@ export interface AgentRunConfig {
   takeScreenshot?: {
     predicate: (agentMetadata: AgentMetadata) => boolean
   };
+
+  /**
+   * Skills that must be present with full description.
+   * Skills other than the required ones will be randomly disabled until the estimated char count falls below the char count budget.
+   */
+  requiredSkills?: string[];
 }
 
 interface KeywordOptions {
@@ -633,33 +641,33 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
     });
   }
 
-  async function run(config: AgentRunConfig): Promise<AgentMetadata> {
+  async function run(runConfig: AgentRunConfig): Promise<AgentMetadata> {
     let testWorkspace: string;
-    if (config.workspace) {
-      testWorkspace = config.workspace;
+    if (runConfig.workspace) {
+      testWorkspace = runConfig.workspace;
     } else {
       testWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "skill-test-"));
     }
-    const FOLLOW_UP_TIMEOUT = config.followUpTimeout ?? 1800000; // 30 minutes by default
+    const FOLLOW_UP_TIMEOUT = runConfig.followUpTimeout ?? 1800000; // 30 minutes by default
 
     let isComplete = false;
 
-    const entry: RunnerCleanup = { config };
+    const entry: RunnerCleanup = { config: runConfig };
     currentCleanups.push(entry);
     entry.workspace = testWorkspace;
-    entry.preserveWorkspace = config.preserveWorkspace;
+    entry.preserveWorkspace = runConfig.preserveWorkspace;
 
     const agentMetadata: AgentMetadata = { events: [], testComments: [], toolCounts: {}, skillFiles: {} };
     entry.agentMetadata = agentMetadata;
 
     try {
       // Run optional setup
-      if (config.setup) {
-        await config.setup(testWorkspace);
+      if (runConfig.setup) {
+        await runConfig.setup(testWorkspace);
       }
 
       // Copilot client with yolo mode
-      const cliArgs: string[] = config.nonInteractive ? ["--yolo"] : [];
+      const cliArgs: string[] = runConfig.nonInteractive ? ["--yolo"] : [];
       if (process.env.DEBUG && isTest()) {
         cliArgs.push("--log-dir");
         cliArgs.push(buildTestCaseDirPath(getTestName()));
@@ -690,17 +698,24 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
       const skillDirectory = path.resolve(__dirname, "../../output/skills");
 
       let disabledSkills: string[] | undefined;
-      if (config.includeSkills) {
+      if (runConfig.includeSkills) {
         const skills = listSkills();
-        if (config.includeSkills.some((skillName) => !skills.includes(skillName))) {
-          const invalidSkills = config.includeSkills.filter((skillName) => !skills.includes(skillName));
+        if (runConfig.includeSkills.some((skillName) => !skills.includes(skillName))) {
+          const invalidSkills = runConfig.includeSkills.filter((skillName) => !skills.includes(skillName));
           throw new Error(`Invalid includeSkills. ${invalidSkills} are not valid skills.`);
         }
-        disabledSkills = skills.filter((skillName) => !config.includeSkills?.includes(skillName));
+        disabledSkills = skills.filter((skillName) => !runConfig.includeSkills?.includes(skillName));
+      } else {
+        // Keep all the required skills, then randomly drop the remaining skills until the estimated char count falls below the budget.
+        // Copilot CLI effectively randomly truncates skills after exceeding the char count budget.
+        // We emulate Copilot CLI's behavior by preserving the required skills and randomly disable the rest of the skills.
+        if (runConfig.requiredSkills) {
+          disabledSkills = await truncateSkills(runConfig.requiredSkills, DEFAULT_SKILL_CHAR_BUDGET);
+        }
       }
 
       const noSkills = process.env.NO_SKILLS === "true";
-      const model = config.model ?? modelOverride ?? "claude-sonnet-4.6";
+      const model = runConfig.model ?? modelOverride ?? "claude-sonnet-4.6";
       const session = await client.createSession({
         model: model,
         onPermissionRequest: approveAll,
@@ -714,7 +729,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
             tools: ["*"]
           }
         },
-        systemMessage: config.systemPrompt
+        systemMessage: runConfig.systemPrompt
       });
       entry.session = session;
 
@@ -734,7 +749,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
 
           agentMetadata.events.push(event);
 
-          if (config.shouldEarlyTerminate?.(agentMetadata)) {
+          if (runConfig.shouldEarlyTerminate?.(agentMetadata)) {
             isComplete = true;
             resolve();
             void session.abort();
@@ -743,12 +758,12 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
         });
       });
 
-      await session.send({ prompt: config.prompt });
+      await session.send({ prompt: runConfig.prompt });
       await done;
 
       // Send follow-up prompts before aggregating stats so tool/skill/token
       // counts include events emitted during follow-up turns.
-      for (const followUpPrompt of config.followUp ?? []) {
+      for (const followUpPrompt of runConfig.followUp ?? []) {
         isComplete = false;
         await session.sendAndWait({ prompt: followUpPrompt }, FOLLOW_UP_TIMEOUT);
       }
@@ -805,7 +820,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
       agentMetadata.toolCounts = toolCounts;
       agentMetadata.skillFiles = skillFiles;
 
-      if (config.takeScreenshot && config.takeScreenshot.predicate(agentMetadata)) {
+      if (runConfig.takeScreenshot && runConfig.takeScreenshot.predicate(agentMetadata)) {
         // Resume the session so it can take a different set of skills and mcp servers.
         // Use playwright mcp server to take a screenshot.
         const screenshotTimeout = 180000; // 3 minutes

--- a/tests/utils/char-budget.ts
+++ b/tests/utils/char-budget.ts
@@ -9,6 +9,10 @@ export const DEFAULT_SKILL_CHAR_BUDGET = 20000;
  */
 export async function truncateSkills(requiredSkills: string[], charBudget: number): Promise<string[] | undefined> {
   const skills = listSkills();
+  const invalidSkills = requiredSkills.filter((s) => !skills.includes(s));
+  if (invalidSkills.length > 0) {
+    throw new Error(`Invalid requiredSkills. ${invalidSkills} do not exist in azure-skills plugin.`);
+  }
   const nonRequiredSkills = skills.filter((s) => !requiredSkills.includes(s));
   let charCount = 0;
 
@@ -16,7 +20,7 @@ export async function truncateSkills(requiredSkills: string[], charBudget: numbe
     const skillXml = await formatSkillForToolDescription(skill);
     // +1 for newline between skills
     charCount += skillXml.length + 1;
-  };
+  }
 
   // Fisher-Yates shuffle
   for (let i = nonRequiredSkills.length - 1; i > 0; i--) {
@@ -33,7 +37,6 @@ export async function truncateSkills(requiredSkills: string[], charBudget: numbe
     } else {
       charCount += skillXml.length + 1;
     }
-    console.log("skill", skill, "chatCount", charCount);
   }
 
   return [];

--- a/tests/utils/char-budget.ts
+++ b/tests/utils/char-budget.ts
@@ -15,9 +15,8 @@ export async function truncateSkills(requiredSkills: string[], charBudget: numbe
   for (const skill of requiredSkills) {
     const skillXml = await formatSkillForToolDescription(skill);
     // +1 for newline between skills
-    charCount += skillXml.length + 1
+    charCount += skillXml.length + 1;
   };
-
 
   // Fisher-Yates shuffle
   for (let i = nonRequiredSkills.length - 1; i > 0; i--) {

--- a/tests/utils/char-budget.ts
+++ b/tests/utils/char-budget.ts
@@ -1,0 +1,67 @@
+import { listSkills, loadSkill } from "./skill-loader.ts";
+
+export const DEFAULT_SKILL_CHAR_BUDGET = 20000;
+
+/**
+ * Load all skills from azure-skills plugin, preserve the required ones and randomly drop the rest of the skills until the estimated char usage falls below the budget.
+ * @param requiredSkills skills that cannot be truncated.
+ * @returns the skills to disable to emulate truncation.
+ */
+export async function truncateSkills(requiredSkills: string[], charBudget: number): Promise<string[] | undefined> {
+  const skills = listSkills();
+  const nonRequiredSkills = skills.filter((s) => !requiredSkills.includes(s));
+  let charCount = 0;
+
+  for (const skill of requiredSkills) {
+    const skillXml = await formatSkillForToolDescription(skill);
+    // +1 for newline between skills
+    charCount += skillXml.length + 1
+  };
+
+
+  // Fisher-Yates shuffle
+  for (let i = nonRequiredSkills.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [nonRequiredSkills[i], nonRequiredSkills[j]] = [nonRequiredSkills[j], nonRequiredSkills[i]];
+  }
+
+  for (let i = 0; i < nonRequiredSkills.length; i++) {
+    const skill = nonRequiredSkills[i];
+    const skillXml = await formatSkillForToolDescription(skill);
+    if (charCount + skillXml.length + 1 >= charBudget) {
+      // Return a list of skills including and after the current one
+      return nonRequiredSkills.slice(i);
+    } else {
+      charCount += skillXml.length + 1;
+    }
+    console.log("skill", skill, "chatCount", charCount);
+  }
+
+  return [];
+}
+
+async function formatSkillForToolDescription(skillName: string): Promise<string> {
+  const skill = await loadSkill(skillName);
+
+  // azure plugin skills are loaded from "Custom" locations when they are installed via marketplace.
+  // The formatted text may be different but the char count would be similar.
+  return `<skill>
+  <name>${escapeXml(skill.metadata.name)}</name>
+  <description>${escapeXml(skill.metadata.description)}</description>
+  <location>Custom</location>
+</skill>`;
+}
+
+/**
+ * Escapes special XML characters in a string.
+ * @param str - The string to escape
+ * @returns The escaped string
+ */
+export function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}

--- a/tests/utils/char-budget.ts
+++ b/tests/utils/char-budget.ts
@@ -17,9 +17,16 @@ export async function truncateSkills(requiredSkills: string[], charBudget: numbe
   let charCount = 0;
 
   for (const skill of requiredSkills) {
-    const skillXml = await formatSkillForToolDescription(skill);
+    const skillObject = await loadSkill(skill);
+    const skillXml = await getFormattedSkillDescription(skillObject.metadata.name, skillObject.metadata.description);
     // +1 for newline between skills
     charCount += skillXml.length + 1;
+  }
+
+  if (charCount > charBudget) {
+    throw new Error(
+      `requiredSkills exceed SKILL_CHAR_BUDGET (${charBudget}). Required skills consume ${charCount} chars; cannot guarantee required skill descriptions will be preserved.`,
+    );
   }
 
   // Fisher-Yates shuffle
@@ -30,7 +37,8 @@ export async function truncateSkills(requiredSkills: string[], charBudget: numbe
 
   for (let i = 0; i < nonRequiredSkills.length; i++) {
     const skill = nonRequiredSkills[i];
-    const skillXml = await formatSkillForToolDescription(skill);
+    const skillObject = await loadSkill(skill);
+    const skillXml = await getFormattedSkillDescription(skillObject.metadata.name, skillObject.metadata.description);
     if (charCount + skillXml.length + 1 >= charBudget) {
       // Return a list of skills including and after the current one
       return nonRequiredSkills.slice(i);
@@ -42,14 +50,12 @@ export async function truncateSkills(requiredSkills: string[], charBudget: numbe
   return [];
 }
 
-async function formatSkillForToolDescription(skillName: string): Promise<string> {
-  const skill = await loadSkill(skillName);
-
+export async function getFormattedSkillDescription(skillName: string, description: string): Promise<string> {
   // azure plugin skills are loaded from "Custom" locations when they are installed via marketplace.
   // The formatted text may be different but the char count would be similar.
   return `<skill>
-  <name>${escapeXml(skill.metadata.name)}</name>
-  <description>${escapeXml(skill.metadata.description)}</description>
+  <name>${escapeXml(skillName)}</name>
+  <description>${escapeXml(description)}</description>
   <location>Custom</location>
 </skill>`;
 }

--- a/tests/vally/tag-helpers.ts
+++ b/tests/vally/tag-helpers.ts
@@ -49,11 +49,6 @@ export type TakeScreenshotCondition = {
   urlPattern: string;
 }
 
-export type RequiredSkillsCondition = {
-  type: "required-skills"
-  skills: string[];
-}
-
 export function isSkillInvocationTest(tags: Record<string, string | string[]> | undefined): boolean {
   return tags?.area === "routing";
 }

--- a/tests/vally/tag-helpers.ts
+++ b/tests/vally/tag-helpers.ts
@@ -49,6 +49,11 @@ export type TakeScreenshotCondition = {
   urlPattern: string;
 }
 
+export type RequiredSkillsCondition = {
+  type: "required-skills"
+  skills: string[];
+}
+
 export function isSkillInvocationTest(tags: Record<string, string | string[]> | undefined): boolean {
   return tags?.area === "routing";
 }
@@ -195,5 +200,23 @@ export function getTakeScreenshotCondition(tags: Record<string, string[] | strin
   } catch (error) {
     console.error("Failed to parse takeScreenshot condition", value, error);
     return {};
+  }
+}
+
+export function getRequiredSkillsCondition(tags: Record<string, string[] | string> | undefined): string[] | undefined {
+  if (!tags) {
+    return undefined;
+  }
+
+  const value = tags["requiredSkills"];
+
+  if (!value) {
+    return undefined;
+  }
+  if (Array.isArray(value)) {
+    return value;
+  } else {
+    console.error("Failed to get requiredSkills from tags", value);
+    return undefined;
   }
 }

--- a/tests/vally/vally-executor.ts
+++ b/tests/vally/vally-executor.ts
@@ -3,7 +3,7 @@ import { computeMetrics } from "@microsoft/vally";
 import type { AgentMetadata, AgentRunConfig } from "../utils/agent-runner.ts";
 import { useAgentRunner, createMarkdownReport } from "../utils/agent-runner.ts";
 import { listSkills } from "../utils/skill-loader.ts";
-import { getEarlyTerminateCondition, getFollowUp, getSkillName, getSystemPrompt, getTakeScreenshotCondition } from "./tag-helpers.ts";
+import { getEarlyTerminateCondition, getFollowUp, getRequiredSkillsCondition, getSkillName, getSystemPrompt, getTakeScreenshotCondition } from "./tag-helpers.ts";
 import { normalizeTestName } from "./utils.ts";
 
 export class IntegrationTestAgentRunner implements Executor {
@@ -30,6 +30,7 @@ export class IntegrationTestAgentRunner implements Executor {
     const followUp = getFollowUp(tags);
     const systemPrompt = getSystemPrompt(tags);
     const { takeScreenshot } = getTakeScreenshotCondition(tags);
+    const requiredSkills = getRequiredSkillsCondition(tags);
     const timeout = options.timeout;
 
     const runConfig: AgentRunConfig = {
@@ -42,6 +43,7 @@ export class IntegrationTestAgentRunner implements Executor {
       systemPrompt: systemPrompt,
       followUpTimeout: timeout,
       takeScreenshot: takeScreenshot,
+      requiredSkills: requiredSkills,
       // Always make our agent runner preserve workspace.
       // vally will delete the test workspace by default.
       preserveWorkspace: true


### PR DESCRIPTION
## Description

Allow vally eval suites to declare required skills, which prevents Copilot CLI from truncating them due to exceeding char budget. The test harness will guarantee the required skills are present, and randomly drop non-required skills emulating the truncation behavior of Copilot CLI.

This change would allow us to ship more skills and exceed the char count budget while still achieve meaningful test results.

Added requiredSkills tags to azure-ai eval suites as an example. Validation scripts are added to help use the new tag correctly.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->