### PR TITLE
fix: properly skip changelog.md when rewriting repo hostname

### DIFF
--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -191,7 +191,7 @@ jobs:
           TARGET_DIRS=("target-repo/.github/plugins/azure-skills/" "target-repo/skills/" "target-repo/hooks/" "target-repo/plugin.json" "target-repo/.mcp.json" "target-repo/.claude-plugin/plugin.json" "target-repo/gemini-extension.json")
           for target in "${TARGET_DIRS[@]}"; do
             if [ -e "$target" ]; then
-              if matches=$(grep -rli --exclude='CHANGELOG.md' --include='*.md' --include='*.json' 'https://github.com/microsoft/github-copilot-for-azure' "$target"); then
+              if matches=$(grep -rli --include='*.md' --include='*.json' --exclude='CHANGELOG.md' 'https://github.com/microsoft/github-copilot-for-azure' "$target"); then
                 echo "$matches" | while IFS= read -r file; do
                   sed -i 's|https://github.com/microsoft/GitHub-Copilot-for-Azure|https://github.com/microsoft/azure-skills|g' "$file"
                   sed -i 's|https://github.com/microsoft/github-copilot-for-azure|https://github.com/microsoft/azure-skills|g' "$file"


### PR DESCRIPTION
## Description

Fix the repo hostname rewriting logic to properly skip changelog.md files.

The grep manual explained why the old code doesn't work. https://www.man7.org/linux/man-pages/man1/grep.1.html
> If contradictory --include and --exclude options are given, the last matching one wins.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

