### PR TITLE
feat: add skill related knowledge into foundry skill

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/skill-management.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/skill-management.md
@@ -101,6 +101,7 @@ azd ai skill update my-skill --set-default-version 1
 The SDK uses `AIProjectClient.beta.skills` (preview API surface, requires `allow_preview=True`).
 
 ```python
+import os
 from azure.ai.projects.aio import AIProjectClient
 from azure.identity.aio import DefaultAzureCredential
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/skill-management.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/skill-management.md
@@ -1,0 +1,154 @@
+# Skills (azd ai)
+
+How to create, manage, and version **skills** (reusable behavioral guidelines) in a Foundry project using `azd ai skill` and the Python SDK.
+
+A **skill** is a Markdown file with YAML front matter (`SKILL.md`), uploaded to a Foundry project, and attached to agents at runtime. Skills enable updating agent behavior **without code changes**.
+
+> 📘 For attaching skills to a toolbox (`azd ai toolbox skill add/remove/list`) and the raw MCP protocol, see [skill-toolbox.md](skill-toolbox.md).
+>
+> 📘 For consuming skills in agent code (Agent Framework SDK integration, progressive disclosure, `load_skill`), see [use-skills-in-hosted-agent.md](use-skills-in-hosted-agent.md).
+
+## Install the extension
+
+```bash
+azd extension install azure.ai.skills
+```
+
+## Skill authoring format
+
+Each skill lives in its own directory with `SKILL.md` at the root:
+
+```
+skills/
+  my-skill/
+    SKILL.md       # YAML front matter + Markdown body
+```
+
+```yaml
+---
+name: my-skill-name
+description: What this skill does and when the agent should load it
+---
+
+# My Skill
+
+Instructions the agent follows when this skill is loaded on demand...
+```
+
+> **The `name` and `description` values must be unquoted** in YAML front matter — quoting causes HTTP 500 on import.
+
+The `description` field drives skill discovery at runtime: the Agent Framework SDK uses it to decide when to load the skill. Write descriptions that clearly state **when** the agent should use the skill. See [use-skills-in-hosted-agent.md § How progressive disclosure works](use-skills-in-hosted-agent.md) for details.
+
+## CLI surface — `azd ai skill`
+
+| Command | What it does |
+|---------|--------------|
+| `azd ai skill create <name> --file <path>` | Create skill + publish v1. Accepts SKILL.md, .zip, or directory. |
+| `azd ai skill create <name> --description "..." --instructions "..."` | Inline create (no file). |
+| `azd ai skill create <name> --file <path> --force` | Delete existing + recreate. Safe to re-run after edits. |
+| `azd ai skill update <name> --file <path>` | New immutable version, promoted to default. |
+| `azd ai skill update <name> --set-default-version <ver>` | Repoint default (rollback) without uploading new content. |
+| `azd ai skill show <name>` | Show metadata (default_version, latest_version). |
+| `azd ai skill list` | List skills in the project. |
+| `azd ai skill download <name>` | Extract to `./.agents/skills/<name>/`. |
+| `azd ai skill download <name> --version <ver>` | Download a specific version. |
+| `azd ai skill download <name> --raw` | Write raw ZIP without extracting. |
+| `azd ai skill delete <name> [--force]` | Delete skill. |
+
+Every mutation creates a new immutable version. `create` promotes v1 to default; `update` promotes the new version to default.
+
+Four mutually exclusive input modes for `create` and `update`:
+
+1. **Directory:** `--file ./skills/my-skill/` (CLI packages as ZIP; requires `SKILL.md` at root)
+2. **SKILL.md:** `--file ./SKILL.md` (CLI parses YAML front matter + body)
+3. **ZIP:** `--file ./skill.zip` (uploaded as multipart/form-data)
+4. **Inline:** `--description "..." --instructions "..."` (no file)
+
+## Recipe: create a skill
+
+```bash
+azd ai skill create support-style --file ./skills/support-style/
+```
+
+## Recipe: batch provision (safe to re-run)
+
+```bash
+for dir in skills/*/; do
+  name=$(basename "$dir")
+  azd ai skill create "$name" --file "$dir" --force
+done
+```
+
+## Recipe: update a skill
+
+```bash
+# Edit SKILL.md locally, then:
+azd ai skill update my-skill --file ./skills/my-skill/
+```
+
+After update:
+- Toolbox skill references (without pinned version) follow the new `default_version` — live immediately, no toolbox republish needed.
+- `SkillsProvider` downloads at agent startup — redeploy agent to pick up the new version.
+
+## Recipe: rollback a skill version
+
+```bash
+azd ai skill update my-skill --set-default-version 1
+```
+
+## Python SDK operations
+
+The SDK uses `AIProjectClient.beta.skills` (preview API surface, requires `allow_preview=True`).
+
+```python
+from azure.ai.projects.aio import AIProjectClient
+from azure.identity.aio import DefaultAzureCredential
+
+async with (
+    DefaultAzureCredential() as credential,
+    AIProjectClient(
+        endpoint=os.environ["FOUNDRY_PROJECT_ENDPOINT"],
+        credential=credential,
+        allow_preview=True,
+    ) as project,
+):
+    # Create from package (in-memory ZIP)
+    imported = await project.beta.skills.create_from_package(zip_bytes)
+
+    # List
+    async for skill in project.beta.skills.list():
+        print(f"{skill.name}: {skill.description}")
+
+    # Download
+    stream = await project.beta.skills.download("my-skill")
+    zip_bytes = b"".join([chunk async for chunk in stream])
+
+    # Delete
+    await project.beta.skills.delete("my-skill")
+```
+
+Full provisioning script: [provision_skills.py](https://github.com/microsoft-foundry/foundry-samples/blob/main/samples/python/hosted-agents/agent-framework/responses/12-foundry-skills/provision_skills.py).
+
+## RBAC
+
+Skills require **Foundry User** on the Foundry project scope (for both the developer identity and the deployed agent's managed identity).
+
+## Versioning
+
+- Every `create` produces version 1 as the default.
+- Every `update` creates a new immutable version and promotes it to default.
+- `azd ai skill update <name> --set-default-version <ver>` repoints without uploading new content.
+- Toolbox skill references without a pinned version follow the skill's `default_version`.
+- Toolbox skill references with a pinned version (`skill@2`) stay on that version regardless.
+- `SkillsProvider` downloads the `default_version` at agent startup.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|------------|-----|
+| HTTP 500 on skill create | Quoted `name` or `description` in YAML front matter | Remove quotes from front matter values |
+| `403 Forbidden` | Missing RBAC | Grant **Foundry User** on the project scope |
+| `azd ai skill` not recognized | Extension not installed | `azd extension install azure.ai.skills` |
+| Skill attached but agent doesn't use it | Description too vague for progressive disclosure | Improve `description` in SKILL.md front matter |
+| Agent still uses old skill content after `update` | Toolbox skill pinned to old version, or `SkillsProvider` caches at startup | Use consumer endpoint (no version pin), or redeploy agent |
+| `create_from_package` fails | SDK client missing preview flag | `AIProjectClient(allow_preview=True)` |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/skill-toolbox.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/skill-toolbox.md
@@ -98,8 +98,10 @@ Skills are exposed through the MCP **resources** protocol (not `tools/list`):
 ```bash
 # Get a bearer token
 TOK=$(az account get-access-token --resource "https://ai.azure.com" --query accessToken -o tsv)
-URL="$PE/toolboxes/<toolbox>/mcp?api-version=v1"
 
+# Foundry project endpoint (no trailing slash)
+PE="<FOUNDRY_PROJECT_ENDPOINT>"
+URL="$PE/toolboxes/<toolbox>/mcp?api-version=v1"
 # List available skills (resources/list)
 curl -s -X POST "$URL" \
   -H "Authorization: Bearer $TOK" \

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/skill-toolbox.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/skill-toolbox.md
@@ -1,0 +1,133 @@
+# Skills in Toolbox
+
+How to attach, list, remove, and version **skills** (reusable behavioral guidelines) in a Foundry toolbox using `azd ai toolbox skill`.
+
+Skills are not a tool `type` — they live in a separate `skills[]` array in the toolbox manifest. At the MCP level, skills are exposed as **resources** (`resources/list` / `resources/read` with `skill://` URIs).
+
+> 📘 For skill resource CRUD (`azd ai skill create/update/list/download/delete`), see [skill-management.md](skill-management.md).
+>
+> 📘 For consuming skills in agent code (Agent Framework SDK integration, progressive disclosure, `load_skill`), see [use-skills-in-hosted-agent.md](use-skills-in-hosted-agent.md).
+
+## Install
+
+```bash
+azd extension install azure.ai.skills       # skill CRUD
+azd extension install azure.ai.toolboxes    # toolbox management
+```
+
+## CLI surface — `azd ai toolbox skill`
+
+| Command | What it does |
+|---------|--------------|
+| `azd ai toolbox skill add <toolbox> <skill>` | Attach skill (follows default version); new immutable toolbox version. |
+| `azd ai toolbox skill add <toolbox> <skill>@<ver>` | Attach skill pinned to a specific version. |
+| `azd ai toolbox skill add <toolbox> --from-file <path>` | Attach multiple skills from JSON/YAML. |
+| `azd ai toolbox skill list <toolbox>` | List skill references in the toolbox. |
+| `azd ai toolbox skill remove <toolbox> <skill> [<skill>...] [--force]` | Detach skills; one new version. |
+
+> Every `skill add` / `skill remove` creates a new immutable toolbox version but does **not** change the default. Run `azd ai toolbox publish <toolbox> <version>` to promote.
+
+## Recipe: attach skill to existing toolbox
+
+```bash
+# 1. Create the skill (if not already uploaded)
+azd ai skill create support-style --file ./skills/support-style/
+
+# 2. Attach to toolbox
+azd ai toolbox skill add agent-tools support-style
+
+# 3. Promote the new toolbox version
+azd ai toolbox publish agent-tools <new-version>
+
+# 4. Verify
+azd ai toolbox skill list agent-tools
+```
+
+## Recipe: include skills in toolbox creation
+
+Skills are a top-level `skills[]` array in the `--from-file` manifest:
+
+```yaml
+description: Agent toolbox with skills
+connections:
+  - name: my-mcp-server
+skills:
+  - name: support-style
+  - name: escalation-policy
+    version: "2"         # pin to version 2; omit to follow default
+tools:
+  - type: web_search
+    name: web
+```
+
+```bash
+azd ai toolbox create agent-tools --from-file tools.yaml
+```
+
+When `version` is omitted from a skill entry, the toolbox resolves the skill's `default_version` at read time. If the skill is updated (`azd ai skill update`), agents on the consumer endpoint pick up the new content without a toolbox republish.
+
+## Recipe: remove skill from toolbox
+
+```bash
+# Remove one or more skills (one new version)
+azd ai toolbox skill remove agent-tools my-skill --force
+
+# Promote
+azd ai toolbox publish agent-tools <new-version>
+```
+
+Removing the last skill is allowed (the toolbox can still have connections and tools).
+
+## Versioning behavior
+
+- Each `skill add` / `skill remove` creates a new immutable toolbox version (default unchanged until `publish`).
+- Skill references without a pinned version follow the skill's `default_version` at read time.
+- Skill references with a pinned version (`skill@2`) stay on that version regardless of skill updates.
+- To rollback: `azd ai toolbox publish <toolbox> <previous-version>`.
+
+## How skills appear at runtime (raw MCP protocol)
+
+Skills are exposed through the MCP **resources** protocol (not `tools/list`):
+
+- `resources/list` advertises each skill as a resource with a `skill://<name>/SKILL.md` URI (name + description).
+- `resources/list` also exposes `skill://index.json` — a discovery index listing every skill on the toolbox version with URLs to read each skill's `SKILL.md` and (for multi-file skills) its ZIP archive.
+- `resources/read` with a `skill://` URI retrieves the full `SKILL.md` body on demand.
+
+### Raw MCP call examples
+
+```bash
+# Get a bearer token
+TOK=$(az account get-access-token --resource "https://ai.azure.com" --query accessToken -o tsv)
+URL="$PE/toolboxes/<toolbox>/mcp?api-version=v1"
+
+# List available skills (resources/list)
+curl -s -X POST "$URL" \
+  -H "Authorization: Bearer $TOK" \
+  -H "Content-Type: application/json" \
+  -H "Foundry-Features: Toolboxes=V1Preview" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}'
+
+# Read skill index
+curl -s -X POST "$URL" \
+  -H "Authorization: Bearer $TOK" \
+  -H "Content-Type: application/json" \
+  -H "Foundry-Features: Toolboxes=V1Preview" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"skill://index.json"}}'
+
+# Read a specific skill's content
+curl -s -X POST "$URL" \
+  -H "Authorization: Bearer $TOK" \
+  -H "Content-Type: application/json" \
+  -H "Foundry-Features: Toolboxes=V1Preview" \
+  -d '{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"skill://my-skill/SKILL.md"}}'
+```
+
+> For how the Agent Framework SDK wraps these MCP resources into a `load_skill` tool for progressive disclosure, see [use-skills-in-hosted-agent.md](use-skills-in-hosted-agent.md).
+
+## Skill + Tool Search interaction
+
+When `toolbox_search_preview` is enabled, regular tools are hidden from `tools/list` and discovered via `tool_search`. Skills remain in `resources/list` regardless of this setting — they are not affected by Tool Search.
+
+## Skills via Toolbox vs SkillsProvider: when to use which
+
+See [use-skills-in-hosted-agent.md § Choosing an approach](use-skills-in-hosted-agent.md) for a comparison table.

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-skills-in-hosted-agent.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-skills-in-hosted-agent.md
@@ -1,0 +1,161 @@
+# Use Skills in a Hosted Agent
+
+How to consume Foundry **skills** (reusable behavioral guidelines) from hosted agent code. Two approaches:
+
+1. **Direct download** — agent downloads skill ZIPs at startup via the Skills API, wires `SkillsProvider` (Python) or `AgentSkillsProvider` (C#).
+2. **Via Toolbox MCP** — agent connects to a toolbox MCP endpoint that exposes skills as resources, wires `AgentSkillsProviderBuilder.UseMcpSkills` (C#) or `MCPStreamableHTTPTool` (Python).
+
+> 📘 For skill resource CRUD (`azd ai skill create/update/list/download/delete`), see [skill-management.md](skill-management.md).
+>
+> 📘 For attaching skills to a toolbox (`azd ai toolbox skill add/remove/list`) and the raw MCP protocol, see [skill-toolbox.md](skill-toolbox.md).
+
+## How progressive disclosure works
+
+The Agent Framework SDK provides **progressive disclosure** so the model only loads skill content when needed:
+
+1. **Advertise** — At agent startup, skill names and descriptions (~100 tokens each) are injected into the system prompt. The model sees *what skills exist* and *when to use them*.
+2. **Load on demand** — The SDK synthesizes a `load_skill` tool. When the model determines a skill is relevant, it calls `load_skill(skill_name)` to retrieve the full `SKILL.md` body.
+3. **Follow** — The model incorporates the loaded skill instructions into its behavior for the remainder of the conversation turn.
+
+This keeps context usage low — only skills relevant to the current query consume tokens.
+
+## Choosing an approach
+
+| | Direct Download | Via Toolbox MCP |
+|--|---|---|
+| How it works | Agent downloads skill ZIPs at startup, extracts to disk, builds provider from local files | Agent connects to toolbox MCP endpoint; SDK reads `resources/list` and wraps into `load_skill` |
+| Provider | `SkillsProvider.from_paths()` (Python) / `AgentSkillsProvider(dir)` (C#) | `MCPStreamableHTTPTool` (Python) / `AgentSkillsProviderBuilder().UseMcpSkills(mcpClient).Build()` (C#) |
+| When skills update | Redeploy agent to pick up new versions | Consumer endpoint picks up new default version automatically (no redeploy) |
+| Feature header | `Foundry-Features: Skills=V1Preview` | `Foundry-Features: Toolboxes=V1Preview` |
+| When to use | Need explicit version control at startup, no toolbox in the project | Agents already consuming a toolbox; want dynamic skill updates without redeployment |
+
+---
+
+## Approach 1: Direct Download
+
+The agent downloads skill ZIPs at startup via the Skills API, extracts them to disk, and builds a `SkillsProvider` / `AgentSkillsProvider` over the extracted files. The SDK then synthesizes `load_skill` for the model.
+
+### Env vars
+
+| Variable | Purpose |
+|----------|---------|
+| `FOUNDRY_PROJECT_ENDPOINT` | Project endpoint for SDK calls |
+| `AZURE_AI_MODEL_DEPLOYMENT_NAME` | Model deployment for the agent |
+| `SKILL_NAMES` | Comma-separated skill names to download |
+
+### Python
+
+The sample downloads each skill via `project.beta.skills.download()`, extracts the ZIP (with zip-slip guard), and attaches a `SkillsProvider` to the agent as a `context_providers` entry.
+
+**Key classes:** `SkillsProvider.from_paths()`, `AIProjectClient` (with `allow_preview=True`).
+
+Full working sample: [12-foundry-skills (Python)](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/agent-framework/responses/12-foundry-skills)
+
+### C#
+
+The sample uses `AgentAdministrationClient` (with `FoundryFeaturesPolicy` for the `Skills=V1Preview` header) to download skills via `ProjectAgentSkills.DownloadSkillAsync()`, extracts ZIPs, and attaches an `AgentSkillsProvider` via `AIContextProviders`.
+
+**Key classes:** `AgentSkillsProvider`, `ProjectAgentSkills`, `AgentAdministrationClient`.
+
+Full working sample: [agent-skills (C#)](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/csharp/hosted-agents/agent-framework/agent-skills)
+
+---
+
+## Approach 2: Via Toolbox MCP
+
+Skills attached to a toolbox are discovered dynamically at runtime through the MCP endpoint. The agent connects to the toolbox, and the SDK reads `resources/list` to discover skills, then wraps them into the `load_skill` progressive disclosure pattern.
+
+**Under the hood:** The toolbox MCP endpoint exposes skills via `resources/list` and `resources/read` with `skill://` URIs (standard MCP resources protocol). See [skill-toolbox.md § How skills appear at runtime](skill-toolbox.md) for raw MCP protocol details.
+
+### Env vars
+
+| Variable | Purpose |
+|----------|---------|
+| `FOUNDRY_PROJECT_ENDPOINT` | Project endpoint for SDK calls |
+| `AZURE_AI_MODEL_DEPLOYMENT_NAME` | Model deployment for the agent |
+| `TOOLBOX_ENDPOINT` | Full toolbox MCP endpoint URL (Python preferred) |
+| `TOOLBOX_NAME` | Toolbox name — SDK constructs endpoint from project endpoint (C# preferred) |
+
+### C#
+
+The sample creates an `McpClient` using `HttpClientTransport` with `StreamableHttp` mode, then builds a skills provider via `AgentSkillsProviderBuilder().UseMcpSkills(mcpClient).Build()`. The framework handles the advertise → load → read lifecycle automatically.
+
+**Key classes:** `AgentSkillsProviderBuilder`, `McpClient`, `BearerTokenHandler` (custom `HttpClientHandler` for token injection).
+
+Full working sample: [foundry-toolbox-mcp-skills (C#)](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/csharp/hosted-agents/agent-framework/foundry-toolbox-mcp-skills)
+
+---
+
+## Deployment
+
+### Provision skills before deploy
+
+Skills must exist in the **same project** the deployed agent connects to:
+
+```bash
+azd ai skill create support-style --file ./skills/support-style/ --force
+azd ai skill create escalation-policy --file ./skills/escalation-policy/ --force
+```
+
+### Wire env vars
+
+```bash
+# Direct download approach
+azd env set SKILL_NAMES "support-style,escalation-policy"
+
+# OR toolbox approach (skills already attached to toolbox)
+azd env set TOOLBOX_NAME "agent-tools"
+```
+
+Add to `<service-dir>/agent.yaml`:
+
+```yaml
+environment_variables:
+  - name: SKILL_NAMES
+    value: ${SKILL_NAMES}
+```
+
+Then `azd deploy`.
+
+### RBAC
+
+The deployed agent's managed identity needs **Foundry User** on the project:
+
+```bash
+az role assignment create \
+  --assignee <managed-identity-object-id> \
+  --role "Foundry User" \
+  --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<account>/projects/<project>
+```
+
+## Verify end-to-end
+
+```bash
+azd ai agent run
+azd ai agent invoke --local "Hi, can I return my tent within 30 days?"
+```
+
+## Samples
+
+| Language | Approach | Sample |
+|----------|----------|--------|
+| Python | Direct download | [12-foundry-skills](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/agent-framework/responses/12-foundry-skills) |
+| Python | Via Toolbox | [04-foundry-toolbox](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/agent-framework/responses/04-foundry-toolbox) |
+| C# | Direct download | [agent-skills](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/csharp/hosted-agents/agent-framework/agent-skills) |
+| C# | Via Toolbox MCP | [foundry-toolbox-mcp-skills](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/csharp/hosted-agents/agent-framework/foundry-toolbox-mcp-skills) |
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|------------|-----|
+| `SKILL.md not found` after download | ZIP doesn't contain `SKILL.md` at root | Ensure skill was created from directory with `SKILL.md` at root |
+| `403` on `beta.skills.download` | Identity missing RBAC | Grant **Foundry User** on the project scope |
+| Agent ignores skills | Skill descriptions don't match user queries | Improve `description` in SKILL.md front matter |
+| Skills load but agent doesn't follow them | Instructions vague or conflicting with system prompt | Refine skill body; test with canary tokens |
+| `asyncio.TimeoutError` (Python) | Slow network or large skill packages | Increase timeout (default 60s) |
+| `allow_preview` error (Python) | SDK client missing preview flag | `AIProjectClient(allow_preview=True)` |
+| HTTP 500 on skill download (C#) | Missing `Foundry-Features: Skills=V1Preview` header | Register `FoundryFeaturesPolicy` on the client |
+| `SKILL_NAMES` not set in deployed agent | Env var missing from `agent.yaml` | Add to `environment_variables[]`, then `azd deploy` |
+| MCP client timeout (Toolbox) | Auth token expired or wrong scope | Use `https://ai.azure.com/.default` scope |
+| Skills not discovered from toolbox | Toolbox version without skills is the default | Run `azd ai toolbox publish <toolbox> <version>` |
+| `Invalid skill name 'xxx:download'` (Python) | SDK `v2.1.0` uses `:download` action syntax not supported by all server versions | Use `agent-framework-foundry` package (wraps the download correctly), or pin `azure-ai-projects>=2.1.0-beta.2` which matches the sample |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-skills-in-hosted-agent.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-skills-in-hosted-agent.md
@@ -11,29 +11,23 @@ How to consume Foundry **skills** (reusable behavioral guidelines) from hosted a
 
 ## How progressive disclosure works
 
-The Agent Framework SDK provides **progressive disclosure** so the model only loads skill content when needed:
-
-1. **Advertise** — At agent startup, skill names and descriptions (~100 tokens each) are injected into the system prompt. The model sees *what skills exist* and *when to use them*.
-2. **Load on demand** — The SDK synthesizes a `load_skill` tool. When the model determines a skill is relevant, it calls `load_skill(skill_name)` to retrieve the full `SKILL.md` body.
-3. **Follow** — The model incorporates the loaded skill instructions into its behavior for the remainder of the conversation turn.
-
-This keeps context usage low — only skills relevant to the current query consume tokens.
+The Agent Framework SDK injects skill names/descriptions into the system prompt (~100 tokens each) and synthesizes a `load_skill` tool. When the model determines a skill is relevant, it calls `load_skill(name)` to retrieve the full body on demand — keeping context usage low.
 
 ## Choosing an approach
 
 | | Direct Download | Via Toolbox MCP |
 |--|---|---|
-| How it works | Agent downloads skill ZIPs at startup, extracts to disk, builds provider from local files | Agent connects to toolbox MCP endpoint; SDK reads `resources/list` and wraps into `load_skill` |
-| Provider | `SkillsProvider.from_paths()` (Python) / `AgentSkillsProvider(dir)` (C#) | `MCPStreamableHTTPTool` (Python) / `AgentSkillsProviderBuilder().UseMcpSkills(mcpClient).Build()` (C#) |
-| When skills update | Redeploy agent to pick up new versions | Consumer endpoint picks up new default version automatically (no redeploy) |
-| Feature header | `Foundry-Features: Skills=V1Preview` | `Foundry-Features: Toolboxes=V1Preview` |
-| When to use | Need explicit version control at startup, no toolbox in the project | Agents already consuming a toolbox; want dynamic skill updates without redeployment |
+| How | Downloads ZIPs at startup, builds provider from local files | Connects to toolbox MCP; SDK reads `resources/list` → `load_skill` |
+| Provider | `SkillsProvider.from_paths()` / `AgentSkillsProvider(dir)` | `MCPStreamableHTTPTool` / `AgentSkillsProviderBuilder.UseMcpSkills()` |
+| Skill updates | Redeploy agent | Consumer endpoint picks up new version automatically |
+| Header | `Foundry-Features: Skills=V1Preview` | `Foundry-Features: Toolboxes=V1Preview` |
+| When to use | No toolbox; need explicit version control | Already have a toolbox; want dynamic updates |
 
 ---
 
 ## Approach 1: Direct Download
 
-The agent downloads skill ZIPs at startup via the Skills API, extracts them to disk, and builds a `SkillsProvider` / `AgentSkillsProvider` over the extracted files. The SDK then synthesizes `load_skill` for the model.
+Downloads skill ZIPs at startup, extracts to disk, builds provider. The SDK synthesizes `load_skill` for the model.
 
 ### Env vars
 
@@ -63,9 +57,7 @@ Full working sample: [agent-skills (C#)](https://github.com/microsoft-foundry/fo
 
 ## Approach 2: Via Toolbox MCP
 
-Skills attached to a toolbox are discovered dynamically at runtime through the MCP endpoint. The agent connects to the toolbox, and the SDK reads `resources/list` to discover skills, then wraps them into the `load_skill` progressive disclosure pattern.
-
-**Under the hood:** The toolbox MCP endpoint exposes skills via `resources/list` and `resources/read` with `skill://` URIs (standard MCP resources protocol). See [skill-toolbox.md § How skills appear at runtime](skill-toolbox.md) for raw MCP protocol details.
+Skills attached to a toolbox are discovered dynamically via `resources/list` and wrapped into `load_skill`. See [skill-toolbox.md](skill-toolbox.md) for MCP protocol details.
 
 ### Env vars
 
@@ -74,13 +66,13 @@ Skills attached to a toolbox are discovered dynamically at runtime through the M
 | `FOUNDRY_PROJECT_ENDPOINT` | Project endpoint for SDK calls |
 | `AZURE_AI_MODEL_DEPLOYMENT_NAME` | Model deployment for the agent |
 | `TOOLBOX_ENDPOINT` | Full toolbox MCP endpoint URL (Python preferred) |
-| `TOOLBOX_NAME` | Toolbox name — SDK constructs endpoint from project endpoint (C# preferred) |
+| `TOOLBOX_NAME` | Toolbox name — SDK constructs endpoint (C# preferred) |
 
 ### C#
 
-The sample creates an `McpClient` using `HttpClientTransport` with `StreamableHttp` mode, then builds a skills provider via `AgentSkillsProviderBuilder().UseMcpSkills(mcpClient).Build()`. The framework handles the advertise → load → read lifecycle automatically.
+The sample creates an `McpClient` pointing at the toolbox endpoint, then builds a skills provider via `AgentSkillsProviderBuilder().UseMcpSkills(mcpClient).Build()`. The framework handles the advertise → load → read lifecycle automatically.
 
-**Key classes:** `AgentSkillsProviderBuilder`, `McpClient`, `BearerTokenHandler` (custom `HttpClientHandler` for token injection).
+**Key classes:** `AgentSkillsProviderBuilder`, `McpClient`, `BearerTokenHandler`.
 
 Full working sample: [foundry-toolbox-mcp-skills (C#)](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/csharp/hosted-agents/agent-framework/foundry-toolbox-mcp-skills)
 
@@ -88,7 +80,7 @@ Full working sample: [foundry-toolbox-mcp-skills (C#)](https://github.com/micros
 
 ## Deployment
 
-### Provision skills before deploy
+### Provision skills
 
 Skills must exist in the **same project** the deployed agent connects to:
 
@@ -97,22 +89,46 @@ azd ai skill create support-style --file ./skills/support-style/ --force
 azd ai skill create escalation-policy --file ./skills/escalation-policy/ --force
 ```
 
-### Wire env vars
+### Direct download approach
 
 ```bash
-# Direct download approach
 azd env set SKILL_NAMES "support-style,escalation-policy"
-
-# OR toolbox approach (skills already attached to toolbox)
-azd env set TOOLBOX_NAME "agent-tools"
 ```
 
-Add to `<service-dir>/agent.yaml`:
+`agent.yaml`:
 
 ```yaml
 environment_variables:
   - name: SKILL_NAMES
     value: ${SKILL_NAMES}
+```
+
+### Toolbox approach
+
+```bash
+# Create toolbox with skills attached
+cat > tools.yaml <<'EOF'
+description: Agent toolbox with skills and tools
+skills:
+  - name: support-style
+  - name: escalation-policy
+tools:
+  - type: web_search
+    name: web
+EOF
+azd ai toolbox create agent-tools --from-file tools.yaml
+
+# Wire endpoint env var
+ENDPOINT=$(azd ai toolbox show agent-tools -o json | jq -r .endpoint)
+azd env set TOOLBOX_ENDPOINT "$ENDPOINT"
+```
+
+`agent.yaml`:
+
+```yaml
+environment_variables:
+  - name: TOOLBOX_ENDPOINT
+    value: ${TOOLBOX_ENDPOINT}
 ```
 
 Then `azd deploy`.
@@ -148,14 +164,14 @@ azd ai agent invoke --local "Hi, can I return my tent within 30 days?"
 
 | Symptom | Likely cause | Fix |
 |---------|------------|-----|
-| `SKILL.md not found` after download | ZIP doesn't contain `SKILL.md` at root | Ensure skill was created from directory with `SKILL.md` at root |
-| `403` on `beta.skills.download` | Identity missing RBAC | Grant **Foundry User** on the project scope |
-| Agent ignores skills | Skill descriptions don't match user queries | Improve `description` in SKILL.md front matter |
-| Skills load but agent doesn't follow them | Instructions vague or conflicting with system prompt | Refine skill body; test with canary tokens |
-| `asyncio.TimeoutError` (Python) | Slow network or large skill packages | Increase timeout (default 60s) |
+| `SKILL.md not found` after download | ZIP doesn't contain `SKILL.md` at root | Create skill from directory with `SKILL.md` at root |
+| `403` on skill download | Identity missing RBAC | Grant **Foundry User** on project scope |
+| Agent ignores skills | Descriptions don't match user queries | Improve `description` in SKILL.md front matter |
+| Skills load but agent doesn't follow | Instructions vague or conflicting | Refine skill body; add canary token to verify loading |
+| `asyncio.TimeoutError` (Python) | Slow network or large packages | Increase bootstrap timeout (default 60s) |
 | `allow_preview` error (Python) | SDK client missing preview flag | `AIProjectClient(allow_preview=True)` |
-| HTTP 500 on skill download (C#) | Missing `Foundry-Features: Skills=V1Preview` header | Register `FoundryFeaturesPolicy` on the client |
-| `SKILL_NAMES` not set in deployed agent | Env var missing from `agent.yaml` | Add to `environment_variables[]`, then `azd deploy` |
-| MCP client timeout (Toolbox) | Auth token expired or wrong scope | Use `https://ai.azure.com/.default` scope |
-| Skills not discovered from toolbox | Toolbox version without skills is the default | Run `azd ai toolbox publish <toolbox> <version>` |
-| `Invalid skill name 'xxx:download'` (Python) | SDK `v2.1.0` uses `:download` action syntax not supported by all server versions | Use `agent-framework-foundry` package (wraps the download correctly), or pin `azure-ai-projects>=2.1.0-beta.2` which matches the sample |
+| HTTP 500 on skill download (C#) | Missing feature header | Add `FoundryFeaturesPolicy` for `Skills=V1Preview` |
+| `SKILL_NAMES` not in deployed agent | Env var missing from `agent.yaml` | Add to `environment_variables[]`, redeploy |
+| MCP timeout (Toolbox) | Auth token expired or wrong scope | Use `https://ai.azure.com/.default`; refresh per request |
+| Skills not discovered from toolbox | New version not published | `azd ai toolbox publish <toolbox> <version>` |
+| `Invalid skill name 'xxx:download'` | SDK bug in beta.2 | Use CLI or `agent-framework-foundry` wrapper |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-toolbox-in-hosted-agent.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-toolbox-in-hosted-agent.md
@@ -72,6 +72,7 @@ The full set is documented in [agent-tools.md](agent-tools.md) and — authorita
 **Adjacent (not a `type` in a toolbox version):**
 
 - **Agent Memory** — use the `MemorySearchTool` SDK class on prompt agents; for hosted agents, configure the memory store via the project (separate from the toolbox). See [tool-memory.md](tool-memory.md).
+- **Skills** — reusable behavioral guidelines (`SKILL.md`) attached via the `skills[]` array, exposed as MCP resources (`skill://` URIs); the Agent Framework SDK wraps these into a `load_skill` tool for progressive disclosure. See [skill-toolbox.md](skill-toolbox.md).
 - **Routines (preview)** — not a tool; an agent **trigger** (`schedule` / `timer` / `github_issue` / `custom`) that invokes an existing agent. See the [public Routines docs](https://learn.microsoft.com/azure/foundry/agents/how-to/use-routines).
 
 ## Information to Gather Before Building a Toolbox Payload


### PR DESCRIPTION
## Description

This pull request introduces comprehensive documentation for managing, attaching, and consuming "skills" (reusable behavioral guidelines) in Microsoft Foundry agent projects. It adds three new reference guides covering skill management via CLI and SDK, skill integration with toolboxes, and best practices for using skills in hosted agents. Additionally, it updates the toolbox reference to clarify the role of skills. These docs are designed to help developers author, version, and deploy skills effectively, and to clarify the runtime behavior and troubleshooting steps for both direct and toolbox-based skill consumption.

**New documentation and guidance:**

*Skill management and authoring:*
- Added `skill-management.md`, a detailed guide on creating, updating, versioning, and troubleshooting skills using `azd ai skill` CLI commands and the Python SDK. Includes best practices for YAML front matter, RBAC requirements, and versioning semantics.

*Skill integration with toolboxes:*
- Added `skill-toolbox.md`, documenting how to attach, list, and remove skills from toolboxes using `azd ai toolbox skill` commands, the manifest format for including skills, and the MCP protocol for skill discovery and retrieval at runtime.
- Updated `use-toolbox-in-hosted-agent.md` to clarify that skills are not a tool `type` but are attached via the `skills[]` array and exposed as MCP resources, with SDK support for progressive disclosure (`load_skill`).

*Consuming skills in hosted agents:*
- Added `use-skills-in-hosted-agent.md`, providing a comparison of direct download vs. toolbox-based skill consumption, environment setup, deployment steps, code samples for Python and C#, and extensive troubleshooting guidance for both approaches.
## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
