### PR TITLE
eval: support multi-file eval spec

### DIFF
--- a/tests/run-vally-test.ts
+++ b/tests/run-vally-test.ts
@@ -315,7 +315,16 @@ async function main(): Promise<void> {
   forwardedArgs.splice(0, 0, "--executor-plugin", path.join(__dirname, "vally", "vally-executor.ts"));
   forwardedArgs.splice(0, 0, "--grader-plugin", path.join(__dirname, "vally", "vally-graders.ts"));
   if (options.skill) {
-    forwardedArgs.splice(0, 0, "--eval-spec", `../evals/${options.skill}/eval.yaml`);
+    const evalSpecDir = path.join(__dirname, `../evals/${options.skill}/`);
+    const evalSpecPaths: string[] = [];
+    const allFiles = await fs.readdir(evalSpecDir);
+    for (const file of allFiles) {
+      if (file.endsWith(".yaml")) {
+        evalSpecPaths.push(path.join(evalSpecDir, file));
+      }
+    }
+
+    forwardedArgs.splice(0, 0, ...evalSpecPaths.map(v => ["--eval-spec", v]).flat());
   }
 
   const exitCode = await runVallyCommand(forwardedArgs);


### PR DESCRIPTION
## Description

Support multi-file eval spec for skills.

**Note:** This only supports placing eval spec files directly under the skill's eval directory. Vally resolves extension plugins from the directory of the eval spec file, so having nested eval specs in subdirectories will lead to runtime errors.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

