### PR TITLE
fix: fix mvc sample

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -810,7 +810,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       await withTestResult(async ({ expectScreenshot }) => {
         expectScreenshot();
         const ASPNETCORE_DOCS_REPO = "https://github.com/dotnet/AspNetCore.Docs.git";
-        const MVCMOVIE90_SPARSE_PATH = "aspnetcore/tutorials/first-mvc-app/start-mvc/sample/MvcMovie90";
+        const MVCMOVIE90_SPARSE_PATH = "aspnetcore/tutorials/first-mvc-app/start-mvc/sample/9.0-completed";
 
         const agentMetadata = await agent.run({
           setup: async (workspace: string) => {


### PR DESCRIPTION
## Description

This MvcMovie90 test has been consistently failing for a long time. Test runs all run into the same 500 error when trying to access the Home controller of the app, even though the app service's /health controller returns 200. The app insights traces indicate there is a runtime exception about "Index" view not found. In a few test runs, the agent was able to modify the code to get the Home view return 200, aligning with the finding of the app insights trace.

I looked into the code and I suspect the app we let the agent to deploy has the bug that caused this. The parent readme has a vague sentence saying that "The completed sample is in the <.NET version>-completed folder. The MvcMovie<.NET version> sample is used for documentation and is difficult to use". I decided to point the test to use the app in the 9.0-completed folder instead.

https://github.com/dotnet/AspNetCore.Docs/tree/main/aspnetcore/tutorials/first-mvc-app/start-mvc/sample

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->