### PR TITLE
fix: cleanup completed agent runs

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -850,7 +850,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
     }
   }
 
-  return { run };
+  return { run, cleanup };
 }
 
 function buildTestCaseDirPath(testName: string): string {

--- a/tests/vally/vally-executor.ts
+++ b/tests/vally/vally-executor.ts
@@ -62,6 +62,7 @@ export class IntegrationTestAgentRunner implements Executor {
       .at(0)?.id;
 
     await createMarkdownReport(normalizedTestName, runConfig, agentMetadata);
+    await agentRunner.cleanup();
 
     // Vally will run the graders and produce results.jsonl.
     // After the all suites complete, we can process the results.json; file and recover our testResults.json file for dashboard consumption. 


### PR DESCRIPTION
## Description

Fix the bug that causes the code to retain completed agent run clients forever.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
