### PR TITLE
eval: Update MvcMovie integration test to .NET 10 sample

### DIFF
--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -806,11 +806,11 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       });
     }, brownfieldTestTimeoutMs);
 
-    test("deploys MvcMovie 90", async () => {
+    test("deploys MvcMovie 10", async () => {
       await withTestResult(async ({ expectScreenshot }) => {
         expectScreenshot();
         const ASPNETCORE_DOCS_REPO = "https://github.com/dotnet/AspNetCore.Docs.git";
-        const MVCMOVIE90_SPARSE_PATH = "aspnetcore/tutorials/first-mvc-app/start-mvc/sample/9.0-completed";
+        const MVCMOVIE90_SPARSE_PATH = "aspnetcore/tutorials/first-mvc-app/start-mvc/sample/10.0-completed";
 
         const agentMetadata = await agent.run({
           setup: async (workspace: string) => {

--- a/tests/azure-deploy/integration.test.ts
+++ b/tests/azure-deploy/integration.test.ts
@@ -810,7 +810,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       await withTestResult(async ({ expectScreenshot }) => {
         expectScreenshot();
         const ASPNETCORE_DOCS_REPO = "https://github.com/dotnet/AspNetCore.Docs.git";
-        const MVCMOVIE90_SPARSE_PATH = "aspnetcore/tutorials/first-mvc-app/start-mvc/sample/10.0-completed";
+        const MVCMOVIE10_SPARSE_PATH = "aspnetcore/tutorials/first-mvc-app/start-mvc/sample/10.0-completed";
 
         const agentMetadata = await agent.run({
           setup: async (workspace: string) => {
@@ -818,7 +818,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
               repoUrl: ASPNETCORE_DOCS_REPO,
               targetDir: workspace,
               depth: 1,
-              sparseCheckoutPath: MVCMOVIE90_SPARSE_PATH,
+              sparseCheckoutPath: MVCMOVIE10_SPARSE_PATH,
             });
           },
           prompt:
@@ -827,7 +827,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
             "Use my current subscription. " +
             "This is for a small scale production environment. " +
             "Use standard SKUs. " +
-            `The app can be found under ${MVCMOVIE90_SPARSE_PATH}.`,
+            `The app can be found under ${MVCMOVIE10_SPARSE_PATH}.`,
           systemPrompt: pseudoRandomResourceGroupNameSystemPromptModifier,
           nonInteractive: true,
           followUp: FOLLOW_UP_PROMPT,


### PR DESCRIPTION
## Description

Update the azure-deploy integration test to reference the 10.0-completed MvcMovie sample project instead of the 9.0-completed version, aligning with .NET 10.

The agent in nightly run tests encountered weird dependency conflicts in this deployed app. We noticed that the 9.0 sample app still uses years old preview version of the packages. Tom suggested us switching to use the 10.0 sample instead since it uses stable version dependencies.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->