### PR TITLE
eval: remove top-level skills environment from eval suites

### DIFF
--- a/evals/airunway-aks-setup/eval.yaml
+++ b/evals/airunway-aks-setup/eval.yaml
@@ -21,10 +21,6 @@ tags:
   type: integration
   skill: airunway-aks-setup
 
-environment:
-  skills:
-    - ../../plugin/skills/airunway-aks-setup
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/appinsights-instrumentation/eval.yaml
+++ b/evals/appinsights-instrumentation/eval.yaml
@@ -17,10 +17,6 @@ tags:
   type: integration
   skill: appinsights-instrumentation
 
-environment:
-  skills:
-    - ../../plugin/skills/appinsights-instrumentation
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-ai/eval.yaml
+++ b/evals/azure-ai/eval.yaml
@@ -15,10 +15,6 @@ tags:
   type: integration
   skill: azure-ai
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-ai
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-aigateway/eval.yaml
+++ b/evals/azure-aigateway/eval.yaml
@@ -16,10 +16,6 @@ tags:
   type: integration
   skill: azure-aigateway
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-aigateway
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-compliance/eval.yaml
+++ b/evals/azure-compliance/eval.yaml
@@ -16,10 +16,6 @@ tags:
   type: integration
   skill: azure-compliance
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-compliance
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-compute/eval.yaml
+++ b/evals/azure-compute/eval.yaml
@@ -49,10 +49,6 @@ tags:
   type: integration
   skill: azure-compute
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-compute
-
 config:
   runs: 3
   timeout: "10m"

--- a/evals/azure-cost/eval.yaml
+++ b/evals/azure-cost/eval.yaml
@@ -22,10 +22,6 @@ tags:
   type: integration
   skill: azure-cost
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-cost
-
 config:
   runs: 3
   timeout: "10m"

--- a/evals/azure-deploy/eval.yaml
+++ b/evals/azure-deploy/eval.yaml
@@ -17,10 +17,6 @@ tags:
   type: integration
   skill: azure-deploy
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-deploy
-
 config:
   runs: 3
   timeout: "7m"

--- a/evals/azure-diagnostics/eval.yaml
+++ b/evals/azure-diagnostics/eval.yaml
@@ -16,10 +16,6 @@ tags:
   type: integration
   skill: azure-diagnostics
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-diagnostics
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-enterprise-infra-planner/eval.yaml
+++ b/evals/azure-enterprise-infra-planner/eval.yaml
@@ -21,10 +21,6 @@ tags:
   type: integration
   skill: azure-enterprise-infra-planner
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-enterprise-infra-planner
-
 config:
   runs: 1
   timeout: "10m"

--- a/evals/azure-hosted-copilot-sdk/eval.yaml
+++ b/evals/azure-hosted-copilot-sdk/eval.yaml
@@ -16,13 +16,6 @@ tags:
   type: integration
   skill: azure-hosted-copilot-sdk
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-hosted-copilot-sdk
-    - ../../plugin/skills/azure-prepare
-    - ../../plugin/skills/azure-validate
-    - ../../plugin/skills/azure-deploy
-
 config:
   runs: 1
   timeout: "10m"

--- a/evals/azure-kubernetes/eval.yaml
+++ b/evals/azure-kubernetes/eval.yaml
@@ -12,10 +12,6 @@ tags:
   type: integration
   skill: azure-kubernetes
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-kubernetes
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-kusto/eval.yaml
+++ b/evals/azure-kusto/eval.yaml
@@ -15,10 +15,6 @@ tags:
   type: integration
   skill: azure-kusto
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-kusto
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-messaging/eval.yaml
+++ b/evals/azure-messaging/eval.yaml
@@ -15,10 +15,6 @@ tags:
   type: integration
   skill: azure-messaging
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-messaging
-
 config:
   runs: 3
   timeout: "10m"

--- a/evals/azure-prepare/eval.yaml
+++ b/evals/azure-prepare/eval.yaml
@@ -26,10 +26,6 @@ tags:
   type: integration
   skill: azure-prepare
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-prepare
-
 config:
   runs: 3
   timeout: "10m"

--- a/evals/azure-quotas/eval.yaml
+++ b/evals/azure-quotas/eval.yaml
@@ -22,10 +22,6 @@ tags:
   type: integration
   skill: azure-quotas
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-quotas
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-rbac/eval.yaml
+++ b/evals/azure-rbac/eval.yaml
@@ -15,10 +15,6 @@ tags:
   type: integration
   skill: azure-rbac
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-rbac
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-reliability/eval.yaml
+++ b/evals/azure-reliability/eval.yaml
@@ -27,10 +27,6 @@ tags:
   type: integration
   skill: azure-reliability
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-reliability
-
 config:
   runs: 1
   timeout: "60m"

--- a/evals/azure-resource-lookup/eval.yaml
+++ b/evals/azure-resource-lookup/eval.yaml
@@ -24,10 +24,6 @@ tags:
   type: integration
   skill: azure-resource-lookup
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-resource-lookup
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-resource-visualizer/eval.yaml
+++ b/evals/azure-resource-visualizer/eval.yaml
@@ -16,10 +16,6 @@ tags:
   type: integration
   skill: azure-resource-visualizer
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-resource-visualizer
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-storage/eval.yaml
+++ b/evals/azure-storage/eval.yaml
@@ -15,10 +15,6 @@ tags:
   type: integration
   skill: azure-storage
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-storage
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/azure-upgrade/eval.yaml
+++ b/evals/azure-upgrade/eval.yaml
@@ -24,10 +24,6 @@ tags:
   type: integration
   skill: azure-upgrade
 
-environment:
-  skills:
-    - ../../plugin/skills/azure-upgrade
-
 config:
   runs: 1
   timeout: "20m"

--- a/evals/entra-agent-id/eval.yaml
+++ b/evals/entra-agent-id/eval.yaml
@@ -27,10 +27,6 @@ tags:
   type: integration
   skill: entra-agent-id
 
-environment:
-  skills:
-    - ../../plugin/skills/entra-agent-id
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/entra-app-registration/eval.yaml
+++ b/evals/entra-app-registration/eval.yaml
@@ -15,10 +15,6 @@ tags:
   type: integration
   skill: entra-app-registration
 
-environment:
-  skills:
-    - ../../plugin/skills/entra-app-registration
-
 config:
   runs: 5
   timeout: "10m"

--- a/evals/microsoft-foundry/eval.yaml
+++ b/evals/microsoft-foundry/eval.yaml
@@ -9,10 +9,6 @@ description: |
 tags:
   skill: microsoft-foundry
 
-environment:
-  skills:
-    - ../../plugin/skills/microsoft-foundry
-
 config:
   runs: 5
   timeout: "30m"

--- a/evals/python-appservice-deploy/eval.yaml
+++ b/evals/python-appservice-deploy/eval.yaml
@@ -28,14 +28,6 @@ tags:
   type: integration
   skill: python-appservice-deploy
 
-environment:
-  skills:
-    - ../../plugin/skills/python-appservice-deploy
-    # azure-prepare is loaded so the negative routing stimuli below can
-    # assert that prompts outside this skill's scope (Java, Container Apps,
-    # Functions, IaC) actually route to azure-prepare.
-    - ../../plugin/skills/azure-prepare
-
 config:
   runs: 3
   # 35m global timeout accommodates the Flask e2e stimulus, which runs a


### PR DESCRIPTION
## Description

Removes the top-level `environment.skills` blocks from all eval.yaml suites under `evals/`. These per-suite skill environment causes the pre-compiled skills to be copied to the test workspace. Viewing these files gives the agent the same instructions but doesn't count as loading the skill. There are false positive failures due to the agent choosing to directly read these files instead of loading the corresponding skill.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->