### PR TITLE
eval: azure-quotas grader bash tool pattern

### DIFF
--- a/evals/azure-quotas/eval.yaml
+++ b/evals/azure-quotas/eval.yaml
@@ -108,7 +108,7 @@ stimuli:
       - type: tool-calls
         config:
           required:
-            - name: "(?i)bash|powershell|pwsh"
+            - name: "(?i)(^bash|powershell|pwsh)"
               command: "(?i)check-quota\\.(ps1|sh)"
       - type: completed
       - type: output-not-matches
@@ -161,7 +161,7 @@ stimuli:
           required:
             # Copilot CLI uses "powershell" tool for executing scripts on Windows
             # Copilot CLI uses "bash" tool for executing scripts on other platforms
-            - name: "(?i)bash|powershell|pwsh"
+            - name: "(?i)(^bash|powershell|pwsh)"
               command: "(?i)check-quota\\.(sh|ps1)"
       - type: completed
       - type: output-not-matches
@@ -189,7 +189,7 @@ stimuli:
           required:
             # Copilot CLI uses "powershell" tool for executing scripts on Windows
             # Copilot CLI uses "bash" tool for executing scripts on other platforms
-            - name: "(?i)bash|powershell|pwsh"
+            - name: "(?i)(^bash|powershell|pwsh)"
               command: "(?i)check-quota\\.(sh|ps1)"
       - type: completed
       - type: output-not-matches

--- a/evals/azure-quotas/eval.yaml
+++ b/evals/azure-quotas/eval.yaml
@@ -108,7 +108,7 @@ stimuli:
       - type: tool-calls
         config:
           required:
-            - name: "(?i)(^bash|powershell|pwsh)"
+            - name: "(?i)^(bash|powershell|pwsh)$"
               command: "(?i)check-quota\\.(ps1|sh)"
       - type: completed
       - type: output-not-matches
@@ -161,7 +161,7 @@ stimuli:
           required:
             # Copilot CLI uses "powershell" tool for executing scripts on Windows
             # Copilot CLI uses "bash" tool for executing scripts on other platforms
-            - name: "(?i)(^bash|powershell|pwsh)"
+            - name: "(?i)^(bash|powershell|pwsh)$"
               command: "(?i)check-quota\\.(sh|ps1)"
       - type: completed
       - type: output-not-matches
@@ -189,7 +189,7 @@ stimuli:
           required:
             # Copilot CLI uses "powershell" tool for executing scripts on Windows
             # Copilot CLI uses "bash" tool for executing scripts on other platforms
-            - name: "(?i)(^bash|powershell|pwsh)"
+            - name: "(?i)^(bash|powershell|pwsh)$"
               command: "(?i)check-quota\\.(sh|ps1)"
       - type: completed
       - type: output-not-matches


### PR DESCRIPTION
## Description

Fix the azure-quotas eval grader bash tool pattern to correct matching behavior. read_bash tool also matches the pattern and since they don't have "command" argument, vally produces grader failures.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->