### PR TITLE
chore: Let vally test step continue on error

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -307,6 +307,7 @@ jobs:
         run: |
           echo test with $MODEL_OVERRIDE
           npm run test:vally -- --skill $SKILL
+        continue-on-error: false
 
       - name: Generate skill report
         if: always()


### PR DESCRIPTION
## Description

Let vally test step continue on error so the process exit code won't cause the subsequent steps for collecting partial results to skip.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
