### PR TITLE
eval: track turn count and support maxTurns abort in agent runner

### DIFF
--- a/tests/utils/__tests__/agent-runner.test.ts
+++ b/tests/utils/__tests__/agent-runner.test.ts
@@ -10,11 +10,11 @@ describe("agent-runner", () => {
     test("isComplete flag prevents event processing after completion", () => {
       // This test verifies the fix for the issue where console.log
       // continues to fire after the test completes/times out.
-      
+
       // Create a mock scenario
       let isComplete = false;
       const events: string[] = [];
-      
+
       const mockEventHandler = (eventType: string) => {
         // Stop processing events if already complete
         if (isComplete) {
@@ -22,50 +22,50 @@ describe("agent-runner", () => {
         }
         events.push(eventType);
       };
-      
+
       // Simulate normal event flow
       mockEventHandler("session.start");
       mockEventHandler("assistant.message");
       mockEventHandler("tool.execution_start");
-      
+
       // Simulate completion
       isComplete = true;
-      
+
       // These events should not be processed
       mockEventHandler("tool.execution_complete");
       mockEventHandler("assistant.message_delta");
-      
+
       // Verify only pre-completion events were recorded
       expect(events).toEqual([
         "session.start",
-        "assistant.message", 
+        "assistant.message",
         "tool.execution_start"
       ]);
       expect(events).not.toContain("tool.execution_complete");
       expect(events).not.toContain("assistant.message_delta");
     });
-    
+
     test("isComplete flag is set on session.idle", () => {
       let isComplete = false;
       const events: string[] = [];
-      
+
       const mockEventHandler = (eventType: string) => {
         if (isComplete) {
           return;
         }
         events.push(eventType);
-        
+
         // Simulate the fix: set isComplete when session.idle is received
         if (eventType === "session.idle") {
           isComplete = true;
         }
       };
-      
+
       mockEventHandler("session.start");
       mockEventHandler("assistant.message");
       mockEventHandler("session.idle");
       mockEventHandler("tool.execution_complete"); // Should not be processed
-      
+
       expect(events).toEqual([
         "session.start",
         "assistant.message",
@@ -73,153 +73,34 @@ describe("agent-runner", () => {
       ]);
       expect(isComplete).toBe(true);
     });
-    
+
     test("isComplete flag is set on early termination", () => {
       let isComplete = false;
       const events: string[] = [];
-      
+
       const mockEventHandler = (eventType: string, shouldTerminate: boolean = false) => {
         if (isComplete) {
           return;
         }
         events.push(eventType);
-        
+
         // Simulate the fix: set isComplete on early termination
         if (shouldTerminate) {
           isComplete = true;
         }
       };
-      
+
       mockEventHandler("session.start");
       mockEventHandler("assistant.message");
       mockEventHandler("tool.execution_start", true); // Early termination
       mockEventHandler("tool.execution_complete"); // Should not be processed
-      
+
       expect(events).toEqual([
         "session.start",
         "assistant.message",
         "tool.execution_start"
       ]);
       expect(isComplete).toBe(true);
-    });
-  });
-
-  describe("maxTurns enforcement", () => {
-    interface MockAgentMetadata {
-      events: Array<{ type: string }>;
-      testComments: string[];
-      turnCount: number;
-    }
-
-    function simulateEventLoop(
-      eventTypes: string[],
-      maxTurns: number | undefined
-    ): { metadata: MockAgentMetadata; isComplete: boolean; aborted: boolean; maxTurnsExceeded: boolean } {
-      let isComplete = false;
-      let aborted = false;
-      let maxTurnsExceeded = false;
-      const metadata: MockAgentMetadata = { events: [], testComments: [], turnCount: 0 };
-
-      for (const type of eventTypes) {
-        if (isComplete) break;
-
-        if (type === "session.idle") {
-          isComplete = true;
-          break;
-        }
-
-        metadata.events.push({ type });
-
-        if (type === "assistant.turn_start") {
-          metadata.turnCount++;
-          if (maxTurns !== undefined && metadata.turnCount > maxTurns) {
-            metadata.testComments.push(
-              `⚠️ Run aborted: turn count (${metadata.turnCount}) exceeded maxTurns (${maxTurns}).`
-            );
-            maxTurnsExceeded = true;
-            isComplete = true;
-            aborted = true;
-            break;
-          }
-        }
-      }
-
-      return { metadata, isComplete, aborted, maxTurnsExceeded };
-    }
-
-    test("turnCount increments on each assistant.turn_start event", () => {
-      const { metadata } = simulateEventLoop(
-        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start", "session.idle"],
-        undefined
-      );
-      expect(metadata.turnCount).toBe(3);
-    });
-
-    test("run completes normally when turn count does not exceed maxTurns", () => {
-      const { metadata, aborted, maxTurnsExceeded } = simulateEventLoop(
-        ["assistant.turn_start", "assistant.turn_start", "session.idle"],
-        5
-      );
-      expect(metadata.turnCount).toBe(2);
-      expect(aborted).toBe(false);
-      expect(maxTurnsExceeded).toBe(false);
-      expect(metadata.testComments).toHaveLength(0);
-    });
-
-    test("run is aborted when turn count exceeds maxTurns", () => {
-      const { metadata, isComplete, aborted, maxTurnsExceeded } = simulateEventLoop(
-        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start"],
-        2
-      );
-      expect(metadata.turnCount).toBe(3);
-      expect(aborted).toBe(true);
-      expect(maxTurnsExceeded).toBe(true);
-      expect(isComplete).toBe(true);
-    });
-
-    test("warning test comment is added when maxTurns is exceeded", () => {
-      const { metadata } = simulateEventLoop(
-        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start"],
-        2
-      );
-      expect(metadata.testComments).toHaveLength(1);
-      expect(metadata.testComments[0]).toContain("⚠️ Run aborted");
-      expect(metadata.testComments[0]).toContain("turn count (3)");
-      expect(metadata.testComments[0]).toContain("maxTurns (2)");
-    });
-
-    test("events after abort are not recorded", () => {
-      const { metadata } = simulateEventLoop(
-        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start", "assistant.message"],
-        2
-      );
-      // The abort fires on turn 3; the subsequent assistant.message should not be recorded
-      expect(metadata.events.map(e => e.type)).not.toContain("assistant.message");
-    });
-
-    test("no abort when maxTurns is undefined", () => {
-      const { aborted } = simulateEventLoop(
-        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start", "assistant.turn_start", "assistant.turn_start"],
-        undefined
-      );
-      expect(aborted).toBe(false);
-    });
-
-    test("maxTurnsExceeded flag prevents follow-up prompts", () => {
-      const followUps = ["follow-up 1", "follow-up 2"];
-      let maxTurnsExceeded = true; // simulates the flag being set
-
-      // Mirrors the actual follow-up guard: (maxTurnsExceeded ? [] : followUps)
-      const promptsToSend = maxTurnsExceeded ? [] : followUps;
-      expect(promptsToSend).toHaveLength(0);
-    });
-
-    test("follow-up prompts are sent when maxTurns is not exceeded", () => {
-      const followUps = ["follow-up 1", "follow-up 2"];
-      let maxTurnsExceeded = false;
-
-      const promptsToSend = maxTurnsExceeded ? [] : followUps;
-      expect(promptsToSend).toEqual(followUps);
     });
   });
 });

--- a/tests/utils/__tests__/agent-runner.test.ts
+++ b/tests/utils/__tests__/agent-runner.test.ts
@@ -103,4 +103,123 @@ describe("agent-runner", () => {
       expect(isComplete).toBe(true);
     });
   });
+
+  describe("maxTurns enforcement", () => {
+    interface MockAgentMetadata {
+      events: Array<{ type: string }>;
+      testComments: string[];
+      turnCount: number;
+    }
+
+    function simulateEventLoop(
+      eventTypes: string[],
+      maxTurns: number | undefined
+    ): { metadata: MockAgentMetadata; isComplete: boolean; aborted: boolean; maxTurnsExceeded: boolean } {
+      let isComplete = false;
+      let aborted = false;
+      let maxTurnsExceeded = false;
+      const metadata: MockAgentMetadata = { events: [], testComments: [], turnCount: 0 };
+
+      for (const type of eventTypes) {
+        if (isComplete) break;
+
+        if (type === "session.idle") {
+          isComplete = true;
+          break;
+        }
+
+        metadata.events.push({ type });
+
+        if (type === "assistant.turn_start") {
+          metadata.turnCount++;
+          if (maxTurns !== undefined && metadata.turnCount > maxTurns) {
+            metadata.testComments.push(
+              `⚠️ Run aborted: turn count (${metadata.turnCount}) exceeded maxTurns (${maxTurns}).`
+            );
+            maxTurnsExceeded = true;
+            isComplete = true;
+            aborted = true;
+            break;
+          }
+        }
+      }
+
+      return { metadata, isComplete, aborted, maxTurnsExceeded };
+    }
+
+    test("turnCount increments on each assistant.turn_start event", () => {
+      const { metadata } = simulateEventLoop(
+        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start", "session.idle"],
+        undefined
+      );
+      expect(metadata.turnCount).toBe(3);
+    });
+
+    test("run completes normally when turn count does not exceed maxTurns", () => {
+      const { metadata, aborted, maxTurnsExceeded } = simulateEventLoop(
+        ["assistant.turn_start", "assistant.turn_start", "session.idle"],
+        5
+      );
+      expect(metadata.turnCount).toBe(2);
+      expect(aborted).toBe(false);
+      expect(maxTurnsExceeded).toBe(false);
+      expect(metadata.testComments).toHaveLength(0);
+    });
+
+    test("run is aborted when turn count exceeds maxTurns", () => {
+      const { metadata, isComplete, aborted, maxTurnsExceeded } = simulateEventLoop(
+        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start"],
+        2
+      );
+      expect(metadata.turnCount).toBe(3);
+      expect(aborted).toBe(true);
+      expect(maxTurnsExceeded).toBe(true);
+      expect(isComplete).toBe(true);
+    });
+
+    test("warning test comment is added when maxTurns is exceeded", () => {
+      const { metadata } = simulateEventLoop(
+        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start"],
+        2
+      );
+      expect(metadata.testComments).toHaveLength(1);
+      expect(metadata.testComments[0]).toContain("⚠️ Run aborted");
+      expect(metadata.testComments[0]).toContain("turn count (3)");
+      expect(metadata.testComments[0]).toContain("maxTurns (2)");
+    });
+
+    test("events after abort are not recorded", () => {
+      const { metadata } = simulateEventLoop(
+        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start", "assistant.message"],
+        2
+      );
+      // The abort fires on turn 3; the subsequent assistant.message should not be recorded
+      expect(metadata.events.map(e => e.type)).not.toContain("assistant.message");
+    });
+
+    test("no abort when maxTurns is undefined", () => {
+      const { aborted } = simulateEventLoop(
+        ["assistant.turn_start", "assistant.turn_start", "assistant.turn_start", "assistant.turn_start", "assistant.turn_start"],
+        undefined
+      );
+      expect(aborted).toBe(false);
+    });
+
+    test("maxTurnsExceeded flag prevents follow-up prompts", () => {
+      const followUps = ["follow-up 1", "follow-up 2"];
+      let maxTurnsExceeded = true; // simulates the flag being set
+
+      // Mirrors the actual follow-up guard: (maxTurnsExceeded ? [] : followUps)
+      const promptsToSend = maxTurnsExceeded ? [] : followUps;
+      expect(promptsToSend).toHaveLength(0);
+    });
+
+    test("follow-up prompts are sent when maxTurns is not exceeded", () => {
+      const followUps = ["follow-up 1", "follow-up 2"];
+      let maxTurnsExceeded = false;
+
+      const promptsToSend = maxTurnsExceeded ? [] : followUps;
+      expect(promptsToSend).toEqual(followUps);
+    });
+  });
 });

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -812,6 +812,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
     const FOLLOW_UP_TIMEOUT = runConfig.followUpTimeout ?? 1800000; // 30 minutes by default
 
     let isComplete = false;
+    let isAborted = false;
 
     const entry: RunnerCleanup = { config: runConfig };
     currentCleanups.push(entry);
@@ -921,6 +922,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
                 `⚠️ Run aborted: turn count (${agentMetadata.turnCount}) exceeded maxTurns (${runConfig.maxTurns}).`
               );
               isComplete = true;
+              isAborted = true;
               resolve();
               void session.abort();
               return;
@@ -929,6 +931,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
 
           if (runConfig.shouldEarlyTerminate?.(agentMetadata)) {
             isComplete = true;
+            isAborted = true;
             resolve();
             void session.abort();
             return;
@@ -943,7 +946,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
       // counts include events emitted during follow-up turns.
       // Skip follow-ups when the run was aborted due to maxTurns being exceeded.
       for (const followUpPrompt of (runConfig.followUp ?? [])) {
-        if (isComplete) break;
+        if (isAborted) break;
         isComplete = false;
         await session.sendAndWait({ prompt: followUpPrompt }, FOLLOW_UP_TIMEOUT);
       }

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -944,7 +944,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
 
       // Send follow-up prompts before aggregating stats so tool/skill/token
       // counts include events emitted during follow-up turns.
-      // Skip follow-ups when the run was aborted due to maxTurns being exceeded.
+      // Skip follow-ups when the run was aborted.
       for (const followUpPrompt of (runConfig.followUp ?? [])) {
         if (isAborted) break;
         isComplete = false;

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -812,7 +812,6 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
     const FOLLOW_UP_TIMEOUT = runConfig.followUpTimeout ?? 1800000; // 30 minutes by default
 
     let isComplete = false;
-    let maxTurnsExceeded = false;
 
     const entry: RunnerCleanup = { config: runConfig };
     currentCleanups.push(entry);
@@ -921,7 +920,6 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
               agentMetadata.testComments.push(
                 `⚠️ Run aborted: turn count (${agentMetadata.turnCount}) exceeded maxTurns (${runConfig.maxTurns}).`
               );
-              maxTurnsExceeded = true;
               isComplete = true;
               resolve();
               void session.abort();
@@ -944,7 +942,8 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
       // Send follow-up prompts before aggregating stats so tool/skill/token
       // counts include events emitted during follow-up turns.
       // Skip follow-ups when the run was aborted due to maxTurns being exceeded.
-      for (const followUpPrompt of (maxTurnsExceeded ? [] : runConfig.followUp ?? [])) {
+      for (const followUpPrompt of (runConfig.followUp ?? [])) {
+        if (isComplete) break;
         isComplete = false;
         await session.sendAndWait({ prompt: followUpPrompt }, FOLLOW_UP_TIMEOUT);
       }

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -812,6 +812,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
     const FOLLOW_UP_TIMEOUT = runConfig.followUpTimeout ?? 1800000; // 30 minutes by default
 
     let isComplete = false;
+    let maxTurnsExceeded = false;
 
     const entry: RunnerCleanup = { config: runConfig };
     currentCleanups.push(entry);
@@ -920,6 +921,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
               agentMetadata.testComments.push(
                 `⚠️ Run aborted: turn count (${agentMetadata.turnCount}) exceeded maxTurns (${runConfig.maxTurns}).`
               );
+              maxTurnsExceeded = true;
               isComplete = true;
               resolve();
               void session.abort();
@@ -941,7 +943,8 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
 
       // Send follow-up prompts before aggregating stats so tool/skill/token
       // counts include events emitted during follow-up turns.
-      for (const followUpPrompt of runConfig.followUp ?? []) {
+      // Skip follow-ups when the run was aborted due to maxTurns being exceeded.
+      for (const followUpPrompt of (maxTurnsExceeded ? [] : runConfig.followUp ?? [])) {
         isComplete = false;
         await session.sendAndWait({ prompt: followUpPrompt }, FOLLOW_UP_TIMEOUT);
       }

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -82,6 +82,12 @@ export interface AgentMetadata {
   tokenUsage?: TokenUsage;
 
   /**
+   * Number of assistant turns that started during the run,
+   * counted from `assistant.turn_start` events.
+   */
+  turnCount: number;
+
+  /**
    * Map from tool name to the number of times that tool was invoked during the run.
    * Excludes the `skill` pseudo-tool; all other tools (including MCP tools) are included,
    * keyed by the raw `event.data.toolName`.
@@ -184,6 +190,13 @@ export interface AgentRunConfig {
    * If specified, only the skills in this array will be included. This option overrides the required skills specified in the {@link requiredSkills}.
    */
   includeSkills?: string[];
+
+  /**
+   * Maximum number of assistant turns allowed before the run is aborted.
+   * Each `assistant.turn_start` event counts as one turn.
+   * If undefined, there is no turn limit.
+   */
+  maxTurns?: number;
 
   /**
    * Number of milliseconds as timeout for follow ups.
@@ -805,7 +818,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
     entry.workspace = testWorkspace;
     entry.preserveWorkspace = runConfig.preserveWorkspace;
 
-    const agentMetadata: AgentMetadata = { events: [], testComments: [], toolCounts: {}, skillFiles: {} };
+    const agentMetadata: AgentMetadata = { events: [], testComments: [], turnCount: 0, toolCounts: {}, skillFiles: {} };
     entry.agentMetadata = agentMetadata;
 
     try {
@@ -900,6 +913,19 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
           }
 
           agentMetadata.events.push(event);
+
+          if (event.type === "assistant.turn_start") {
+            agentMetadata.turnCount++;
+            if (runConfig.maxTurns !== undefined && agentMetadata.turnCount > runConfig.maxTurns) {
+              agentMetadata.testComments.push(
+                `⚠️ Run aborted: turn count (${agentMetadata.turnCount}) exceeded maxTurns (${runConfig.maxTurns}).`
+              );
+              isComplete = true;
+              resolve();
+              void session.abort();
+              return;
+            }
+          }
 
           if (runConfig.shouldEarlyTerminate?.(agentMetadata)) {
             isComplete = true;

--- a/tests/vally/vally-executor.ts
+++ b/tests/vally/vally-executor.ts
@@ -44,6 +44,7 @@ export class IntegrationTestAgentRunner implements Executor {
       followUpTimeout: timeout,
       takeScreenshot: takeScreenshot,
       requiredSkills: requiredSkills,
+      maxTurns: stimulus.constraints?.max_turns,
       // Always make our agent runner preserve workspace.
       // vally will delete the test workspace by default.
       preserveWorkspace: true


### PR DESCRIPTION
## Summary

Add `turnCount` to `AgentMetadata` to track the number of assistant turns started (via `assistant.turn_start` events), and an optional `maxTurns` field to `AgentRunConfig`. When the turn count exceeds `maxTurns`, the session is aborted and a warning comment is appended to `agentMetadata.testComments` so the markdown report reflects the reason.

## Changes

- **`AgentMetadata.turnCount`** — new field initialized to `0`; incremented on each `assistant.turn_start` event.
- **`AgentRunConfig.maxTurns`** — optional field; when set, the run aborts once `turnCount > maxTurns`.
- Abort path pushes a ⚠️ test comment: `Run aborted: turn count (N) exceeded maxTurns (M).`