### PR TITLE
eval: fix tf container image pattern grader

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -680,7 +680,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /registry/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, tfPattern)).toBe(true);
         // Phase 1: Image variable defaults to empty so placeholder is used during provisioning
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /container_image|image_name/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /image\s*=/i, tfPattern)).toBe(true);
         // AcrPull role assignment ensures managed identity can pull from ACR
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /AcrPull/i, tfPattern)).toBe(true);
       });
@@ -722,7 +722,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /registry/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, tfPattern)).toBe(true);
         // Phase 1: Image variable defaults to empty so placeholder is used during provisioning
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /container_image|image_name/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /image\s*=/i, tfPattern)).toBe(true);
         // AcrPull role assignment ensures managed identity can pull from ACR
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /AcrPull/i, tfPattern)).toBe(true);
       });
@@ -764,7 +764,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /registry/i, tfPattern)).toBe(true);
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /identity.*system|system.*identity/i, tfPattern)).toBe(true);
         // Phase 1: Image variable defaults to empty so placeholder is used during provisioning
-        expect(doesWorkspaceFileIncludePattern(workspacePath!, /container_image|image_name/i, tfPattern)).toBe(true);
+        expect(doesWorkspaceFileIncludePattern(workspacePath!, /image\s*=/i, tfPattern)).toBe(true);
         // AcrPull role assignment ensures managed identity can pull from ACR
         expect(doesWorkspaceFileIncludePattern(workspacePath!, /AcrPull/i, tfPattern)).toBe(true);
       });


### PR DESCRIPTION
## Description

Fixes the Terraform container image pattern grader in the azure-deploy integration test suite. Corrects the matching logic so the grader properly validates container image patterns.

I don't know where the old pattern come from. The schema indicates the property name is `image`. I checked a few recent runs and they all generated tf IaC following the schema and failed this grader.
https://registry.terraform.io/providers/hashicorp/azurerm/4.78.0/docs/data-sources/container_app

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests

## Related Issues
