### PR TITLE
feat: review per-call tool usage in the integration-tests dashboard

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -397,3 +397,16 @@ jobs:
           BRANCH: ${{ github.ref_name }}
           RUN_ID: ${{ github.run_id }}
         run: npm run upload:token-usage
+
+      # Upload per-run tool usage (one row per tool call) to the Azure Table that
+      # powers the dashboard's per-run tool review. Runs for both scheduled and manual runs.
+      # Note: The managed identity must have Storage Table Data Contributor on the storage account.
+      - name: Upload tool usage to table
+        if: always() && vars.REPORT_STORAGE_ACCOUNT != ''
+        env:
+          TOOL_USAGE_STORAGE_ACCOUNT: ${{ vars.REPORT_STORAGE_ACCOUNT }}
+          TOOL_USAGE_TABLE_NAME: ${{ vars.TOOL_USAGE_TABLE || 'integrationtoolusage' }}
+          SKILL: ${{ matrix.skill }}
+          BRANCH: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: npm run upload:tool-usage

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -271,3 +271,16 @@ jobs:
           BRANCH: ${{ github.ref_name }}
           RUN_ID: ${{ github.run_id }}
         run: npm run upload:token-usage
+
+      # Upload per-run tool usage (one row per tool call) to the Azure Table that
+      # powers the dashboard's per-run tool review. Runs for both scheduled and manual runs.
+      # Note: The managed identity must have Storage Table Data Contributor on the storage account.
+      - name: Upload tool usage to table
+        if: always() && vars.REPORT_STORAGE_ACCOUNT != ''
+        env:
+          TOOL_USAGE_STORAGE_ACCOUNT: ${{ vars.REPORT_STORAGE_ACCOUNT }}
+          TOOL_USAGE_TABLE_NAME: ${{ vars.TOOL_USAGE_TABLE || 'integrationtoolusage' }}
+          SKILL: azure-deploy
+          BRANCH: ${{ github.ref_name }}
+          RUN_ID: ${{ github.run_id }}
+        run: npm run upload:tool-usage

--- a/dashboard/api/src/blobEnumerator.ts
+++ b/dashboard/api/src/blobEnumerator.ts
@@ -34,15 +34,7 @@ function getContainerClient(containerName: string): ContainerClient {
 
 function isExcluded(blobName: string): boolean {
     const filename = blobName.split("/").pop() ?? "";
-    if (EXCLUDED_FILENAMES.has(filename)) {
-        return true;
-    }
-    // Per-run tool-usage capture files (tool-usage-<token>.json) are uploaded but
-    // not exposed via the dashboard API yet.
-    if (filename.startsWith("tool-usage-") && filename.endsWith(".json")) {
-        return true;
-    }
-    return false;
+    return EXCLUDED_FILENAMES.has(filename);
 }
 
 /**

--- a/dashboard/api/src/blobEnumerator.ts
+++ b/dashboard/api/src/blobEnumerator.ts
@@ -34,7 +34,15 @@ function getContainerClient(containerName: string): ContainerClient {
 
 function isExcluded(blobName: string): boolean {
     const filename = blobName.split("/").pop() ?? "";
-    return EXCLUDED_FILENAMES.has(filename);
+    if (EXCLUDED_FILENAMES.has(filename)) {
+        return true;
+    }
+    // Per-run tool-usage capture files (tool-usage-<token>.json) are uploaded but
+    // not exposed via the dashboard API yet.
+    if (filename.startsWith("tool-usage-") && filename.endsWith(".json")) {
+        return true;
+    }
+    return false;
 }
 
 /**

--- a/dashboard/api/src/functions/getData.ts
+++ b/dashboard/api/src/functions/getData.ts
@@ -15,11 +15,13 @@ import { logRequestIdentity } from "../requestIdentity";
  * 5. ${DATE}/${RUN_ID}/{skill-name}/{arbitrary-test-case-name}/agent-metadata-{datetime}{optional-dedupe-suffix}.md
  * 6. ${DATE}/${RUN_ID}/{skill-name}/{arbitrary-test-case-name}/agent-metadata.json
  * 7. ${DATE}/${RUN_ID}/{skill-name}/{arbitrary-test-case-name}/token-usage.json
+ * 8. ${DATE}/${RUN_ID}/{skill-name}/{arbitrary-test-case-name}/tool-usage-{datetime}{optional-dedupe-suffix}.json
  * 
  * The test-run-{datetime}-{skill-name}-SKILL-REPORT.md is unique per skill. It is a summarized version of the result of all test runs in its job.
  * The test-consolidated-report.md is unique per test case. It is a summarized version of the result of all agent runs for its test case.
  * The agent-metadata-{datetime}{optional-dedupe-suffix}.md captures the details of each agent run for its test case.
- * token-usage.json and agent-metadata.json should not be exposed for now.
+ * The tool-usage-{datetime}{optional-dedupe-suffix}.json captures the ordered tool calls of each agent run, named to match its agent-metadata-*.md report.
+ * token-usage.json, agent-metadata.json, and tool-usage-*.json should not be exposed for now.
  * 
  * For azure-deploy skill:
  * 1. ${DATE}/${RUN_ID}/{skill-name}/{test-group}/test-run-{datetime}-{skill-name}-SKILL-REPORT.md
@@ -29,6 +31,7 @@ import { logRequestIdentity } from "../requestIdentity";
  * 5. ${DATE}/${RUN_ID}/{skill-name}/{test-group}/{arbitrary-test-case-name}/agent-metadata-{datetime}{optional-dedupe-suffix}.md
  * 6. ${DATE}/${RUN_ID}/{skill-name}/{test-group}/{arbitrary-test-case-name}/agent-metadata.json
  * 7. ${DATE}/${RUN_ID}/{skill-name}/{test-group}/{arbitrary-test-case-name}/token-usage.json
+ * 8. ${DATE}/${RUN_ID}/{skill-name}/{test-group}/{arbitrary-test-case-name}/tool-usage-{datetime}{optional-dedupe-suffix}.json
  * 
  * All ${DATE} are in the format of yyyy-mm-dd.
  */

--- a/dashboard/api/src/functions/getToolUsage.ts
+++ b/dashboard/api/src/functions/getToolUsage.ts
@@ -1,0 +1,115 @@
+import { app, HttpRequest, HttpResponseInit, InvocationContext } from "@azure/functions";
+import { TableClient } from "@azure/data-tables";
+import { AzureCliCredential, ManagedIdentityCredential } from "@azure/identity";
+import { logRequestIdentity } from "../requestIdentity";
+
+const STORAGE_ACCOUNT_NAME = process.env.STORAGE_ACCOUNT_NAME;
+const TOOL_USAGE_TABLE_NAME = process.env.TOOL_USAGE_TABLE_NAME;
+
+function getToolUsageTableClient(): TableClient {
+    if (!STORAGE_ACCOUNT_NAME) {
+        throw new Error("STORAGE_ACCOUNT_NAME environment variable is not set");
+    }
+    if (!TOOL_USAGE_TABLE_NAME) {
+        throw new Error("TOOL_USAGE_TABLE_NAME environment variable is not set");
+    }
+    const clientId = process.env.AZURE_CLIENT_ID;
+    const isDevEnvironment = process.env.AZURE_FUNCTIONS_ENVIRONMENT === "Development";
+    const credential = isDevEnvironment ? new AzureCliCredential() : new ManagedIdentityCredential(clientId!);
+    return new TableClient(
+        `https://${STORAGE_ACCOUNT_NAME}.table.core.windows.net`,
+        TOOL_USAGE_TABLE_NAME,
+        credential
+    );
+}
+
+/** Escape a value for use inside an OData string literal (single quotes are doubled). */
+function odataLiteral(value: string): string {
+    return value.replace(/'/g, "''");
+}
+
+/**
+ * Build the OData filter for tool-usage queries from optional equality filters.
+ * Returns undefined when no filters are provided.
+ */
+export function buildToolUsageFilter(filters: {
+    skill?: string;
+    test?: string;
+    branch?: string;
+    runId?: string;
+    runToken?: string;
+}): string | undefined {
+    const clauses: string[] = [];
+    if (filters.skill) clauses.push(`skill eq '${odataLiteral(filters.skill)}'`);
+    if (filters.test) clauses.push(`testName eq '${odataLiteral(filters.test)}'`);
+    if (filters.branch) clauses.push(`branch eq '${odataLiteral(filters.branch)}'`);
+    if (filters.runId) clauses.push(`runId eq '${odataLiteral(filters.runId)}'`);
+    if (filters.runToken) clauses.push(`runToken eq '${odataLiteral(filters.runToken)}'`);
+    return clauses.length > 0 ? clauses.join(" and ") : undefined;
+}
+
+/**
+ * Returns integration-test tool usage rows from the table.
+ * GET /api/tool-usage
+ * Query params: skill (optional), test (optional), branch (optional),
+ *               runId (optional), runToken (optional)
+ *
+ * Each row represents a single tool call in one run. Full tool arguments are not
+ * stored here — they live in the per-run blob and are fetched on demand.
+ */
+async function getToolUsage(request: HttpRequest, context: InvocationContext): Promise<HttpResponseInit> {
+    logRequestIdentity(request, context, "getToolUsage");
+
+    const filter = buildToolUsageFilter({
+        skill: request.query.get("skill") || undefined,
+        test: request.query.get("test") || undefined,
+        branch: request.query.get("branch") || undefined,
+        runId: request.query.get("runId") || undefined,
+        runToken: request.query.get("runToken") || undefined,
+    });
+
+    try {
+        const tableClient = getToolUsageTableClient();
+        const listOptions = filter ? { queryOptions: { filter } } : {};
+        const entities: Record<string, unknown>[] = [];
+
+        for await (const entity of tableClient.listEntities(listOptions)) {
+            entities.push({
+                skill: entity.skill,
+                testName: entity.testName,
+                branch: entity.branch,
+                runId: entity.runId,
+                runDate: entity.runDate,
+                runTimestamp: entity.runTimestamp,
+                runToken: entity.runToken,
+                reportFile: entity.reportFile,
+                sessionId: entity.sessionId,
+                model: entity.model,
+                order: entity.order,
+                toolName: entity.toolName,
+                toolCallId: entity.toolCallId,
+                successState: entity.successState,
+            });
+        }
+
+        return {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(entities),
+        };
+    } catch (err: any) {
+        context.error("Error querying tool usage:", err?.message ?? err);
+        return {
+            status: 500,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ error: "Failed to query tool usage" }),
+        };
+    }
+}
+
+app.http("getToolUsage", {
+    methods: ["GET"],
+    authLevel: "anonymous",
+    route: "tool-usage",
+    handler: getToolUsage,
+});

--- a/dashboard/api/src/functions/getToolUsage.ts
+++ b/dashboard/api/src/functions/getToolUsage.ts
@@ -38,6 +38,7 @@ export function buildToolUsageFilter(filters: {
     branch?: string;
     runId?: string;
     runToken?: string;
+    runDate?: string;
 }): string | undefined {
     const clauses: string[] = [];
     if (filters.skill) clauses.push(`skill eq '${odataLiteral(filters.skill)}'`);
@@ -45,6 +46,7 @@ export function buildToolUsageFilter(filters: {
     if (filters.branch) clauses.push(`branch eq '${odataLiteral(filters.branch)}'`);
     if (filters.runId) clauses.push(`runId eq '${odataLiteral(filters.runId)}'`);
     if (filters.runToken) clauses.push(`runToken eq '${odataLiteral(filters.runToken)}'`);
+    if (filters.runDate) clauses.push(`runDate eq '${odataLiteral(filters.runDate)}'`);
     return clauses.length > 0 ? clauses.join(" and ") : undefined;
 }
 
@@ -52,7 +54,7 @@ export function buildToolUsageFilter(filters: {
  * Returns integration-test tool usage rows from the table.
  * GET /api/tool-usage
  * Query params: skill (optional), test (optional), branch (optional),
- *               runId (optional), runToken (optional)
+ *               runId (optional), runToken (optional), runDate (optional)
  *
  * Each row represents a single tool call in one run. Full tool arguments are not
  * stored here — they live in the per-run blob and are fetched on demand.
@@ -66,6 +68,7 @@ async function getToolUsage(request: HttpRequest, context: InvocationContext): P
         branch: request.query.get("branch") || undefined,
         runId: request.query.get("runId") || undefined,
         runToken: request.query.get("runToken") || undefined,
+        runDate: request.query.get("runDate") || undefined,
     });
 
     try {
@@ -89,6 +92,8 @@ async function getToolUsage(request: HttpRequest, context: InvocationContext): P
                 toolName: entity.toolName,
                 toolCallId: entity.toolCallId,
                 successState: entity.successState,
+                durationMs: entity.durationMs,
+                outputBytes: entity.outputBytes,
             });
         }
 

--- a/dashboard/api/src/functions/getToolUsage.ts
+++ b/dashboard/api/src/functions/getToolUsage.ts
@@ -71,9 +71,21 @@ async function getToolUsage(request: HttpRequest, context: InvocationContext): P
         runDate: request.query.get("runDate") || undefined,
     });
 
+    // Require at least one filter. An unfiltered scan of the one-row-per-tool-call
+    // table can be very large and risks timeouts / excessive storage reads.
+    if (!filter) {
+        return {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                error: "At least one filter is required: skill, test, branch, runId, runToken, or runDate.",
+            }),
+        };
+    }
+
     try {
         const tableClient = getToolUsageTableClient();
-        const listOptions = filter ? { queryOptions: { filter } } : {};
+        const listOptions = { queryOptions: { filter } };
         const entities: Record<string, unknown>[] = [];
 
         for await (const entity of tableClient.listEntities(listOptions)) {

--- a/dashboard/infra/main.bicep
+++ b/dashboard/infra/main.bicep
@@ -21,6 +21,9 @@ param msbenchReportsContainerName string = 'msbench-reports'
 @description('Name of the Azure Table that stores integration-test token usage history.')
 param tokenUsageTableName string = 'integrationtokenusage'
 
+@description('Name of the Azure Table that stores integration-test per-run tool usage history.')
+param toolUsageTableName string = 'integrationtoolusage'
+
 @description('Principal (object) ID of the user-assigned managed identity used by the integration test pipeline to write token usage rows (skillcitestidentity).')
 param ciTestIdentityPrincipalId string = '531282f7-49cb-4149-af74-6c84a5270e87'
 
@@ -76,6 +79,7 @@ module storage './modules/storage.bicep' = {
     environmentName: environmentName
     principalId: identity.outputs.identityPrincipalId
     tokenUsageTableName: tokenUsageTableName
+    toolUsageTableName: toolUsageTableName
     ciTestIdentityPrincipalId: ciTestIdentityPrincipalId
   }
 }
@@ -99,6 +103,7 @@ module functionApp './modules/function-app.bicep' = {
     userAssignedIdentityClientId: identity.outputs.identityClientId
     storageAccountName: storage.outputs.storageAccountName
     tokenUsageTableName: storage.outputs.tokenUsageTableName
+    toolUsageTableName: storage.outputs.toolUsageTableName
     msbenchStorageAccountName: msbenchStorageAccountName
     msbenchEvalTableName: msbenchEvalTableName
     msbenchReportsContainerName: msbenchReportsContainerName

--- a/dashboard/infra/modules/function-app.bicep
+++ b/dashboard/infra/modules/function-app.bicep
@@ -21,6 +21,9 @@ param storageAccountName string
 @description('Name of the Azure Table that stores integration-test token usage history.')
 param tokenUsageTableName string
 
+@description('Name of the Azure Table that stores integration-test per-run tool usage history.')
+param toolUsageTableName string
+
 @description('Application Insights connection string for monitoring.')
 param appInsightsConnectionString string
 
@@ -118,6 +121,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
         { name: 'AZURE_CLIENT_ID', value: userAssignedIdentityClientId }
         { name: 'STORAGE_ACCOUNT_NAME', value: storageAccountName }
         { name: 'TOKEN_USAGE_TABLE_NAME', value: tokenUsageTableName }
+        { name: 'TOOL_USAGE_TABLE_NAME', value: toolUsageTableName }
         { name: 'MSBENCH_STORAGE_ACCOUNT', value: msbenchStorageAccountName }
         { name: 'MSBENCH_REPORTS_CONTAINER', value: msbenchReportsContainerName }
         { name: 'MSBENCH_EVAL_TABLE_NAME', value: msbenchEvalTableName }

--- a/dashboard/infra/modules/storage.bicep
+++ b/dashboard/infra/modules/storage.bicep
@@ -15,6 +15,9 @@ param principalId string
 @description('Name of the Azure Table that stores integration-test token usage history.')
 param tokenUsageTableName string = 'integrationtokenusage'
 
+@description('Name of the Azure Table that stores integration-test per-run tool usage history.')
+param toolUsageTableName string = 'integrationtoolusage'
+
 @description('Principal (object) ID of the user-assigned managed identity used by the integration test pipeline to write token usage rows (skillcitestidentity in the skillcitest resource group, GithubCopilotForAzure-Testing subscription).')
 param ciTestIdentityPrincipalId string = '531282f7-49cb-4149-af74-6c84a5270e87'
 
@@ -97,6 +100,11 @@ resource tokenUsageTable 'Microsoft.Storage/storageAccounts/tableServices/tables
   name: tokenUsageTableName
 }
 
+resource toolUsageTable 'Microsoft.Storage/storageAccounts/tableServices/tables@2023-05-01' = {
+  parent: tableServices
+  name: toolUsageTableName
+}
+
 resource storageBlobDataReaderRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(storageAccount.id, principalId, storageBlobDataReaderRoleId)
   scope: storageAccount
@@ -107,7 +115,7 @@ resource storageBlobDataReaderRole 'Microsoft.Authorization/roleAssignments@2022
   }
 }
 
-// Allows the dashboard Function App identity to read token-usage entities from the table.
+// Allows the dashboard Function App identity to read token-usage and tool-usage entities from the tables.
 resource storageTableDataReaderRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(storageAccount.id, principalId, storageTableDataReaderRoleId)
   scope: storageAccount
@@ -118,7 +126,7 @@ resource storageTableDataReaderRole 'Microsoft.Authorization/roleAssignments@202
   }
 }
 
-// Allows the integration test pipeline identity to write token-usage entities to the table.
+// Allows the integration test pipeline identity to write token-usage and tool-usage entities to the tables.
 resource storageTableDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
   name: guid(storageAccount.id, ciTestIdentityPrincipalId, storageTableDataContributorRoleId)
   scope: storageAccount
@@ -131,3 +139,4 @@ resource storageTableDataContributorRole 'Microsoft.Authorization/roleAssignment
 
 output storageAccountName string = storageAccount.name
 output tokenUsageTableName string = tokenUsageTable.name
+output toolUsageTableName string = toolUsageTable.name

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -83,6 +83,128 @@ async function findAppSnapshotBlob(date: string, testName: string): Promise<stri
     return found[0] ?? null;
 }
 
+// --- Tool usage (Phase 2b) -------------------------------------------------
+
+/** One tool call as returned by GET /api/tool-usage (one row per call). */
+interface ToolCallRow {
+    runToken: string;
+    runId: string;
+    runDate: string;
+    runTimestamp: string;
+    order: number;
+    toolName: string;
+    /** "true" | "false" | "unknown". */
+    successState: string;
+    /** Present only when a completion was observed. */
+    durationMs?: number;
+    outputBytes?: number;
+}
+
+/** Tool calls for a single run, ordered by call order. */
+interface ToolRun {
+    runToken: string;
+    runId: string;
+    runTimestamp: string;
+    calls: ToolCallRow[];
+}
+
+// Cache /api/tool-usage responses keyed by skill+test+date so re-expanding a
+// test's Tools section reuses a single network request.
+const toolUsageCache = new Map<string, Promise<ToolCallRow[]>>();
+
+function fetchToolUsage(skill: string, test: string, runDate: string): Promise<ToolCallRow[]> {
+    const key = `${skill}\u0000${test}\u0000${runDate}`;
+    let cached = toolUsageCache.get(key);
+    if (!cached) {
+        const params = new URLSearchParams({ skill, test, runDate });
+        cached = fetch(apiUrl(`/api/tool-usage?${params.toString()}`))
+            .then((res) => {
+                if (!res.ok) throw new Error(`API error: ${res.status}`);
+                return res.json() as Promise<ToolCallRow[]>;
+            })
+            .catch((err) => {
+                toolUsageCache.delete(key);
+                throw err;
+            });
+        toolUsageCache.set(key, cached);
+    }
+    return cached;
+}
+
+/** Group flat tool-call rows into runs (by runToken), each sorted by order. */
+function groupToolRuns(rows: ToolCallRow[]): ToolRun[] {
+    const byToken = new Map<string, ToolRun>();
+    for (const r of rows) {
+        let run = byToken.get(r.runToken);
+        if (!run) {
+            run = { runToken: r.runToken, runId: r.runId, runTimestamp: r.runTimestamp, calls: [] };
+            byToken.set(r.runToken, run);
+        }
+        run.calls.push(r);
+    }
+    const runs = [...byToken.values()];
+    for (const run of runs) {
+        run.calls.sort((a, b) => a.order - b.order);
+    }
+    runs.sort(
+        (a, b) =>
+            (a.runTimestamp || "").localeCompare(b.runTimestamp || "") ||
+            a.runToken.localeCompare(b.runToken),
+    );
+    return runs;
+}
+
+/** Locate this run's tool-usage-<runToken>.json blob within the date's tree. */
+async function findToolUsageBlob(date: string, runToken: string): Promise<string | null> {
+    const tree = await fetchBlobTree(date);
+    const dateNode = tree[date];
+    if (!dateNode) return null;
+    const target = `tool-usage-${runToken}.json`;
+    let result: string | null = null;
+    const walk = (node: BlobTreeNode): void => {
+        if (result) return;
+        for (const file of node.files) {
+            if (file.name === target) {
+                result = file.blobName;
+                return;
+            }
+        }
+        for (const child of Object.values(node.children)) {
+            if (result) return;
+            walk(child);
+        }
+    };
+    walk(dateNode);
+    return result;
+}
+
+/** Fetch a single tool call's full arguments on demand from the per-run blob. */
+async function fetchToolCallArguments(date: string, runToken: string, order: number): Promise<unknown> {
+    const blobName = await findToolUsageBlob(date, runToken);
+    if (!blobName) throw new Error("Tool-usage blob not found for this run.");
+    const res = await fetch(apiUrl(`/api/fetch?path=${encodeURIComponent(blobName)}`));
+    if (!res.ok) throw new Error(`Fetch error: ${res.status}`);
+    const data = (await res.json()) as { toolCalls?: Array<{ order: number; arguments?: unknown }> };
+    const call = data.toolCalls?.find((c) => c.order === order);
+    if (!call) throw new Error("Tool call not found in run blob.");
+    return call.arguments ?? null;
+}
+
+/** Human-readable duration; em dash when unknown (no completion observed). */
+function formatDuration(durationMs?: number): string {
+    if (typeof durationMs !== "number") return "\u2014";
+    if (durationMs < 1000) return `${durationMs} ms`;
+    return `${(durationMs / 1000).toFixed(2)} s`;
+}
+
+/** Human-readable byte size; em dash when unknown. */
+function formatBytes(bytes?: number): string {
+    if (typeof bytes !== "number") return "\u2014";
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
 const AZURE_DEPLOY_SKILL = "azure-deploy";
 
 interface SkillStats {
@@ -292,6 +414,11 @@ function App() {
                                             date={selectedDate!}
                                             testName={ft.testName}
                                         />
+                                        <ToolUsageSection
+                                            date={selectedDate!}
+                                            skill={detailsPanelSkill!}
+                                            testName={ft.testName}
+                                        />
                                         {/* Show the preview for legacy items which don't the flag set */}
                                         {detailsPanelSkill === AZURE_DEPLOY_SKILL && ft.expectsScreenshot !== false && (
                                             <AppSnapshotPreview
@@ -327,6 +454,11 @@ function App() {
                                         )}
                                         <ViewAgentMetadataButton
                                             date={selectedDate!}
+                                            testName={pt.testName}
+                                        />
+                                        <ToolUsageSection
+                                            date={selectedDate!}
+                                            skill={detailsPanelSkill!}
                                             testName={pt.testName}
                                         />
                                         {/* Show the preview for legacy items which don't the flag set */}
@@ -429,6 +561,127 @@ function AppSnapshotPreview({ date, testName }: { date: string; testName: string
                 />
             </a>
         </div>
+    );
+}
+
+function ToolUsageSection({ date, skill, testName }: { date: string; skill: string; testName: string }) {
+    const [open, setOpen] = useState(false);
+    const [runs, setRuns] = useState<ToolRun[] | null>(null);
+    const [loading, setLoading] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+
+    const toggle = async () => {
+        const next = !open;
+        setOpen(next);
+        if (next && runs === null && !loading) {
+            setLoading(true);
+            setErr(null);
+            try {
+                const rows = await fetchToolUsage(skill, formatTestName(testName), date);
+                setRuns(groupToolRuns(rows));
+            } catch (e) {
+                setErr(e instanceof Error ? e.message : String(e));
+            } finally {
+                setLoading(false);
+            }
+        }
+    };
+
+    return (
+        <div className="it-tools">
+            <button className="it-tools-toggle" onClick={toggle} aria-expanded={open}>
+                {open ? "\u25be" : "\u25b8"} Tools
+            </button>
+            {open && (
+                <div className="it-tools-body">
+                    {loading ? (
+                        <p className="it-muted">Loading tools&hellip;</p>
+                    ) : err ? (
+                        <p className="it-error">{err}</p>
+                    ) : !runs || runs.length === 0 ? (
+                        <p className="it-muted">No tool data for this run.</p>
+                    ) : (
+                        runs.map((run, i) => (
+                            <div key={run.runToken} className="it-tool-run">
+                                <div className="it-tool-run-header">
+                                    <span className="it-tool-run-title">
+                                        {runs.length > 1 ? `Run ${i + 1}` : "Run"} &middot; {run.calls.length} call{run.calls.length === 1 ? "" : "s"}
+                                    </span>
+                                    <span className="it-tool-run-meta">{run.runTimestamp}</span>
+                                </div>
+                                <ol className="it-tool-call-list">
+                                    {run.calls.map((call) => (
+                                        <ToolCallItem
+                                            key={call.order}
+                                            date={date}
+                                            runToken={run.runToken}
+                                            call={call}
+                                        />
+                                    ))}
+                                </ol>
+                            </div>
+                        ))
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+function ToolCallItem({ date, runToken, call }: { date: string; runToken: string; call: ToolCallRow }) {
+    const [open, setOpen] = useState(false);
+    const [args, setArgs] = useState<string | undefined>(undefined);
+    const [loading, setLoading] = useState(false);
+    const [err, setErr] = useState<string | null>(null);
+
+    const toggleArgs = async () => {
+        const next = !open;
+        setOpen(next);
+        if (next && args === undefined && !loading) {
+            setLoading(true);
+            setErr(null);
+            try {
+                const a = await fetchToolCallArguments(date, runToken, call.order);
+                setArgs(JSON.stringify(a, null, 2));
+            } catch (e) {
+                setErr(e instanceof Error ? e.message : String(e));
+            } finally {
+                setLoading(false);
+            }
+        }
+    };
+
+    const icon = call.successState === "true" ? "\u2713" : call.successState === "false" ? "\u2717" : "?";
+    const iconClass =
+        call.successState === "true"
+            ? "it-tool-ok"
+            : call.successState === "false"
+              ? "it-tool-fail"
+              : "it-tool-unknown";
+
+    return (
+        <li className="it-tool-call">
+            <div className="it-tool-call-row">
+                <span className="it-tool-order">{call.order}</span>
+                <span className={`it-tool-status ${iconClass}`} title={`success: ${call.successState}`}>
+                    {icon}
+                </span>
+                <span className="it-tool-name">{call.toolName}</span>
+                <span className="it-tool-metric" title="duration">{formatDuration(call.durationMs)}</span>
+                <span className="it-tool-metric" title="output size">{formatBytes(call.outputBytes)}</span>
+                <button className="it-tool-args-btn" onClick={toggleArgs} aria-expanded={open}>
+                    {open ? "hide args" : "args"}
+                </button>
+            </div>
+            {open &&
+                (loading ? (
+                    <p className="it-muted">Loading args&hellip;</p>
+                ) : err ? (
+                    <p className="it-error">{err}</p>
+                ) : (
+                    <pre className="it-tool-args">{args}</pre>
+                ))}
+        </li>
     );
 }
 

--- a/dashboard/src/integration-tests/integration-tests.css
+++ b/dashboard/src/integration-tests/integration-tests.css
@@ -458,6 +458,143 @@ body:has(.it-dashboard) {
     cursor: zoom-in;
 }
 
+/* ── Tool usage (per-test tool calls) ───── */
+
+.it-tools {
+    width: 100%;
+    margin-top: 6px;
+}
+
+.it-tools-toggle {
+    padding: 2px 8px;
+    font-size: 0.6875rem;
+    font-weight: 600;
+    font-family: inherit;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.it-tools-toggle:hover {
+    background: var(--color-focus);
+    color: #fff;
+    border-color: var(--color-focus);
+}
+
+.it-tools-body {
+    margin-top: 6px;
+}
+
+.it-tool-run {
+    margin-bottom: 8px;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.it-tool-run-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+    padding: 4px 8px;
+    background: var(--color-surface-alt, rgba(127, 127, 127, 0.08));
+    font-size: 0.6875rem;
+    font-weight: 600;
+}
+
+.it-tool-run-meta {
+    color: var(--color-text-muted);
+    font-weight: 400;
+}
+
+.it-tool-call-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.it-tool-call {
+    border-top: 1px solid var(--color-border);
+    padding: 3px 8px;
+}
+
+.it-tool-call-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 0.6875rem;
+}
+
+.it-tool-order {
+    min-width: 1.5em;
+    text-align: right;
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+}
+
+.it-tool-status {
+    font-weight: 700;
+}
+
+.it-tool-ok {
+    color: var(--color-pass);
+}
+
+.it-tool-fail {
+    color: var(--color-fail);
+}
+
+.it-tool-unknown {
+    color: var(--color-text-muted);
+}
+
+.it-tool-name {
+    flex: 1;
+    font-family: var(--font-mono, monospace);
+    word-break: break-all;
+}
+
+.it-tool-metric {
+    color: var(--color-text-muted);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+.it-tool-args-btn {
+    padding: 1px 6px;
+    font-size: 0.625rem;
+    font-weight: 600;
+    font-family: inherit;
+    color: var(--color-text-muted);
+    background: transparent;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius);
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.it-tool-args-btn:hover {
+    background: var(--color-focus);
+    color: #fff;
+    border-color: var(--color-focus);
+}
+
+.it-tool-args {
+    margin: 4px 0 2px;
+    padding: 6px 8px;
+    font-size: 0.6875rem;
+    background: var(--color-surface-alt, rgba(127, 127, 127, 0.08));
+    border-radius: var(--radius);
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: auto;
+}
+
 /* ── Responsive ─────────────────────────── */
 
 @media (max-width: 768px) {

--- a/dashboard/sync/src/msbenchBlobEnumerator.ts
+++ b/dashboard/sync/src/msbenchBlobEnumerator.ts
@@ -26,7 +26,15 @@ function getContainerClient() {
 
 function isExcluded(blobName: string): boolean {
     const filename = blobName.split("/").pop() ?? "";
-    return EXCLUDED_FILENAMES.has(filename);
+    if (EXCLUDED_FILENAMES.has(filename)) {
+        return true;
+    }
+    // Per-run tool-usage capture files (tool-usage-<token>.json) are uploaded but
+    // not exposed via the dashboard API yet.
+    if (filename.startsWith("tool-usage-") && filename.endsWith(".json")) {
+        return true;
+    }
+    return false;
 }
 
 function createNode(): BlobTreeNode {

--- a/tests/package.json
+++ b/tests/package.json
@@ -15,6 +15,7 @@
     "test:vally": "npx tsx ./run-vally-test.ts",
     "report": "npx tsx scripts/generate-test-reports.ts",
     "upload:token-usage": "npx tsx scripts/upload-token-usage.ts",
+    "upload:tool-usage": "npx tsx scripts/upload-tool-usage.ts",
     "results": "node scripts/show-test-results.js",
     "update:mcp-tool-snapshot": "node scripts/update-mcp-tool-snapshot.js",
     "update:snapshots": "node scripts/update-snapshots.js",

--- a/tests/scripts/__tests__/upload-tool-usage.test.ts
+++ b/tests/scripts/__tests__/upload-tool-usage.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the tool-usage uploader pure helpers (Phase 2a).
+ *
+ * Focuses on the deterministic transforms — run-token derivation, success
+ * mapping, per-call row expansion, and row-key distinctness — that turn a
+ * captured tool-usage-<token>.json file into Azure Table rows.
+ */
+
+import {
+  deriveRunToken,
+  successStateOf,
+  buildToolRowKey,
+  expandToolUsageToRows,
+  type ToolUsageFile,
+  type UploadContext,
+} from "../upload-tool-usage.ts";
+
+const ctx: UploadContext = { skill: "azure-quotas", branch: "main", runId: "123" };
+
+describe("deriveRunToken", () => {
+  test("strips the tool-usage- prefix and .json suffix", () => {
+    expect(deriveRunToken("tool-usage-2026-06-15T11-44-05-123Z.json")).toBe(
+      "2026-06-15T11-44-05-123Z",
+    );
+  });
+
+  test("works on a full path and preserves a collision dedupe suffix", () => {
+    expect(deriveRunToken("/a/b/tool-usage-2026-06-15T11-44-05-123Z-2.json")).toBe(
+      "2026-06-15T11-44-05-123Z-2",
+    );
+  });
+});
+
+describe("successStateOf", () => {
+  test("maps true/false/null/undefined to stable states", () => {
+    expect(successStateOf(true)).toBe("true");
+    expect(successStateOf(false)).toBe("false");
+    expect(successStateOf(null)).toBe("unknown");
+    expect(successStateOf(undefined)).toBe("unknown");
+  });
+});
+
+describe("buildToolRowKey", () => {
+  test("is stable for the same inputs", () => {
+    const a = buildToolRowKey("main", "123", "t", "tok", 0);
+    const b = buildToolRowKey("main", "123", "t", "tok", 0);
+    expect(a).toBe(b);
+  });
+
+  test("differs by order within the same run", () => {
+    const a = buildToolRowKey("main", "123", "t", "tok", 0);
+    const b = buildToolRowKey("main", "123", "t", "tok", 1);
+    expect(a).not.toBe(b);
+  });
+
+  test("differs across runs of the same test (distinct run tokens)", () => {
+    const a = buildToolRowKey("main", "123", "t", "tokA", 0);
+    const b = buildToolRowKey("main", "123", "t", "tokB", 0);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe("expandToolUsageToRows", () => {
+  const file: ToolUsageFile = {
+    testName: "azure-quotas_Quota_check",
+    reportFile: "agent-metadata-2026-06-15T11-44-05-123Z.md",
+    sessionId: "sess-1",
+    model: "claude-sonnet-4.6",
+    timestamp: "2026-06-15T11:44:05.123Z",
+    toolCalls: [
+      { order: 0, toolName: "skill", toolCallId: "s1", success: true, durationMs: 12, outputBytes: 40 },
+      { order: 1, toolName: "bash", toolCallId: "c1", success: false, durationMs: 3400, outputBytes: 0 },
+      { order: 2, toolName: "view", toolCallId: "c2", success: null, durationMs: null, outputBytes: null },
+    ],
+  };
+
+  test("emits one row per tool call with run context and derived runDate", () => {
+    const rows = expandToolUsageToRows(file, "2026-06-15T11-44-05-123Z", ctx);
+
+    expect(rows).toHaveLength(3);
+    expect(rows.map((r) => [r.order, r.toolName, r.successState])).toEqual([
+      [0, "skill", "true"],
+      [1, "bash", "false"],
+      [2, "view", "unknown"],
+    ]);
+
+    const [first] = rows;
+    expect(first.partitionKey).toBe("azure-quotas");
+    expect(first.skill).toBe("azure-quotas");
+    expect(first.branch).toBe("main");
+    expect(first.runId).toBe("123");
+    expect(first.runToken).toBe("2026-06-15T11-44-05-123Z");
+    expect(first.runDate).toBe("2026-06-15");
+    expect(first.runTimestamp).toBe("2026-06-15T11:44:05.123Z");
+    expect(first.reportFile).toBe("agent-metadata-2026-06-15T11-44-05-123Z.md");
+    expect(first.sessionId).toBe("sess-1");
+    expect(first.model).toBe("claude-sonnet-4.6");
+  });
+
+  test("gives every row in a run a distinct rowKey", () => {
+    const rows = expandToolUsageToRows(file, "tok", ctx);
+    const keys = new Set(rows.map((r) => r.rowKey));
+    expect(keys.size).toBe(rows.length);
+  });
+
+  test("includes durationMs only when known, omitting it otherwise", () => {
+    const rows = expandToolUsageToRows(file, "tok", ctx);
+    expect(rows[0].durationMs).toBe(12);
+    expect(rows[1].durationMs).toBe(3400);
+    expect("durationMs" in rows[2]).toBe(false);
+  });
+
+  test("includes outputBytes when known (including 0), omitting it otherwise", () => {
+    const rows = expandToolUsageToRows(file, "tok", ctx);
+    expect(rows[0].outputBytes).toBe(40);
+    expect(rows[1].outputBytes).toBe(0);
+    expect("outputBytes" in rows[2]).toBe(false);
+  });
+
+  test("returns no rows when there are no tool calls", () => {
+    const empty: ToolUsageFile = { testName: "t", toolCalls: [] };
+    expect(expandToolUsageToRows(empty, "tok", ctx)).toEqual([]);
+  });
+
+  test("falls back to safe defaults for missing optional fields", () => {
+    const sparse: ToolUsageFile = {
+      testName: "t",
+      toolCalls: [{ order: 0, toolName: "bash", toolCallId: "c1" }],
+    };
+    const [row] = expandToolUsageToRows(sparse, "tok", ctx);
+    expect(row.reportFile).toBe("");
+    expect(row.sessionId).toBe("");
+    expect(row.model).toBe("unknown");
+    expect(row.successState).toBe("unknown");
+  });
+});

--- a/tests/scripts/__tests__/upload-tool-usage.test.ts
+++ b/tests/scripts/__tests__/upload-tool-usage.test.ts
@@ -11,7 +11,9 @@ import {
   successStateOf,
   buildToolRowKey,
   expandToolUsageToRows,
+  groupRowsForTransactions,
   type ToolUsageFile,
+  type ToolUsageRow,
   type UploadContext,
 } from "../upload-tool-usage.ts";
 
@@ -132,5 +134,59 @@ describe("expandToolUsageToRows", () => {
     expect(row.sessionId).toBe("");
     expect(row.model).toBe("unknown");
     expect(row.successState).toBe("unknown");
+  });
+});
+
+describe("groupRowsForTransactions", () => {
+  function rowWith(partitionKey: string, rowKey: string): ToolUsageRow {
+    return {
+      partitionKey,
+      rowKey,
+      skill: partitionKey,
+      testName: "t",
+      branch: "main",
+      runId: "123",
+      runDate: "2026-06-15",
+      runTimestamp: "2026-06-15T11:44:05.123Z",
+      runToken: "tok",
+      reportFile: "",
+      sessionId: "",
+      model: "unknown",
+      order: 0,
+      toolName: "bash",
+      toolCallId: "c",
+      successState: "unknown",
+    };
+  }
+
+  test("returns no batches for no rows", () => {
+    expect(groupRowsForTransactions([])).toEqual([]);
+  });
+
+  test("keeps a single small same-partition run in one batch", () => {
+    const rows = [rowWith("s", "a"), rowWith("s", "b"), rowWith("s", "c")];
+    const batches = groupRowsForTransactions(rows);
+    expect(batches).toHaveLength(1);
+    expect(batches[0]).toHaveLength(3);
+  });
+
+  test("chunks a large same-partition run to at most maxBatchSize", () => {
+    const rows = Array.from({ length: 250 }, (_, i) => rowWith("s", `r${i}`));
+    const batches = groupRowsForTransactions(rows, 100);
+    expect(batches.map((b) => b.length)).toEqual([100, 100, 50]);
+    // No batch mixes partition keys.
+    for (const batch of batches) {
+      expect(new Set(batch.map((r) => r.partitionKey)).size).toBe(1);
+    }
+  });
+
+  test("never mixes partition keys within a batch", () => {
+    const rows = [rowWith("a", "1"), rowWith("b", "1"), rowWith("a", "2")];
+    const batches = groupRowsForTransactions(rows);
+    for (const batch of batches) {
+      expect(new Set(batch.map((r) => r.partitionKey)).size).toBe(1);
+    }
+    // All rows are preserved across batches.
+    expect(batches.reduce((n, b) => n + b.length, 0)).toBe(3);
   });
 });

--- a/tests/scripts/upload-tool-usage.ts
+++ b/tests/scripts/upload-tool-usage.ts
@@ -1,0 +1,370 @@
+#!/usr/bin/env tsx
+
+/**
+ * Tool Usage Uploader
+ *
+ * Reads the per-run tool-usage files produced by the integration test run
+ * (tool-usage-<token>.json under the reports directory) and uploads one row per
+ * tool call to an Azure Table. The table provides the durable, queryable history
+ * that powers the dashboard's per-run tool review.
+ *
+ * Granularity: one row per tool call (per run, per test, per branch, per run id).
+ * Full tool arguments are NOT stored here — they remain in the per-run blob and
+ * are fetched on demand by the dashboard. Only name/order/success are uploaded.
+ *
+ * Authentication uses DefaultAzureCredential, which picks up the Azure session
+ * established earlier in the workflow (azure/login / az login).
+ *
+ * Required environment variables:
+ *   TOOL_USAGE_STORAGE_ACCOUNT  Storage account that hosts the table.
+ *   TOOL_USAGE_TABLE_NAME       Name of the Azure Table (e.g. integrationtoolusage).
+ *   SKILL                       Skill under test (becomes the PartitionKey).
+ *   BRANCH                      Git branch (e.g. github.ref_name).
+ *   RUN_ID                      Unique run identifier (e.g. github.run_id).
+ *
+ * Optional:
+ *   TOOL_USAGE_REPORTS_DIR      Reports directory to scan (default: tests/reports).
+ *
+ * The script is a no-op (exit 0) when the storage account/table is not
+ * configured or when no tool-usage files are found, so it can be wired
+ * unconditionally into pipelines without breaking runs that lack the data.
+ */
+
+import * as crypto from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import { fileURLToPath } from "url";
+import { TableClient } from "@azure/data-tables";
+import { DefaultAzureCredential } from "@azure/identity";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const TOOL_USAGE_PREFIX = "tool-usage-";
+const TOOL_USAGE_SUFFIX = ".json";
+
+/** A single tool call as written by agent-runner.ts computeToolUsage. */
+export interface ToolCallRecord {
+  order: number;
+  toolName: string;
+  toolCallId: string;
+  success?: boolean | null;
+  durationMs?: number | null;
+  outputBytes?: number | null;
+}
+
+/** A per-run tool-usage file as written by agent-runner.ts writeMarkdownReport. */
+export interface ToolUsageFile {
+  testName: string;
+  reportFile?: string;
+  sessionId?: string | null;
+  model?: string;
+  timestamp?: string;
+  toolCalls?: ToolCallRecord[];
+}
+
+/** One table-ready row representing a single tool call. */
+export interface ToolUsageRow {
+  partitionKey: string;
+  rowKey: string;
+  skill: string;
+  testName: string;
+  branch: string;
+  runId: string;
+  runDate: string;
+  runTimestamp: string;
+  runToken: string;
+  reportFile: string;
+  sessionId: string;
+  model: string;
+  order: number;
+  toolName: string;
+  toolCallId: string;
+  successState: string;
+  /**
+   * Wall-clock duration in milliseconds, omitted when no completion was observed
+   * (so the Table entity has no property rather than a null value).
+   */
+  durationMs?: number;
+  /**
+   * UTF-8 byte size of the tool's full textual output, omitted when no
+   * completion was observed.
+   */
+  outputBytes?: number;
+}
+
+/** Context shared by every row produced from a single upload invocation. */
+export interface UploadContext {
+  skill: string;
+  branch: string;
+  runId: string;
+}
+
+/**
+ * Sanitize a value for use in an Azure Table key. Table keys cannot contain
+ * the characters / \ # ? or control characters, and are length-limited.
+ */
+export function sanitizeKey(value: string): string {
+  let result = "";
+  for (const ch of value) {
+    const code = ch.codePointAt(0)!;
+    const isForbidden = ch === "/" || ch === "\\" || ch === "#" || ch === "?";
+    const isControl = code <= 0x1f || (code >= 0x7f && code <= 0x9f);
+    result += isForbidden || isControl ? "-" : ch;
+  }
+  return result.substring(0, 700);
+}
+
+/**
+ * Build a collision-resistant RowKey for a single tool call. Sanitization can
+ * map distinct tuples to the same string and long names get truncated, so a
+ * short hash of the original, unsanitized tuple is appended to keep otherwise-
+ * colliding rows distinct.
+ */
+export function buildToolRowKey(
+  branch: string,
+  runId: string,
+  testName: string,
+  runToken: string,
+  order: number,
+): string {
+  const hash = crypto
+    .createHash("sha256")
+    .update(`${branch}\u0000${runId}\u0000${testName}\u0000${runToken}\u0000${order}`)
+    .digest("hex")
+    .slice(0, 16);
+  const prefix = sanitizeKey(
+    `${branch}__${runId}__${testName}__${runToken}__${order}`,
+  ).substring(0, 600);
+  return `${prefix}__${hash}`;
+}
+
+/** Derive the shared run token from a tool-usage-<token>.json file name. */
+export function deriveRunToken(fileName: string): string {
+  const base = path.basename(fileName);
+  if (base.startsWith(TOOL_USAGE_PREFIX) && base.endsWith(TOOL_USAGE_SUFFIX)) {
+    return base.slice(TOOL_USAGE_PREFIX.length, base.length - TOOL_USAGE_SUFFIX.length);
+  }
+  return base;
+}
+
+/** Map a captured success value (true/false/null/undefined) to a stored state. */
+export function successStateOf(success: boolean | null | undefined): string {
+  if (success === true) return "true";
+  if (success === false) return "false";
+  return "unknown";
+}
+
+/** Expand one per-run tool-usage file into one table row per tool call. */
+export function expandToolUsageToRows(
+  file: ToolUsageFile,
+  runToken: string,
+  ctx: UploadContext,
+): ToolUsageRow[] {
+  const timestamp = file.timestamp || new Date().toISOString();
+  const runDate = timestamp.slice(0, 10);
+  const partitionKey = sanitizeKey(ctx.skill);
+  const rows: ToolUsageRow[] = [];
+  for (const call of file.toolCalls ?? []) {
+    const row: ToolUsageRow = {
+      partitionKey,
+      rowKey: buildToolRowKey(ctx.branch, ctx.runId, file.testName, runToken, call.order),
+      skill: ctx.skill,
+      testName: file.testName,
+      branch: ctx.branch,
+      runId: ctx.runId,
+      runDate,
+      runTimestamp: timestamp,
+      runToken,
+      reportFile: file.reportFile || "",
+      sessionId: file.sessionId || "",
+      model: file.model || "unknown",
+      order: call.order,
+      toolName: call.toolName,
+      toolCallId: call.toolCallId,
+      successState: successStateOf(call.success),
+    };
+    if (typeof call.durationMs === "number") {
+      row.durationMs = call.durationMs;
+    }
+    if (typeof call.outputBytes === "number") {
+      row.outputBytes = call.outputBytes;
+    }
+    rows.push(row);
+  }
+  return rows;
+}
+
+/** True when an Azure error indicates the caller lacks table write permission. */
+function isPermissionError(err: unknown): boolean {
+  const e = err as { statusCode?: number; code?: string };
+  return e?.statusCode === 403 || e?.code === "AuthorizationPermissionMismatch";
+}
+
+/**
+ * Render an Azure/REST error with the fields that actually help diagnose it:
+ * the OData error code, HTTP status, and the service message.
+ */
+function formatAzureError(err: unknown): string {
+  const e = err as {
+    code?: string;
+    statusCode?: number;
+    message?: string;
+    details?: { odataError?: { message?: { value?: string } } };
+  };
+  const parts: string[] = [];
+  if (e?.code) parts.push(`code=${e.code}`);
+  if (typeof e?.statusCode === "number") parts.push(`statusCode=${e.statusCode}`);
+  const serviceMessage = e?.details?.odataError?.message?.value || e?.message;
+  if (serviceMessage) parts.push(`message=${serviceMessage}`);
+  return parts.length > 0 ? parts.join(" ") : String(err);
+}
+
+/**
+ * Validate a name against the Azure Table naming rules and throw an actionable
+ * error if it is invalid.
+ */
+function assertValidTableName(name: string): void {
+  if (!/^[A-Za-z][A-Za-z0-9]{2,62}$/.test(name)) {
+    throw new Error(
+      `Invalid TOOL_USAGE_TABLE_NAME '${name}'. Azure Table names must be ` +
+        "alphanumeric only (no hyphens, underscores, or dots), must start with a " +
+        "letter, and be 3-63 characters long (e.g. 'integrationtoolusage').",
+    );
+  }
+}
+
+/** Recursively find all tool-usage-*.json files under a directory. */
+export function findToolUsageFiles(dir: string): string[] {
+  const found: string[] = [];
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...findToolUsageFiles(full));
+    } else if (
+      entry.isFile() &&
+      entry.name.startsWith(TOOL_USAGE_PREFIX) &&
+      entry.name.endsWith(TOOL_USAGE_SUFFIX)
+    ) {
+      found.push(full);
+    }
+  }
+  return found;
+}
+
+/** Parse a tool-usage-<token>.json file, returning null when unreadable/invalid. */
+export function parseToolUsageFile(filePath: string): ToolUsageFile | null {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, "utf-8");
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.testName === "string" && Array.isArray(parsed.toolCalls)) {
+      return parsed as ToolUsageFile;
+    }
+  } catch {
+    // skip malformed files
+  }
+  return null;
+}
+
+async function main(): Promise<void> {
+  const storageAccount = process.env.TOOL_USAGE_STORAGE_ACCOUNT;
+  const tableName = process.env.TOOL_USAGE_TABLE_NAME;
+  const skill = process.env.SKILL || "unknown";
+  const branch = process.env.BRANCH || "unknown";
+  const runId = process.env.RUN_ID || "unknown";
+  const reportsDir = process.env.TOOL_USAGE_REPORTS_DIR || path.resolve(__dirname, "../reports");
+
+  if (!storageAccount || !tableName) {
+    console.log(
+      "TOOL_USAGE_STORAGE_ACCOUNT or TOOL_USAGE_TABLE_NAME not set; skipping tool usage upload.",
+    );
+    return;
+  }
+
+  assertValidTableName(tableName);
+
+  const files = findToolUsageFiles(reportsDir);
+  if (files.length === 0) {
+    console.log(`No ${TOOL_USAGE_PREFIX}*.json files found under ${reportsDir}; nothing to upload.`);
+    return;
+  }
+
+  const ctx: UploadContext = { skill, branch, runId };
+  const rows: ToolUsageRow[] = [];
+  for (const file of files) {
+    const parsed = parseToolUsageFile(file);
+    if (!parsed) continue;
+    rows.push(...expandToolUsageToRows(parsed, deriveRunToken(file), ctx));
+  }
+
+  if (rows.length === 0) {
+    console.log("No valid tool call records found; nothing to upload.");
+    return;
+  }
+
+  const credential = new DefaultAzureCredential();
+  const tableEndpoint = `https://${storageAccount}.table.core.windows.net`;
+  const tableClient = new TableClient(tableEndpoint, tableName, credential);
+
+  console.log(
+    `Uploading tool usage to ${tableEndpoint} table='${tableName}' ` +
+      `(skill='${skill}', branch='${branch}', run='${runId}', rows=${rows.length}).`,
+  );
+
+  // Ensure the table exists (idempotent; ignores "already exists").
+  try {
+    await tableClient.createTable();
+  } catch (err) {
+    const statusCode = (err as { statusCode?: number })?.statusCode;
+    if (statusCode !== 409) {
+      console.error(`createTable failed for table='${tableName}': ${formatAzureError(err)}`);
+      throw err;
+    }
+  }
+
+  let uploaded = 0;
+  for (const row of rows) {
+    try {
+      await tableClient.upsertEntity({ ...row }, "Replace");
+    } catch (err) {
+      console.error(
+        `upsertEntity failed for table='${tableName}' ` +
+          `partitionKey='${row.partitionKey}' rowKey='${row.rowKey}': ${formatAzureError(err)}`,
+      );
+      throw err;
+    }
+    uploaded++;
+  }
+
+  console.log(
+    `Uploaded ${uploaded} tool call row(s) for skill='${skill}', branch='${branch}', run='${runId}'.`,
+  );
+}
+
+// Only run when executed directly (not when imported by tests).
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main().catch((err) => {
+    // Tool usage upload is auxiliary telemetry; a missing/incorrect table-write
+    // role assignment should surface a clear warning but must not fail the run.
+    if (isPermissionError(err)) {
+      console.warn(
+        "WARNING: Skipping tool usage upload - the workflow identity lacks " +
+          "'Storage Table Data Contributor' on the storage account. Grant the role to enable uploads.",
+      );
+      return;
+    }
+    console.error("Failed to upload tool usage:", formatAzureError(err));
+    process.exit(1);
+  });
+}

--- a/tests/scripts/upload-tool-usage.ts
+++ b/tests/scripts/upload-tool-usage.ts
@@ -35,6 +35,7 @@ import * as fs from "fs";
 import * as path from "path";
 import { fileURLToPath } from "url";
 import { TableClient } from "@azure/data-tables";
+import type { TransactionAction } from "@azure/data-tables";
 import { DefaultAzureCredential } from "@azure/identity";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -195,6 +196,33 @@ export function expandToolUsageToRows(
   return rows;
 }
 
+/** Maximum number of entities allowed in a single Azure Table transaction. */
+export const MAX_TABLE_BATCH_SIZE = 100;
+
+/**
+ * Group rows into Azure Table transaction batches. A transaction requires every
+ * entity in the batch to share a PartitionKey and allows at most 100 entities,
+ * so rows are grouped by `partitionKey` and then chunked to `maxBatchSize`.
+ */
+export function groupRowsForTransactions(
+  rows: ToolUsageRow[],
+  maxBatchSize: number = MAX_TABLE_BATCH_SIZE,
+): ToolUsageRow[][] {
+  const byPartition = new Map<string, ToolUsageRow[]>();
+  for (const row of rows) {
+    const list = byPartition.get(row.partitionKey);
+    if (list) list.push(row);
+    else byPartition.set(row.partitionKey, [row]);
+  }
+  const batches: ToolUsageRow[][] = [];
+  for (const list of byPartition.values()) {
+    for (let i = 0; i < list.length; i += maxBatchSize) {
+      batches.push(list.slice(i, i + maxBatchSize));
+    }
+  }
+  return batches;
+}
+
 /** True when an Azure error indicates the caller lacks table write permission. */
 function isPermissionError(err: unknown): boolean {
   const e = err as { statusCode?: number; code?: string };
@@ -333,22 +361,25 @@ async function main(): Promise<void> {
     }
   }
 
+  const batches = groupRowsForTransactions(rows);
   let uploaded = 0;
-  for (const row of rows) {
+  for (const batch of batches) {
+    const actions: TransactionAction[] = batch.map((row) => ["upsert", { ...row }, "Replace"]);
     try {
-      await tableClient.upsertEntity({ ...row }, "Replace");
+      await tableClient.submitTransaction(actions);
     } catch (err) {
       console.error(
-        `upsertEntity failed for table='${tableName}' ` +
-          `partitionKey='${row.partitionKey}' rowKey='${row.rowKey}': ${formatAzureError(err)}`,
+        `submitTransaction failed for table='${tableName}' ` +
+          `partitionKey='${batch[0]?.partitionKey}' size=${batch.length}: ${formatAzureError(err)}`,
       );
       throw err;
     }
-    uploaded++;
+    uploaded += batch.length;
   }
 
   console.log(
-    `Uploaded ${uploaded} tool call row(s) for skill='${skill}', branch='${branch}', run='${runId}'.`,
+    `Uploaded ${uploaded} tool call row(s) in ${batches.length} batch(es) ` +
+      `for skill='${skill}', branch='${branch}', run='${runId}'.`,
   );
 }
 

--- a/tests/utils/__tests__/tool-usage.test.ts
+++ b/tests/utils/__tests__/tool-usage.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for per-run tool-usage capture (Phase 1).
+ *
+ * Covers computeToolUsage (ordering, success join, skill inclusion) and
+ * deriveToolUsageFileName (1:1 correlation with the markdown report name).
+ */
+
+import * as path from "path";
+import type { SessionEvent } from "@github/copilot-sdk";
+import { computeToolUsage, deriveToolUsageFileName } from "../agent-runner.ts";
+
+// Minimal event factories. Cast through unknown because we only populate the
+// fields computeToolUsage reads; the full SessionEvent union is much larger.
+function startEvent(toolName: string, toolCallId: string, args: unknown): SessionEvent {
+  return {
+    type: "tool.execution_start",
+    data: { toolName, toolCallId, arguments: args },
+  } as unknown as SessionEvent;
+}
+
+function completeEvent(toolCallId: string, success: boolean): SessionEvent {
+  return {
+    type: "tool.execution_complete",
+    data: { toolCallId, success },
+  } as unknown as SessionEvent;
+}
+
+function otherEvent(type: string): SessionEvent {
+  return { type, data: {} } as unknown as SessionEvent;
+}
+
+describe("computeToolUsage", () => {
+  test("captures tools in emission order with 0-based order index", () => {
+    const events: SessionEvent[] = [
+      otherEvent("assistant.message"),
+      startEvent("bash", "c1", { command: "ls" }),
+      completeEvent("c1", true),
+      startEvent("view", "c2", { path: "/tmp/a" }),
+      completeEvent("c2", true),
+    ];
+
+    const result = computeToolUsage(events);
+
+    expect(result.map((t) => [t.order, t.toolName])).toEqual([
+      [0, "bash"],
+      [1, "view"],
+    ]);
+  });
+
+  test("includes the skill pseudo-tool in the sequence", () => {
+    const events: SessionEvent[] = [
+      startEvent("skill", "s1", { skill: "azure-deploy" }),
+      completeEvent("s1", true),
+      startEvent("bash", "c1", { command: "azd up" }),
+      completeEvent("c1", true),
+    ];
+
+    const result = computeToolUsage(events);
+
+    expect(result.map((t) => t.toolName)).toEqual(["skill", "bash"]);
+    expect(result[0].arguments).toEqual({ skill: "azure-deploy" });
+  });
+
+  test("joins success by toolCallId and uses null when no completion exists", () => {
+    const events: SessionEvent[] = [
+      startEvent("bash", "c1", { command: "ok" }),
+      completeEvent("c1", true),
+      startEvent("bash", "c2", { command: "boom" }),
+      completeEvent("c2", false),
+      // c3 never completes (e.g. early termination / timeout).
+      startEvent("view", "c3", { path: "/tmp/x" }),
+    ];
+
+    const result = computeToolUsage(events);
+
+    expect(result).toEqual([
+      { order: 0, toolName: "bash", toolCallId: "c1", arguments: { command: "ok" }, success: true },
+      { order: 1, toolName: "bash", toolCallId: "c2", arguments: { command: "boom" }, success: false },
+      { order: 2, toolName: "view", toolCallId: "c3", arguments: { path: "/tmp/x" }, success: null },
+    ]);
+  });
+
+  test("normalizes missing arguments to null", () => {
+    const events: SessionEvent[] = [startEvent("bash", "c1", undefined)];
+    const result = computeToolUsage(events);
+    expect(result[0].arguments).toBeNull();
+  });
+
+  test("returns an empty array when there are no tool calls", () => {
+    expect(computeToolUsage([otherEvent("assistant.message")])).toEqual([]);
+  });
+});
+
+describe("deriveToolUsageFileName", () => {
+  test("derives a matching tool-usage name from the markdown report path", () => {
+    const report = path.join("a", "b", "agent-metadata-2026-06-15T11-44-05-123Z.md");
+    expect(deriveToolUsageFileName(report)).toBe(
+      path.join("a", "b", "tool-usage-2026-06-15T11-44-05-123Z.json"),
+    );
+  });
+
+  test("preserves the collision dedupe suffix so it stays 1:1 with the report", () => {
+    const report = path.join("dir", "agent-metadata-2026-06-15T11-44-05-123Z-2.md");
+    expect(deriveToolUsageFileName(report)).toBe(
+      path.join("dir", "tool-usage-2026-06-15T11-44-05-123Z-2.json"),
+    );
+  });
+});

--- a/tests/utils/__tests__/tool-usage.test.ts
+++ b/tests/utils/__tests__/tool-usage.test.ts
@@ -11,17 +11,24 @@ import { computeToolUsage, deriveToolUsageFileName } from "../agent-runner.ts";
 
 // Minimal event factories. Cast through unknown because we only populate the
 // fields computeToolUsage reads; the full SessionEvent union is much larger.
-function startEvent(toolName: string, toolCallId: string, args: unknown): SessionEvent {
+function startEvent(toolName: string, toolCallId: string, args: unknown, timestamp?: string): SessionEvent {
   return {
     type: "tool.execution_start",
+    timestamp,
     data: { toolName, toolCallId, arguments: args },
   } as unknown as SessionEvent;
 }
 
-function completeEvent(toolCallId: string, success: boolean): SessionEvent {
+function completeEvent(
+  toolCallId: string,
+  success: boolean,
+  timestamp?: string,
+  result?: unknown,
+): SessionEvent {
   return {
     type: "tool.execution_complete",
-    data: { toolCallId, success },
+    timestamp,
+    data: { toolCallId, success, result },
   } as unknown as SessionEvent;
 }
 
@@ -74,10 +81,72 @@ describe("computeToolUsage", () => {
     const result = computeToolUsage(events);
 
     expect(result).toEqual([
-      { order: 0, toolName: "bash", toolCallId: "c1", arguments: { command: "ok" }, success: true },
-      { order: 1, toolName: "bash", toolCallId: "c2", arguments: { command: "boom" }, success: false },
-      { order: 2, toolName: "view", toolCallId: "c3", arguments: { path: "/tmp/x" }, success: null },
+      { order: 0, toolName: "bash", toolCallId: "c1", arguments: { command: "ok" }, success: true, durationMs: null, outputBytes: null },
+      { order: 1, toolName: "bash", toolCallId: "c2", arguments: { command: "boom" }, success: false, durationMs: null, outputBytes: null },
+      { order: 2, toolName: "view", toolCallId: "c3", arguments: { path: "/tmp/x" }, success: null, durationMs: null, outputBytes: null },
     ]);
+  });
+
+  test("computes durationMs from start and completion timestamps", () => {
+    const events: SessionEvent[] = [
+      startEvent("bash", "c1", { command: "ok" }, "2026-06-15T11:44:05.000Z"),
+      completeEvent("c1", true, "2026-06-15T11:44:06.500Z"),
+      // No completion -> null duration.
+      startEvent("view", "c2", { path: "/tmp/x" }, "2026-06-15T11:44:07.000Z"),
+    ];
+
+    const result = computeToolUsage(events);
+
+    expect(result.map((t) => t.durationMs)).toEqual([1500, null]);
+  });
+
+  test("uses null duration when a completion timestamp predates its start", () => {
+    const events: SessionEvent[] = [
+      startEvent("bash", "c1", {}, "2026-06-15T11:44:06.000Z"),
+      completeEvent("c1", true, "2026-06-15T11:44:05.000Z"),
+    ];
+    expect(computeToolUsage(events)[0].durationMs).toBeNull();
+  });
+
+  test("measures output bytes, preferring detailedContent over content", () => {
+    const events: SessionEvent[] = [
+      startEvent("bash", "c1", {}, "2026-06-15T11:44:05.000Z"),
+      completeEvent("c1", true, "2026-06-15T11:44:05.100Z", {
+        content: "short",
+        detailedContent: "the full detailed output",
+      }),
+    ];
+    expect(computeToolUsage(events)[0].outputBytes).toBe(
+      Buffer.byteLength("the full detailed output", "utf8"),
+    );
+  });
+
+  test("falls back to content, then to text/terminal blocks, excluding binary", () => {
+    const fromContent: SessionEvent[] = [
+      startEvent("bash", "c1", {}, "2026-06-15T11:44:05.000Z"),
+      completeEvent("c1", true, "2026-06-15T11:44:05.100Z", { content: "café" }),
+    ];
+    // "café" is 5 UTF-8 bytes (é = 2 bytes).
+    expect(computeToolUsage(fromContent)[0].outputBytes).toBe(5);
+
+    const fromBlocks: SessionEvent[] = [
+      startEvent("bash", "c2", {}, "2026-06-15T11:44:05.000Z"),
+      completeEvent("c2", true, "2026-06-15T11:44:05.100Z", {
+        contents: [
+          { type: "text", text: "abc" },
+          { type: "terminal", text: "de" },
+          { type: "image", data: "BIGBASE64SHOULDNOTCOUNT" },
+        ],
+      }),
+    ];
+    expect(computeToolUsage(fromBlocks)[0].outputBytes).toBe(5);
+  });
+
+  test("uses null output bytes when there is no completion", () => {
+    const events: SessionEvent[] = [
+      startEvent("view", "c1", { path: "/tmp/x" }, "2026-06-15T11:44:05.000Z"),
+    ];
+    expect(computeToolUsage(events)[0].outputBytes).toBeNull();
   });
 
   test("normalizes missing arguments to null", () => {

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -98,6 +98,44 @@ export interface AgentMetadata {
 }
 
 /**
+ * A single tool invocation captured during an agent run, in emission order.
+ * Includes the `skill` pseudo-tool so the full sequence can be reconstructed.
+ */
+export interface ToolCall {
+  /** 0-based index over `tool.execution_start` events in emission order. */
+  order: number;
+  /** Raw `event.data.toolName` (e.g. "skill", "bash", an MCP tool name). */
+  toolName: string;
+  /** Correlates the start event to its `tool.execution_complete`. */
+  toolCallId: string;
+  /** Full tool arguments, secret-redacted on write, untruncated. */
+  arguments: unknown;
+  /**
+   * Success of the matching `tool.execution_complete`, or `null` when no
+   * completion event was observed for this call.
+   */
+  success: boolean | null;
+}
+
+/**
+ * Structured, per-run record of the tools called during a single agent run.
+ * Written alongside (and named to match) that run's markdown report so the tool
+ * sequence for a specific run can be reconstructed even when the same stimulus
+ * runs multiple times in the same test-case directory.
+ */
+export interface ToolUsageRecord {
+  testName: string;
+  /** Basename of this run's `agent-metadata-<token>.md` report (1:1 correlation). */
+  reportFile: string;
+  /** Session id from the `session.start` event, if present. */
+  sessionId: string | null;
+  model: string | undefined;
+  /** ISO-8601 timestamp of when this file was written. */
+  timestamp: string;
+  toolCalls: ToolCall[];
+}
+
+/**
  * A unique identifier to use for the test run name.
  * By default, reports for each test run will be written to a pseudo-unique directory under "reports/test-run-{timestamp}/".
  * If {@link testRunId} is non-empty, reports for this test run will be written to a directory under "reports/test-run-{testRunId}/".
@@ -286,6 +324,54 @@ function computeToolAndSkillStats(
   }
 
   return { toolCounts, skillFiles };
+}
+
+/**
+ * Build the ordered list of tool calls for a single run from its session events.
+ *
+ * - One entry per `tool.execution_start` event, in emission order, including the
+ *   `skill` pseudo-tool.
+ * - `success` is resolved by joining each start to its `tool.execution_complete`
+ *   by `toolCallId`; `null` when no completion event exists.
+ */
+export function computeToolUsage(events: SessionEvent[]): ToolCall[] {
+  // First pass: success by toolCallId from completion events.
+  const successById = new Map<string, boolean>();
+  for (const event of events) {
+    if (event.type !== "tool.execution_complete") continue;
+    const id = event.data.toolCallId as string | undefined;
+    if (id !== undefined) successById.set(id, Boolean(event.data.success));
+  }
+
+  const toolCalls: ToolCall[] = [];
+  for (const event of events) {
+    if (event.type !== "tool.execution_start") continue;
+    const toolName = event.data.toolName as string | undefined;
+    const toolCallId = event.data.toolCallId as string | undefined;
+    if (!toolName || toolCallId === undefined) continue;
+    toolCalls.push({
+      order: toolCalls.length,
+      toolName,
+      toolCallId,
+      arguments: event.data.arguments ?? null,
+      success: successById.has(toolCallId) ? successById.get(toolCallId)! : null,
+    });
+  }
+  return toolCalls;
+}
+
+/**
+ * Derive the per-run tool-usage JSON path from a run's markdown report path,
+ * so the two share the same `<token>` and correlate 1:1.
+ * `.../agent-metadata-<token>.md` -> `.../tool-usage-<token>.json`
+ */
+export function deriveToolUsageFileName(reportFilePath: string): string {
+  const dir = path.dirname(reportFilePath);
+  const base = path
+    .basename(reportFilePath)
+    .replace(/^agent-metadata-/, "tool-usage-")
+    .replace(/\.md$/, ".json");
+  return path.join(dir, base);
 }
 
 /**
@@ -949,6 +1035,34 @@ function writeMarkdownReport(testName: string, config: AgentRunConfig, agentMeta
       skillFiles: agentMetadata.skillFiles,
     };
     fs.writeFileSync(jsonPath, redactSecrets(JSON.stringify(jsonData, null, 2)), "utf-8");
+
+    // Write per-run tool-usage JSON (Phase 1: capture for review). Named to match
+    // this run's markdown report so the tool sequence for a specific run can be
+    // reconstructed even when the same stimulus runs multiple times in one
+    // directory (where agent-metadata.json is overwritten). Best-effort: never
+    // fail a test because capture failed.
+    try {
+      const toolUsagePath = deriveToolUsageFileName(reportTargetPath);
+      const sessionId =
+        agentMetadata.events.find((e) => e.type === "session.start")?.id ?? null;
+      const toolUsage: ToolUsageRecord = {
+        testName,
+        reportFile: path.basename(reportTargetPath),
+        sessionId,
+        model: config.model ?? agentMetadata.tokenUsage?.model,
+        timestamp: new Date().toISOString(),
+        toolCalls: computeToolUsage(agentMetadata.events),
+      };
+      fs.writeFileSync(
+        toolUsagePath,
+        redactSecrets(JSON.stringify(toolUsage, null, 2)),
+        "utf-8",
+      );
+    } catch (error) {
+      if (process.env.DEBUG) {
+        console.error("Failed to write tool usage JSON:", error);
+      }
+    }
 
     if (process.env.DEBUG) {
       console.log(`Markdown report written to: ${reportTargetPath}`);

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -115,6 +115,17 @@ export interface ToolCall {
    * completion event was observed for this call.
    */
   success: boolean | null;
+  /**
+   * Wall-clock duration in milliseconds, computed from the start and matching
+   * completion event timestamps, or `null` when no completion was observed.
+   */
+  durationMs: number | null;
+  /**
+   * UTF-8 byte size of the tool's full textual output (`detailedContent`,
+   * falling back to `content`, then to text/terminal result blocks). Binary
+   * blocks (image/audio) are excluded. `null` when no completion was observed.
+   */
+  outputBytes: number | null;
 }
 
 /**
@@ -335,12 +346,18 @@ function computeToolAndSkillStats(
  *   by `toolCallId`; `null` when no completion event exists.
  */
 export function computeToolUsage(events: SessionEvent[]): ToolCall[] {
-  // First pass: success by toolCallId from completion events.
+  // First pass: success and completion timestamp by toolCallId from completion events.
   const successById = new Map<string, boolean>();
+  const completeTimeById = new Map<string, string>();
+  const outputBytesById = new Map<string, number | null>();
   for (const event of events) {
     if (event.type !== "tool.execution_complete") continue;
     const id = event.data.toolCallId as string | undefined;
-    if (id !== undefined) successById.set(id, Boolean(event.data.success));
+    if (id !== undefined) {
+      successById.set(id, Boolean(event.data.success));
+      completeTimeById.set(id, event.timestamp);
+      outputBytesById.set(id, computeOutputBytes(event.data.result));
+    }
   }
 
   const toolCalls: ToolCall[] = [];
@@ -355,9 +372,54 @@ export function computeToolUsage(events: SessionEvent[]): ToolCall[] {
       toolCallId,
       arguments: event.data.arguments ?? null,
       success: successById.has(toolCallId) ? successById.get(toolCallId)! : null,
+      durationMs: computeDurationMs(event.timestamp, completeTimeById.get(toolCallId)),
+      outputBytes: outputBytesById.has(toolCallId) ? outputBytesById.get(toolCallId)! : null,
     });
   }
   return toolCalls;
+}
+
+/**
+ * UTF-8 byte size of a completion's full textual output. Prefers `detailedContent`,
+ * falls back to `content`, then to concatenated text from text/terminal result
+ * blocks. Binary blocks (image/audio) and resources are excluded. Returns `null`
+ * when no textual output is present.
+ */
+function computeOutputBytes(
+  result:
+    | { content?: string; detailedContent?: string; contents?: unknown[] }
+    | undefined,
+): number | null {
+  if (!result) return null;
+  let text: string | undefined;
+  if (typeof result.detailedContent === "string") {
+    text = result.detailedContent;
+  } else if (typeof result.content === "string") {
+    text = result.content;
+  } else if (Array.isArray(result.contents)) {
+    const parts: string[] = [];
+    for (const block of result.contents) {
+      const blockText = (block as { text?: unknown }).text;
+      if (typeof blockText === "string") parts.push(blockText);
+    }
+    text = parts.length > 0 ? parts.join("") : undefined;
+  }
+  if (text === undefined) return null;
+  return Buffer.byteLength(text, "utf8");
+}
+
+/**
+ * Wall-clock duration in milliseconds between a tool call's start and matching
+ * completion timestamp. Returns `null` when the completion is missing or either
+ * timestamp is unparseable, or when the result would be negative.
+ */
+function computeDurationMs(startTs: string, completeTs: string | undefined): number | null {
+  if (!completeTs) return null;
+  const start = Date.parse(startTs);
+  const end = Date.parse(completeTs);
+  if (Number.isNaN(start) || Number.isNaN(end)) return null;
+  const delta = end - start;
+  return delta >= 0 ? delta : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds an end-to-end pipeline so the integration-tests dashboard can show **exactly which tools were called in each agent run**, for reviewability of nightly runs (not automated pass/fail comparison).

Delivered in three compartmentalized phases:

### Phase 1 — capture (`de434420`)
- `tests/utils/agent-runner.ts`: `computeToolUsage` records the ordered tool-call sequence per run (incl. the `skill` pseudo-tool, success joined by `toolCallId`, plus per-call **`durationMs`** and **`outputBytes`**), written to a per-run `tool-usage-<token>.json` blob named 1:1 with the run''s markdown report.

### Phase 2a — storage + API (`08f682e8`)
- `tests/scripts/upload-tool-usage.ts`: uploads **one Azure Table row per tool call** (name, order, success, duration, output size); full arguments stay in the blob and are fetched on demand.
- `dashboard/api` `getToolUsage.ts`: `GET /api/tool-usage` read endpoint with skill/test/branch/runId/runToken/runDate filters.
- `dashboard/infra`: provisions the `integrationtoolusage` table and wires `TOOL_USAGE_TABLE_NAME` through the bicep modules.
- CI: an "Upload tool usage to table" step in the integration and azure-deploy workflows.

### Phase 2b — dashboard UI (`e6cac93f`)
- A collapsible **"Tools"** toggle under each test item (passed and failed) in the details panel. On expand it lazy-loads the API filtered by skill + test + selected date, groups calls by `runToken` (one block per run, ordered by call order), and lists each call as order · ✓/✗/? · tool name · duration · output size. Clicking **args** fetches that call''s full arguments on demand from the per-run blob.

## Testing
- `tests`: `npm run typecheck`, `npm run lint`, unit tests for capture + uploader transforms all green.
- `dashboard/api`: `tsc` build clean.
- `dashboard`: `vite build` + `tsc --noEmit` clean for changed files.
- `az bicep build` clean (pre-existing tag warnings only).
