### PR TITLE
fix: mitigate action cancel error (maybe?)

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -297,6 +297,7 @@ jobs:
           fi
         continue-on-error: false
 
+      # Override the number of concurrent workers to 2 to prevent a GitHub hosted Actions runner running out of memory.
       - name: Run integration tests (vally) - ${{ matrix.skill }}
         if: ${{ contains(fromJson(env.VALLY_SKILLS), matrix.skill) }}
         env:
@@ -306,7 +307,7 @@ jobs:
           SKILL: ${{ matrix.skill }}
         run: |
           echo test with $MODEL_OVERRIDE
-          npm run test:vally -- --skill $SKILL
+          npm run test:vally -- --skill $SKILL --workers 2
 
       - name: Generate skill report
         if: always()


### PR DESCRIPTION
## Description

Try limiting the number of concurrent workers to 2 to prevent GitHub hosted Action runner running out of memory. It might be the cause of the operation canceled error we see in the integration test workflows for skills like azure-kubernetes and entra-agent-id.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
