### PR TITLE
eval: disable session telemetry in test agent runner

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -879,7 +879,9 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
             tools: ["*"]
           }
         },
-        systemMessage: runConfig.systemPrompt
+        systemMessage: runConfig.systemPrompt,
+        // Disable session telemetry so usage of skills and tools by the test agent runner don't end up sending Copilot CLI telemetry.
+        enableSessionTelemetry: false
       });
       entry.session = session;
 
@@ -985,7 +987,9 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
               tools: ["*"]
             }
           },
-          onPermissionRequest: approveAll
+          onPermissionRequest: approveAll,
+          // Disable session telemetry so usage of skills and tools by the test agent runner don't end up sending Copilot CLI telemetry.
+          enableSessionTelemetry: false
         });
         await playwrightSession.sendAndWait({
           prompt: `Use playwright mcp tools to take a screenshot of the deployed app. Save the screenshot to this directory at this file location ${screenshotPath}`


### PR DESCRIPTION
## Description

Disable session telemetry in the test agent runner so that skills and tools exercised by the test agent don't emit Copilot CLI telemetry. Sets `enableSessionTelemetry: false` on the agent and Playwright sessions created in `tests/utils/agent-runner.ts`.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->