### PR TITLE
doc: document dashboard's container query parameter

### DIFF
--- a/dashboard/Readme.md
+++ b/dashboard/Readme.md
@@ -128,3 +128,7 @@ npm run dashboard:collect
 ```
 
 The collected data will be saved at `data/latest.json` file. To deploy it to the website, move this file into `dashboard/public/data/latest.json` and redeploy the app. The web app will pick up the data and use it to render the dashboard.
+
+## Custom container
+
+When reading the integration test results, a `container=<container-name>` can be added to read data from a custom blob container in the configured storage account. Manual runs of the CI integration test workflow writes test results to a blob container named `manual-integration-reports`. They can be easily accessed by adding `container=manual-integration-reports` to the dashboard website's url. This can also be handy for skill authors to temporarily store ad-hoc test run results and share with other people.

--- a/dashboard/Readme.md
+++ b/dashboard/Readme.md
@@ -129,6 +129,6 @@ npm run dashboard:collect
 
 The collected data will be saved at `data/latest.json` file. To deploy it to the website, move this file into `dashboard/public/data/latest.json` and redeploy the app. The web app will pick up the data and use it to render the dashboard.
 
-## Custom container
+## Custom Container
 
-When reading the integration test results, a `container=<container-name>` can be added to read data from a custom blob container in the configured storage account. Manual runs of the CI integration test workflow writes test results to a blob container named `manual-integration-reports`. They can be easily accessed by adding `container=manual-integration-reports` to the dashboard website's url. This can also be handy for skill authors to temporarily store ad-hoc test run results and share with other people.
+When viewing integration test results in the dashboard, you can read data from a custom blob container in the configured storage account by adding the `container` query parameter (for example, `?container=<container-name>`). Manual runs of the CI integration test workflow write test results to the `manual-integration-reports` container; to view them, open the dashboard with `?container=manual-integration-reports` (or `&container=manual-integration-reports` if the page already has query parameters).


### PR DESCRIPTION
## Description

Document the existence of the `container` query parameter in the dashboard app and how to use it.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
