### PR TITLE
chore: disable automatic analyze-test-run

### DIFF
--- a/.github/workflows/analyze-test-run.lock.yml
+++ b/.github/workflows/analyze-test-run.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"717d0e9544b999b70bd81d7d80078304d369696392e8c607b6995f3b8d8542c9","body_hash":"912978c046e7eb9ec466f4252253458f1db9e2fbd74f06edbb327cd1b34b2b1b","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v4","frontmatter_hash":"67700342fb62168cc9dd749824a16e332a83c40ba40759293af0389be7590dbc","body_hash":"912978c046e7eb9ec466f4252253458f1db9e2fbd74f06edbb327cd1b34b2b1b","compiler_version":"v0.77.5","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/github-script","sha":"3a2844b7e9c422d3c10d287c895573f7108da1b3","version":"v9.0.0"},{"repo":"actions/github-script","sha":"d746ffe35508b1917358783b479e04febd2b8f71","version":"v9.0.0"},{"repo":"actions/setup-node","sha":"48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e","version":"v6.4.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"github/gh-aw-actions/setup","sha":"3ea13c02d765410340d533515cb31a7eef2baaf0","version":"v0.77.5"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.58"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.58"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.3.22"},{"image":"ghcr.io/github/github-mcp-server:v1.1.0"},{"image":"node:lts-alpine","digest":"sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14","pinned_image":"node:lts-alpine@sha256:2bdb65ed1dab192432bc31c95f94155ca5ad7fc1392fb7eb7526ab682fa5bf14"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -62,14 +62,6 @@ on:
         description: GitHub Actions run ID or run URL to analyze
         required: true
         type: string
-  workflow_run:
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    branches:
-    - main
-    types:
-    - completed
-    workflows:
-    - "Integration Tests - all"
 
 permissions: {}
 
@@ -80,12 +72,7 @@ run-name: "Analyze Test Run"
 
 jobs:
   activation:
-    needs: pre_activation
-    # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
-    if: >
-      (needs.pre_activation.outputs.activated == 'true' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'schedule')) &&
-      (github.event_name != 'workflow_run' || github.event.workflow_run.repository.id == github.repository_id &&
-      (!(github.event.workflow_run.repository.fork)))
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'schedule'
     runs-on: ubuntu-slim
     permissions:
       actions: read
@@ -108,8 +95,6 @@ jobs:
         with:
           destination: ${{ runner.temp }}/gh-aw/actions
           job-name: ${{ github.job }}
-          trace-id: ${{ needs.pre_activation.outputs.setup-trace-id }}
-          parent-span-id: ${{ needs.pre_activation.outputs.setup-parent-span-id || needs.pre_activation.outputs.setup-span-id }}
         env:
           GH_AW_SETUP_WORKFLOW_NAME: "Analyze Test Run"
           GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/analyze-test-run.lock.yml@${{ github.ref }}
@@ -208,20 +193,20 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_629c29e73de2203d_EOF'
+          cat << 'GH_AW_PROMPT_448e273b28b5c894_EOF'
           <system>
-          GH_AW_PROMPT_629c29e73de2203d_EOF
+          GH_AW_PROMPT_448e273b28b5c894_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_629c29e73de2203d_EOF'
+          cat << 'GH_AW_PROMPT_448e273b28b5c894_EOF'
           <safe-output-tools>
           Tools: create_issue(max:10), missing_tool, missing_data, noop
           </safe-output-tools>
-          GH_AW_PROMPT_629c29e73de2203d_EOF
+          GH_AW_PROMPT_448e273b28b5c894_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/mcp_cli_tools_prompt.md"
-          cat << 'GH_AW_PROMPT_629c29e73de2203d_EOF'
+          cat << 'GH_AW_PROMPT_448e273b28b5c894_EOF'
           <github-context>
           The following GitHub context information is available for this workflow:
           {{#if github.actor}}
@@ -250,13 +235,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_629c29e73de2203d_EOF
+          GH_AW_PROMPT_448e273b28b5c894_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_629c29e73de2203d_EOF'
+          cat << 'GH_AW_PROMPT_448e273b28b5c894_EOF'
           </system>
           {{#runtime-import .github/skills/analyze-test-run/SKILL.md}}
           {{#runtime-import .github/workflows/analyze-test-run.md}}
-          GH_AW_PROMPT_629c29e73de2203d_EOF
+          GH_AW_PROMPT_448e273b28b5c894_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
@@ -284,7 +269,6 @@ jobs:
           GH_AW_GITHUB_RUN_ID: ${{ github.run_id }}
           GH_AW_GITHUB_WORKSPACE: ${{ github.workspace }}
           GH_AW_MCP_CLI_SERVERS_LIST: '- `safeoutputs` — run `safeoutputs --help` to see available tools'
-          GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: ${{ needs.pre_activation.outputs.activated }}
         with:
           script: |
             const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
@@ -305,8 +289,7 @@ jobs:
                 GH_AW_GITHUB_REPOSITORY: process.env.GH_AW_GITHUB_REPOSITORY,
                 GH_AW_GITHUB_RUN_ID: process.env.GH_AW_GITHUB_RUN_ID,
                 GH_AW_GITHUB_WORKSPACE: process.env.GH_AW_GITHUB_WORKSPACE,
-                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST,
-                GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED: process.env.GH_AW_NEEDS_PRE_ACTIVATION_OUTPUTS_ACTIVATED
+                GH_AW_MCP_CLI_SERVERS_LIST: process.env.GH_AW_MCP_CLI_SERVERS_LIST
               }
             });
       - name: Validate prompt placeholders
@@ -345,9 +328,6 @@ jobs:
       actions: read
       contents: read
       issues: read
-    concurrency:
-      group: "gh-aw-copilot-${{ github.workflow }}"
-      queue: max
     env:
       DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
       GH_AW_ASSETS_ALLOWED_EXTS: ""
@@ -473,9 +453,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_3b2b8eb392e21bae_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_95ff0fefd403750f_EOF'
           {"create_issue":{"labels":["bug","integration-test"],"max":10},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_3b2b8eb392e21bae_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_95ff0fefd403750f_EOF
       - name: Generate Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -683,7 +663,7 @@ jobs:
           
           mkdir -p /home/runner/.copilot
           GH_AW_NODE=$(which node 2>/dev/null || command -v node 2>/dev/null || echo node)
-          cat << GH_AW_MCP_CONFIG_6e0c795bc89617a7_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
+          cat << GH_AW_MCP_CONFIG_5fbe8aeb73870b0b_EOF | "$GH_AW_NODE" "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.cjs"
           {
             "mcpServers": {
               "github": {
@@ -724,7 +704,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_6e0c795bc89617a7_EOF
+          GH_AW_MCP_CONFIG_5fbe8aeb73870b0b_EOF
       - name: Mount MCP servers as CLIs
         id: mount-mcp-clis
         continue-on-error: true
@@ -1331,41 +1311,6 @@ jobs:
                 core.setFailed(msg);
               }
             }
-
-  pre_activation:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'schedule'
-    runs-on: ubuntu-slim
-    outputs:
-      activated: ${{ steps.check_membership.outputs.is_team_member == 'true' }}
-      matched_command: ''
-      setup-parent-span-id: ${{ steps.setup.outputs.parent-span-id || steps.setup.outputs.span-id }}
-      setup-span-id: ${{ steps.setup.outputs.span-id }}
-      setup-trace-id: ${{ steps.setup.outputs.trace-id }}
-    steps:
-      - name: Setup Scripts
-        id: setup
-        uses: github/gh-aw-actions/setup@3ea13c02d765410340d533515cb31a7eef2baaf0 # v0.77.5
-        with:
-          destination: ${{ runner.temp }}/gh-aw/actions
-          job-name: ${{ github.job }}
-        env:
-          GH_AW_SETUP_WORKFLOW_NAME: "Analyze Test Run"
-          GH_AW_CURRENT_WORKFLOW_REF: ${{ github.repository }}/.github/workflows/analyze-test-run.lock.yml@${{ github.ref }}
-          GH_AW_INFO_VERSION: "1.0.55"
-          GH_AW_INFO_AWF_VERSION: "v0.25.58"
-          GH_AW_INFO_ENGINE_ID: "copilot"
-      - name: Check team membership for workflow
-        id: check_membership
-        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
-        env:
-          GH_AW_REQUIRED_ROLES: "admin,maintainer,write"
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { setupGlobals } = require('${{ runner.temp }}/gh-aw/actions/setup_globals.cjs');
-            setupGlobals(core, github, context, exec, io, getOctokit);
-            const { main } = require('${{ runner.temp }}/gh-aw/actions/check_membership.cjs');
-            await main();
 
   safe_outputs:
     needs:

--- a/.github/workflows/analyze-test-run.md
+++ b/.github/workflows/analyze-test-run.md
@@ -10,11 +10,11 @@ on:
         description: "GitHub Actions run ID or run URL to analyze"
         required: true
         type: string
-  workflow_run:
-    workflows: ["Integration Tests - all"]
-    types: [completed]
-    branches:
-      - main
+  # workflow_run:
+  #   workflows: ["Integration Tests - all"]
+  #   types: [completed]
+  #   branches:
+  #     - main
 
 if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.event == 'schedule'
 

--- a/.github/workflows/analyze-test-run.md
+++ b/.github/workflows/analyze-test-run.md
@@ -10,6 +10,9 @@ on:
         description: "GitHub Actions run ID or run URL to analyze"
         required: true
         type: string
+  # As of June 10th 2026, we keep getting 429 errors for the automated agentic workflow runs.
+  # Also due to flakiness of some of the tests, we are running out of resource for reviewing and addressing auto created issues.
+  # We may re-enable it when the tests are less flaky and the rate limiting allows them to do meaningful work. 
   # workflow_run:
   #   workflows: ["Integration Tests - all"]
   #   types: [completed]


### PR DESCRIPTION
## Description

This workflow had gotten a lot of 429 errors in the past few days. There is no point keep running them when most of them get rate limited. 

For copilot reviewr: yml file is compiled artifact from the modified markdown. Don't ask me to modify anything in it.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
