### PR TITLE
fix(microsoft-foundry): sync latest azd contract and schema

### DIFF
--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -180,7 +180,7 @@ Layer sources in this order:
 1. Explicit user input and values already selected in the session
 2. azd environment values for deployment context
 3. `.foundry/agent-metadata*.yaml` overlay values and remote suite/cache references
-4. `agent.yaml` and `eval.yaml` local source configuration
+4. `azure.yaml` and `eval.yaml` local source configuration
 5. User prompts for anything still missing
 
 If azd and metadata both provide the same value and they differ, stop and ask which source is authoritative. If they match, use the azd value and avoid rewriting the duplicate on future metadata writes.
@@ -188,7 +188,7 @@ If azd and metadata both provide the same value and they differ, stop and ask wh
 | Effective Value | Preferred Source | Used By |
 |-----------------|------------------|---------|
 | Project endpoint | azd env | deploy, invoke, observe, trace, troubleshoot |
-| Agent name/version | azd agent variables, then `agent.yaml` | invoke, observe, trace, troubleshoot |
+| Agent name/version | azd agent variables, then `azure.yaml` | invoke, observe, trace, troubleshoot |
 | ACR | azd env | deploy |
 | Evaluation suites and cache paths | `.foundry/agent-metadata*.yaml` | observe, eval-datasets |
 | Local seed dataset/evaluator intent | `eval.yaml` | observe, eval-datasets |

--- a/plugin/skills/microsoft-foundry/foundry-agent/agent-optimizer/agent-optimizer.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/agent-optimizer/agent-optimizer.md
@@ -17,7 +17,7 @@ DO NOT USE FOR: non-Python agents, prompt agents, running standalone batch evalu
 | Required runtime | azd project with hosted agent |
 | Required package | `azure-ai-agentserver-optimization` |
 | Required import | `from azure.ai.agentserver.optimization import load_config` |
-| Required baseline | `.agent_configs/baseline/` beside `agent.yaml` |
+| Required baseline | `.agent_configs/baseline/` in the agent's service source directory |
 | Supported targets | instruction, model, skill folder, function tool definitions |
 | azd setup | [azd Setup](references/azd-setup.md) |
 | Detailed scaffold steps | [Scaffold Workflow](references/scaffold.md) |

--- a/plugin/skills/microsoft-foundry/foundry-agent/agent-optimizer/references/azd-setup.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/agent-optimizer/references/azd-setup.md
@@ -26,10 +26,10 @@ Confirm:
 - agent kind is `hosted`
 - project endpoint/project ID and deployed agent name/version are known
 
-If `agent.yaml` is missing, ask before initializing:
+If the agent's `azure.yaml` service block is missing, ask before initializing:
 
 ```bash
 azd ai agent init --project-id <project-id>
 ```
 
-Use the project ID from azd context when available; otherwise ask the user. After init, stop for review of generated `agent.yaml`.
+Use the project ID from azd context when available; otherwise ask the user. After init, stop for review of the generated `azure.yaml` service block.

--- a/plugin/skills/microsoft-foundry/foundry-agent/agent-optimizer/references/python-patterns.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/agent-optimizer/references/python-patterns.md
@@ -18,11 +18,11 @@ from azure.ai.agentserver.optimization import load_config
 
 ## Baseline Folder
 
-Create `.agent_configs/baseline/` beside `agent.yaml`:
+Create `.agent_configs/baseline/` in the agent's service source directory (beside the entry point):
 
 ```text
 <agent-root>/
-  agent.yaml
+  main.py
   .agent_configs/
     baseline/
       metadata.yaml

--- a/plugin/skills/microsoft-foundry/foundry-agent/agent-optimizer/references/scaffold.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/agent-optimizer/references/scaffold.md
@@ -18,7 +18,7 @@ Use [Python Patterns](python-patterns.md#target-selection) to map evaluator/data
 
 ## Step 3: Scaffold Baseline Files
 
-Create the required `.agent_configs/baseline/` folder beside `agent.yaml`:
+Create the required `.agent_configs/baseline/` folder in the agent's service source directory (beside the entry point):
 
 ```text
 .agent_configs/
@@ -68,7 +68,7 @@ Map resolved values:
 - Skills -> `config.skills_dir` with `load_skills_from_dir(...)` only when the runtime has a safe skill/tool mechanism
 - Function tool definitions -> `config.apply_tool_descriptions(tools)` when tool metadata can be patched safely
 
-Do not add optimization runtime env vars to `agent.yaml`. The default local config path is `.agent_configs/`; use `load_config(config_dir="...")` only when the scaffold intentionally uses a non-default local config directory.
+Do not add optimization runtime env vars to the agent's `environmentVariables` in `azure.yaml`. The default local config path is `.agent_configs/`; use `load_config(config_dir="...")` only when the scaffold intentionally uses a non-default local config directory.
 
 ## Step 5: Verify and Stop
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -21,7 +21,7 @@ Scaffold a hosted Foundry agent project with the Azure Developer CLI (`azd`) and
 ## When to Use This Skill
 
 - Create a new hosted agent from a curated Foundry sample.
-- Lift an existing agent project (Python, .NET, Node.js) into a hosted Foundry agent.
+- Lift an existing agent project (Python, .NET) into a hosted Foundry agent.
 - Add tools (web search, AI Search, MCP, A2A) to a hosted agent.
 - Run and iterate on a hosted agent locally before deploying.
 
@@ -31,7 +31,7 @@ For prompt agents (LLM + instructions, no container), use [create-prompt.md](cre
 
 | | Hosted | Prompt |
 |--|--------|--------|
-| Custom Python / .NET / Node code? | Yes -> this skill | No -> [create-prompt.md](create-prompt.md) |
+| Custom Python / .NET code? | Yes -> this skill | No -> [create-prompt.md](create-prompt.md) |
 | Tools / RAG / MCP / A2A | Toolbox + connections | Built-in tool configs |
 | Local debugging | `azd ai agent run` | Limited |
 | Output | New immutable agent version per `azd deploy` | `agent_update` via MCP / SDK |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -12,7 +12,7 @@ Scaffold a hosted Foundry agent project with the Azure Developer CLI (`azd`) and
 |----------|-------|
 | Agent type | Hosted (container or code) |
 | Primary CLI | `azd ai agent` (from extension `azure.ai.agents`) |
-| Scaffold command | `azd ai agent init -m <manifestUrl> --deploy-mode code --runtime python_3_13 --entry-point main.py`, pass `--runtime dotnet_10 --entry-point MyAgent.dll` for .NET project (or `--from-code` for brownfield) |
+| Scaffold command | `azd ai agent init -m <manifestUrl> --deploy-mode code --runtime python_3_13 --entry-point main.py`, pass `--runtime dotnet_10 --entry-point MyAgent.dll` for .NET project (or `--src <dir>` for brownfield) |
 | Local run | `azd ai agent run` + `azd ai agent invoke --local "..."` |
 | Deploy handoff | [deploy/deploy.md](../deploy/deploy.md) |
 | Sample catalog | `azd ai agent sample list --featured-only --output json` |
@@ -55,7 +55,7 @@ Act on the summary prefixes:
 - `[WARN]` -- non-blocking; continue.
 - `[ACTION]` -- resolve first, then rerun the script. If `az` or `azd` is missing, ask before installing in interactive mode; install directly in non-interactive mode. For how to install `azd`, see <https://learn.microsoft.com/en-us/azure/developer/azure-developer-cli/install-azd>. In any mode, never run `az login` or `azd auth login`; stop and ask the user to log in manually. Missing `azure.ai.agents` / `azure.ai.projects` extensions may be resolved with `azd extension install <name>`. Failed `az` or `azd` auth checks must stop the workflow until the user logs in manually.
 
-> **Preflight: get `AZURE_SUBSCRIPTION_ID` + `AZURE_LOCATION` into the azd env *before* the first `azd ai agent init`.** Without both, init defers model resolution -> `azure.yaml services.<name>.config.deployments[]` ends up empty -> `AI_PROJECT_DEPLOYMENTS=[]` -> `azd provision` creates zero model deployments -> `agent.yaml` keeps the literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder. `azd ai agent init` itself has **no** `--subscription` / `--location` flags (those live on core `azd init`). Pick the **first** option that fits, ranked best-first:
+> **Preflight: get `AZURE_SUBSCRIPTION_ID` + `AZURE_LOCATION` into the azd env *before* the first `azd ai agent init`.** Without both, init defers model resolution -> `azure.yaml services.ai-project.deployments[]` ends up empty -> `AI_PROJECT_DEPLOYMENTS=[]` -> `azd provision` creates zero model deployments -> the agent service's `environmentVariables` keep the literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder. `azd ai agent init` itself has **no** `--subscription` / `--location` flags (those live on core `azd init`). Pick the **first** option that fits, ranked best-first:
 >
 > 1. **Pre-bootstrap with core `azd init`** — per-project, no global state. **Recommended default for scripted / MCP / agent-driven flows.** Run in the target empty directory:
 >    ```bash
@@ -123,7 +123,7 @@ For a generic new hosted agent request, start from the basic sample. Use tool/fu
 > azd init -t Azure-Samples/azd-ai-starter-basic . -e <env-name> --subscription <id> -l <region>
 > ```
 >
-> Then run `azd ai agent init` inside the bootstrapped directory. `azd ai agent init` itself has **no** `--subscription` / `--location` flags (passing them fails with `unknown flag`); core `azd init` does. If init still defers resolution (empty `config.deployments[]` / `{{...}}` placeholder), see the recovery paths after the init example below — do **not** blindly re-run init.
+> Then run `azd ai agent init` inside the bootstrapped directory. `azd ai agent init` itself has **no** `--subscription` / `--location` flags (passing them fails with `unknown flag`); core `azd init` does. If init still defers resolution (empty `services.ai-project.deployments[]` / `{{...}}` placeholder), see the recovery paths after the init example below — do **not** blindly re-run init.
 
 Python Example (add `--project-id "<resourceId>"` for an existing Foundry project; add `--agent-name <name>` if the user wants a custom name -- omit otherwise to keep the sample default):
 
@@ -135,42 +135,42 @@ azd ai agent init --no-prompt \
   --entry-point main.py
 ```
 
-> `--agent-name` at init names both `agent.yaml name:` and `azure.yaml services:<key>:` in one shot; renaming after init requires editing both files.
+> `--agent-name` at init sets both the `azure.yaml` service key and its `name:` in one shot; renaming after init requires editing both in `azure.yaml`.
 
 Do not run `azd env new`, `azd env select`, or `azd env set` before `azd ai agent init` in a new temp/workspace; there is no azd project yet, so those commands fail and waste time. For an existing project, `--project-id` is enough during init. Set endpoint/model values immediately after init, once `azure.yaml` and the azd env exist.
 
 > Tip: if the manifest declares a `parameters:` block (check by `curl <manifestUrl>`), collect required values before init when an azd project already exists. In a new empty workspace, prefer a sample without required secrets; there is no azd env to set until init creates the project files.
 
-`init` writes `azure.yaml` (or appends to it), `<service-dir>/agent.yaml`, and `<service-dir>/.agentignore` (code-deploy only). A successful direct-code init produces `<service-dir>/agent.yaml` with `code_configuration:`. For file shapes, see [azd-ai-cli](references/azd-ai-cli.md).
+`init` writes `azure.yaml` (or appends the agent service to it), the agent source under `src/<name>/`, and `<service-dir>/.agentignore` (code-deploy only). A successful direct-code init produces an `azure.yaml` service block (`host: azure.ai.agent`) with `codeConfiguration:`. For file shapes, see [azd-ai-cli](references/azd-ai-cli.md).
 
 #### Model deployments (azd Golden Path)
 
-`azure.yaml services.<name>.config.deployments[]` is the **single source of truth** for model deployments in azd-managed Foundry projects. The flow is:
+`azure.yaml services.ai-project.deployments[]` is the **single source of truth** for model deployments in azd-managed Foundry projects. Model deployments live under the dedicated `ai-project` service (`host: azure.ai.project`); the agent service links to it via `uses: [ai-project]` and references the model through its `environmentVariables`. The flow is:
 
 ```
-manifest → azd ai agent init → azure.yaml config.deployments[] → AI_PROJECT_DEPLOYMENTS env (internal) → Bicep → Microsoft.CognitiveServices/accounts/deployments
+manifest → azd ai agent init → azure.yaml ai-project deployments[] → AI_PROJECT_DEPLOYMENTS env (internal) → Bicep → Microsoft.CognitiveServices/accounts/deployments
 ```
 
 Rules:
 
-- **`azd ai agent init` writes `config.deployments[]` from the sample's manifest** and also sets `AZURE_AI_MODEL_DEPLOYMENT_NAME` to the first deployment's `name`. `azd provision` then creates the deployment through Bicep. No `az` calls are needed in the Golden Path.
+- **`azd ai agent init` writes `services.ai-project.deployments[]` from the sample's manifest** and also sets `AZURE_AI_MODEL_DEPLOYMENT_NAME` to the first deployment's `name`. `azd provision` then creates the deployment through Bicep. No `az` calls are needed in the Golden Path.
 - **`deployments[].name` is the literal Azure deployment resource name** — not a label, not a placeholder. Use a human-readable model name (e.g. `gpt-4o-mini`, `gpt-4.1-mini`). **Never** use the literal string `AZURE_AI_MODEL_DEPLOYMENT_NAME` as the `name` value; doing so creates a deployment literally named `AZURE_AI_MODEL_DEPLOYMENT_NAME` and the agent will 404 on its first invoke.
-- **Adding a *second* model (or any change to `config.deployments[]`) to an existing project:** edit `azure.yaml services.<name>.config.deployments[]` directly (and update `agent.yaml model_deployment_name:` / `${AZURE_AI_MODEL_DEPLOYMENT_NAME}` if the new entry should become the default), then run `azd provision`. The extension's `preprovision` hook calls `envUpdate` automatically, which re-marshals `azure.yaml deployments[]` and re-writes `AI_PROJECT_DEPLOYMENTS` with the correct double-escaping before Bicep runs. **Do not re-run `azd ai agent init`** for this case — it triggers the non-idempotent collision flow (see anti-patterns) and at best (with explicit "Overwrite existing") re-resolves models from the original manifest rather than merging your edit.
-- **`agent.yaml`: prefer `${AZURE_AI_MODEL_DEPLOYMENT_NAME}` over a hardcoded model name.** The `${VAR}` form is resolved from the active azd env at run / deploy time, so a single `azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME <name>` (or env switch dev → prod) updates `agent.yaml` without touching the file. Init writes this form by default (`init_from_code.go`); only the literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` (double braces) is a failure marker that means model resolution deferred.
-- **Recovery: `config.deployments[]` is empty or `agent.yaml` has the literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder.** First get sub + location into the env (see [Step 1 preflight](#step-1----verify-the-environment) options). Then pick **one** of these three paths — init is **not** idempotent:
+- **Adding a *second* model (or any change to `services.ai-project.deployments[]`) to an existing project:** edit `azure.yaml services.ai-project.deployments[]` directly (and update the agent service's `environmentVariables` `AZURE_AI_MODEL_DEPLOYMENT_NAME` if the new entry should become the default), then run `azd provision`. The extension's `preprovision` hook calls `envUpdate` automatically, which re-marshals the deployments and re-writes `AI_PROJECT_DEPLOYMENTS` with the correct double-escaping before Bicep runs. **Do not re-run `azd ai agent init`** for this case — it triggers the non-idempotent collision flow (see anti-patterns) and at best (with explicit "Overwrite existing") re-resolves models from the original manifest rather than merging your edit.
+- **Agent `environmentVariables`: prefer `${AZURE_AI_MODEL_DEPLOYMENT_NAME}` over a hardcoded model name.** The `${VAR}` form is resolved from the active azd env at run / deploy time, so a single `azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME <name>` (or env switch dev → prod) updates the agent without touching the file. Init writes this form by default; only the literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` (double braces) is a failure marker that means model resolution deferred.
+- **Recovery: `services.ai-project.deployments[]` is empty or the agent service's `environmentVariables` have the literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder.** First get sub + location into the env (see [Step 1 preflight](#step-1----verify-the-environment) options). Then pick **one** of these three paths — init is **not** idempotent:
   1. **Clean re-init (preferred when no user code has been added to `src/<name>/` yet):** delete `src/<name>/`, remove the `services.<name>:` block from `azure.yaml`, then re-run `azd ai agent init`. No collision, scaffolds cleanly with the resolved model.
   2. **Interactive overwrite:** re-run `azd ai agent init` **without `--no-prompt`**. When the collision prompt appears, **actively arrow-up and select "Overwrite existing"** — the default selection is *not* overwrite (it's "Use a different service name", which produces `<name>-2`).
-  3. **Hand-fix in place (preserves any user code in `src/<name>/`):** edit `azure.yaml services.<name>.config.deployments[]` to add the model block (`name`, `model.{name, format, version}`, `sku.{name, capacity}`), replace the literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` in `agent.yaml` with `${AZURE_AI_MODEL_DEPLOYMENT_NAME}`, then `azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME <deployment-name>`. Run `azd provision`; the `preprovision` hook auto-syncs `AI_PROJECT_DEPLOYMENTS`.
+  3. **Hand-fix in place (preserves any user code in `src/<name>/`):** edit `azure.yaml services.ai-project.deployments[]` to add the model block (`name`, `model.{name, format, version}`, `sku.{name, capacity}`), replace the literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` in the agent service's `environmentVariables` with `${AZURE_AI_MODEL_DEPLOYMENT_NAME}`, then `azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME <deployment-name>`. Run `azd provision`; the `preprovision` hook auto-syncs `AI_PROJECT_DEPLOYMENTS`.
 - **Anti-patterns — do not do these:**
   - **Blindly re-running `azd ai agent init` against an existing project.** Under `--no-prompt` init silently auto-suffixes (`<service>-2`, then `-3`, ...) via `nextAvailableName`; in interactive mode the collision prompt's default is "Use a different service name". There is **no flag** (`--force` does not apply here) to make `--no-prompt` overwrite. Use one of the three recovery paths above.
   - **Reaching for `azd config set defaults.subscription` / `defaults.location` as the *first* fix for the deferral.** This mutates `~/.azure/config.json` for every azd project on the machine. Prefer pre-bootstrap with `azd init -t ... --subscription -l` (per-project) or `--project-id` (existing project) first — see the [Step 1 preflight options](#step-1----verify-the-environment).
   - `azd env set AI_PROJECT_DEPLOYMENTS '[...]'` — `AI_PROJECT_DEPLOYMENTS` is internal extension state. The extension writes it with double-escaped JSON (`\\` and `\"`) required by Bicep parameter substitution; `azd env set` only single-escapes and breaks the parse with `invalid character 'n' after object key:value pair`.
   - `az cognitiveservices account deployment create ...` against the azd-managed Foundry account — creates the deployment outside the azd lifecycle, so `azd provision` won't manage it and `azd down` won't clean it up. Use `az cognitiveservices` (or [models/deploy-model](../../models/deploy-model/SKILL.md)) **only** for shared/pre-existing Foundry projects that are not managed by this azd project.
-  - Hand-patching the `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder in `agent.yaml` *without also* adding the matching entry to `azure.yaml services.<name>.config.deployments[]` — the agent will reference a deployment name that Bicep never created. Use the [hand-fix recovery path](#step-4a----greenfield-scaffold-from-a-sample) above (path #3) which fixes both files together.
+  - Hand-patching the `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder in the agent service's `environmentVariables` *without also* adding the matching entry to `azure.yaml services.ai-project.deployments[]` — the agent will reference a deployment name that Bicep never created. Use the [hand-fix recovery path](#step-4a----greenfield-scaffold-from-a-sample) above (path #3) which fixes both together.
 
 Check the scaffold before local run:
 
-1. **Verify `azure.yaml services.<name>.config.deployments[]` is non-empty** and that `<service-dir>/agent.yaml` has either a literal `model_deployment_name:` value or the `${AZURE_AI_MODEL_DEPLOYMENT_NAME}` substitution form — **not** the double-brace literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` (that placeholder is the marker that init deferred model resolution). Also confirm `azure.yaml` has only **one** service entry for your agent — a duplicate `<name>-2` means a previous init re-ran against the existing project (collision prompt default + `--no-prompt` silent auto-suffix; see anti-patterns above). If either condition fails, use one of the three [recovery paths in the anti-patterns section](#model-deployments-azd-golden-path) (clean re-init / interactive overwrite / hand-fix). Do **not** `azd env set AI_PROJECT_DEPLOYMENTS`.
+1. **Verify `azure.yaml services.ai-project.deployments[]` is non-empty** and that the agent service's `environmentVariables` `AZURE_AI_MODEL_DEPLOYMENT_NAME` is a literal value or the `${AZURE_AI_MODEL_DEPLOYMENT_NAME}` substitution form — **not** the double-brace literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` (that placeholder is the marker that init deferred model resolution). Also confirm `azure.yaml` has only **one** service entry for your agent — a duplicate `<name>-2` means a previous init re-ran against the existing project (collision prompt default + `--no-prompt` silent auto-suffix; see anti-patterns above). If either condition fails, use one of the three [recovery paths in the anti-patterns section](#model-deployments-azd-golden-path) (clean re-init / interactive overwrite / hand-fix). Do **not** `azd env set AI_PROJECT_DEPLOYMENTS`.
 2. If the user supplied an existing project endpoint, project ARM ID, or model deployment name, set them in the active azd env and verify the values. `azd ai agent run` injects azd env values before `.env`, so a stale `AZURE_AI_MODEL_DEPLOYMENT_NAME` can override a correct `.env` file.
    ```bash
    azd env set AZURE_AI_PROJECT_ENDPOINT "<project-endpoint>"
@@ -183,9 +183,9 @@ Check the scaffold before local run:
    FOUNDRY_PROJECT_ENDPOINT=https://<account>.services.ai.azure.com/api/projects/<project>
    AZURE_AI_MODEL_DEPLOYMENT_NAME=<model-deployment-name>
    ```
-4. Prefer direct code deployment. Inspect `<service-dir>/agent.yaml`; if `code_configuration:` is missing and the agent does not need a custom Dockerfile or system packages, add it before deployment.
-5. Prefer `--agent-name` at init time (above). Fallback only: if init already ran without it, rename the agent in `<service-dir>/agent.yaml` AND the matching key under `azure.yaml services:` to the same value, preserving its `project:` path.
-6. If you change CPU or memory, keep `<service-dir>/agent.yaml` and `azure.yaml services.<name>.config.container.resources` aligned because the `azure.yaml` service config can override the agent file.
+4. Prefer direct code deployment. Inspect the agent's `azure.yaml` service block; if `codeConfiguration:` is missing and the agent does not need a custom Dockerfile or system packages, add it before deployment.
+5. Prefer `--agent-name` at init time (above). Fallback only: if init already ran without it, rename the `azure.yaml` service key AND its `name:` to the same value, preserving its `project:` path.
+6. If you change CPU or memory, set it in the agent service's `container.resources` in `azure.yaml`.
 
 ### Step 4b -- Brownfield: lift existing code
 
@@ -200,7 +200,7 @@ azd ai agent init --no-prompt \
   --entry-point app.py
 ```
 
-`--runtime` and `--entry-point` are required with `--deploy-mode code --no-prompt`. Runtimes: `python_3_13`, `python_3_14`, `dotnet_10`, `node_22`. `--deploy-mode container` builds from `Dockerfile`. For an existing Foundry project, add `--project-id "<resourceId>"`.
+`--runtime` and `--entry-point` are required with `--deploy-mode code --no-prompt`. Runtimes: `python_3_13`, `python_3_14`, `dotnet_10`. `--deploy-mode container` builds from `Dockerfile`. For an existing Foundry project, add `--project-id "<resourceId>"`.
 
 ### Step 5 -- Write the agent instruction file (required)
 
@@ -224,10 +224,10 @@ Tools attach through **toolboxes** -- bundled MCP-compatible endpoints.
 
 Flow (only when the user asks you to create the toolbox):
 
-1. Create the **connection** (`azd ai agent connection create ...`).
+1. Create the **connection** (`azd ai connection create ...`).
 2. Create or update the **toolbox** (`azd ai toolbox create` / `connection add`).
 3. Set the agent env var (`azd env set TOOLBOX_<NAME>_MCP_ENDPOINT ...`).
-4. Reference it in `agent.yaml` `environment_variables[]`.
+4. Reference it in the agent service's `environmentVariables` in `azure.yaml`.
 5. `azd deploy`.
 
 Full recipes (GitHub MCP, Azure AI Search, A2A, Bing Custom) in [tools](references/tools.md).
@@ -246,8 +246,8 @@ After `azd provision` completes for an `azd ai agent`-scaffolded project (defaul
 | `ENABLE_CAPABILITY_HOST` | `false` | Set automatically by `azd ai agent init`. Leave as-is unless you are intentionally targeting Standard Agent Setup. |
 | `FOUNDRY_PROJECT_ENDPOINT` | `https://<account>.services.ai.azure.com/api/projects/<project>` | Populated by provision (or pre-set if reusing an existing project). |
 | `AZURE_AI_PROJECT_ID` | Full ARM resource ID of the Foundry project | Populated by provision; required for deploy. |
-| `AZURE_AI_MODEL_DEPLOYMENT_NAME` | Model deployment name (e.g. `gpt-4o`) | Set automatically by `azd ai agent init` from the first entry in `azure.yaml services.<name>.config.deployments[]`. Required for local run and deploy. |
-| `AI_PROJECT_DEPLOYMENTS` | escaped JSON array, e.g. `[{\"name\":\"gpt-4o\",...}]` | **Internal extension state.** Managed by `azd ai agent init` from `azure.yaml services.<name>.config.deployments[]`. Carries deployments into the Bicep parameter `aiProjectDeploymentsJson`. **Never** set with `azd env set` — manual edits single-escape the JSON and break Bicep `json()` parsing. |
+| `AZURE_AI_MODEL_DEPLOYMENT_NAME` | Model deployment name (e.g. `gpt-4o`) | Set automatically by `azd ai agent init` from the first entry in `azure.yaml services.ai-project.deployments[]`. Required for local run and deploy. |
+| `AI_PROJECT_DEPLOYMENTS` | escaped JSON array, e.g. `[{\"name\":\"gpt-4o\",...}]` | **Internal extension state.** Managed by `azd ai agent init` from `azure.yaml services.ai-project.deployments[]`. Carries deployments into the Bicep parameter `aiProjectDeploymentsJson`. **Never** set with `azd env set` — manual edits single-escape the JSON and break Bicep `json()` parsing. |
 | `AI_AGENT_PENDING_PROVISION` | *(empty / unset)* | Non-empty means provision is still mid-flight; do not deploy. |
 
 `Microsoft.CognitiveServices/accounts/capabilityHosts/agents` is **not** provisioned by `azd ai agent init` (Basic Agent Setup). Its absence is expected. The resource only appears under Standard Agent Setup, which is documented separately in [references/standard-agent-setup.md](../../references/standard-agent-setup.md).
@@ -262,8 +262,8 @@ See the canonical env-var registry: [azure-dev/cli/azd/docs/environment-variable
 2. **Prefer azd over az** -- fall back to `az` only as a last resort, with explicit consent.
 3. **Don't auto-login** -- `az login` and `azd auth login` are user-owned browser flows; ask the user and stop.
 4. **JSON output** -- add `--output json` only to read-only `azd ai agent` commands such as `show`. Do not add it to `azd ai agent invoke`; invoke supports `default` and `raw`, not `json`.
-5. **Two files** -- `agent.yaml` is the agent; `azure.yaml services.<name>.config` is service config. See [azd-ai-cli](references/azd-ai-cli.md).
-6. **Reserved env vars** -- `FOUNDRY_*` and `AGENT_*` are platform-injected at runtime; `AI_PROJECT_DEPLOYMENTS`, `AI_PROJECT_RESOURCES`, and `AI_PROJECT_TOOL_CONNECTIONS` are extension-managed transport for Bicep. Never set any of these with `azd env set` — edit `azure.yaml services.<name>.config` and re-run `azd ai agent init`.
+5. **One file** -- the agent is defined as a service block in `azure.yaml` (`host: azure.ai.agent`). See [azd-ai-cli](references/azd-ai-cli.md).
+6. **Reserved env vars** -- `FOUNDRY_*` and `AGENT_*` are platform-injected at runtime; `AI_PROJECT_DEPLOYMENTS`, `AI_PROJECT_RESOURCES`, and `AI_PROJECT_TOOL_CONNECTIONS` are extension-managed transport for Bicep. Never set any of these with `azd env set` -- edit `azure.yaml` and re-run `azd ai agent init`.
 
 ## Non-Interactive / YOLO Mode
 
@@ -281,9 +281,9 @@ Defaults when unspecified: greenfield + Python + `azd ai agent sample list --fea
 | `not_logged_in` / `login_expired` | Ask user to run `az login` and `azd auth login`; never run those commands for them. |
 | `unknown flag: --subscription` / `--location` on `azd ai agent init` | Wrong command — those flags live on **core** `azd init`. See [Step 1 preflight](#step-1----verify-the-environment) for the four options. |
 | `no project exists; to create a new project, run azd init` on `azd env set` | The azd env does not exist yet — `azd env set` cannot create it. See [Step 1 preflight](#step-1----verify-the-environment). |
-| `agent.yaml` contains literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder after init | Init deferred model resolution. **Do not blindly re-run init** (default prompt = `<name>-2`; `--no-prompt` silently auto-suffixes). Pick one of the three [recovery paths](#model-deployments-azd-golden-path): clean re-init after deleting `src/<name>/`, interactive overwrite, or hand-fix `azure.yaml` + replace `{{...}}` with `${AZURE_AI_MODEL_DEPLOYMENT_NAME}` and `azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME <name>`, then `azd provision`. |
-| `azure.yaml` has duplicate `<service>-2` entry after re-running init | Init is not idempotent: interactive default is "Use a different service name" and `--no-prompt` silently appends `-2`. To recover, merge the resolved `deployments:` block from `<service>-2` into the original service, delete the `<service>-2` entry from `azure.yaml`, remove `src/<service>-2/`, then `azd provision`. |
-| `invalid character 'n' after object key:value pair` during `azd provision` | You used `azd env set AI_PROJECT_DEPLOYMENTS '[...]'` (single-escaped JSON breaks Bicep `json()`). Clear it (`azd env set AI_PROJECT_DEPLOYMENTS ""`), declare the deployment in `azure.yaml services.<name>.config.deployments[]` instead, then re-run `azd provision` (its `preprovision` hook re-syncs `AI_PROJECT_DEPLOYMENTS` with the correct double-escaping). |
+| the agent service's `environmentVariables` contain literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder after init | Init deferred model resolution. **Do not blindly re-run init** (default prompt = `<name>-2`; `--no-prompt` silently auto-suffixes). Pick one of the three [recovery paths](#model-deployments-azd-golden-path): clean re-init after deleting `src/<name>/`, interactive overwrite, or hand-fix `azure.yaml` + replace `{{...}}` with `${AZURE_AI_MODEL_DEPLOYMENT_NAME}` and `azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME <name>`, then `azd provision`. |
+| `azure.yaml` has duplicate `<service>-2` entry after re-running init | Init is not idempotent: interactive default is "Use a different service name" and `--no-prompt` silently appends `-2`. To recover, delete the `<service>-2` entry from `azure.yaml`, remove `src/<service>-2/`, then `azd provision`. |
+| `invalid character 'n' after object key:value pair` during `azd provision` | You used `azd env set AI_PROJECT_DEPLOYMENTS '[...]'` (single-escaped JSON breaks Bicep `json()`). Clear it (`azd env set AI_PROJECT_DEPLOYMENTS ""`), declare the deployment in `azure.yaml services.ai-project.deployments[]` instead, then re-run `azd provision` (its `preprovision` hook re-syncs `AI_PROJECT_DEPLOYMENTS` with the correct double-escaping). |
 | `missing_project_endpoint` | Run `azd provision`, or `azd env set AZURE_AI_PROJECT_ENDPOINT <url>` |
 | `project_not_found` | cwd has no `azure.yaml`; move to project root or run init |
 | Secret parameter prompt under `--no-prompt` | In an empty workspace, choose a simpler sample without secret parameters. In an existing azd project, set `PARAM_<CONN>_<KEY>` with `azd env set` before init; keep `--no-prompt`. |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -12,7 +12,7 @@ Use this when the request is to create a new hosted Foundry agent end-to-end —
 
 | Property | Default (when user is silent) | Override |
 |----------|-------------------------------|----------|
-| Language / runtime | Python 3.13 (`python_3_13`) | Any of `python_3_13`, `python_3_14`, `dotnet_10`, `node_22` |
+| Language / runtime | Python 3.13 (`python_3_13`) | Any of `python_3_13`, `python_3_14`, `dotnet_10` |
 | Sample | Featured basic starter for the chosen language (`azd ai agent sample list --featured-only --language <lang> --output json`) | User may name a different featured sample |
 | Subscription | `az account show` | User may supply |
 | Region | `northcentralus` | Ask user to confirm or pick another |
@@ -47,7 +47,7 @@ For any values **not** already in the prompt, ask the rest in a single `AskUserQ
 | Value | Default | Notes |
 |-------|---------|-------|
 | Project / agent name | `ai-agent-<random6>` (6 lowercase alphanumeric chars) | Used as agent name, service key, and project directory. |
-| Language | `python_3_13` | One of `python_3_13`, `python_3_14`, `dotnet_10`, `node_22`. |
+| Language | `python_3_13` | One of `python_3_13`, `python_3_14`, `dotnet_10`. |
 | Subscription | `az account show --query id -o tsv` | Must be a GUID. |
 | Region | `northcentralus` | Confirm or override. |
 | Foundry project | Ask if the user doesn't mention one | User said create new → create a new one (no `--project-id`). User gave an existing project → use its ARM resource ID *or* Foundry project endpoint URL. User didn't mention a project at all → stop and ask, offering existing vs new. |
@@ -78,7 +78,6 @@ Step 6 needs `--runtime` and `--entry-point` values. These are CLI args, **not**
 |----------|-------------|-----------------|
 | Python | `python_3_13` | `main.py` |
 | .NET | `dotnet_10` | `MyAgent.dll` |
-| Node | `node_22` | `index.js` |
 
 ### Step 4 — Create the project directory
 
@@ -89,7 +88,9 @@ cd <project-name>
 
 ### Step 5 — Pre-bootstrap with core `azd init`
 
-This step writes `AZURE_SUBSCRIPTION_ID` + `AZURE_LOCATION` into the azd env *before* `azd ai agent init` runs, which prevents init from deferring model resolution and leaving the `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder in `agent.yaml`.
+This step writes `AZURE_SUBSCRIPTION_ID` + `AZURE_LOCATION` into the azd env *before* `azd ai agent init` runs, which prevents init from deferring model resolution and leaving the `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` placeholder in the agent service's `environmentVariables`.
+
+> `azd init` requires an **empty** directory — `--no-prompt` does **not** bypass the overwrite prompt and exits non-zero if files already exist. Step 4 created a fresh directory, so this is satisfied.
 
 ```bash
 azd init -t Azure-Samples/azd-ai-starter-basic . \
@@ -115,13 +116,13 @@ azd ai agent init --no-prompt \
 Values you **must** substitute from Step 3 — do not pass placeholders or guesses:
 
 - `--runtime`: exactly one of `python_3_13`, `python_3_14`, `dotnet_10` (the bare value `python` fails with `--runtime must be one of: python_3_13, python_3_14, dotnet_10`).
-- `--entry-point`: the file name from the manifest's `code_configuration.entry_point` (e.g. `main.py`, not `app.py` — a wrong value scaffolds correctly but breaks local run and deploy).
+- `--entry-point`: the entry-point file the sample declares (e.g. `main.py`, not `app.py` — a wrong value scaffolds correctly but breaks local run and deploy).
 
 If using an existing Foundry project, add `--project-id "<arm-id>"`.
 
 ⏳ May take time — init resolves the model catalog server-side. Wait for the prompt to return; do not interrupt.
 
-`init` writes `azure.yaml` (appending the service), `src/<project>/agent.yaml`, `src/<project>/.agentignore`, and the sample source files under `src/<project>/`.
+`init` writes `azure.yaml` (appending the agent service), `src/<project>/.agentignore`, and the sample source files under `src/<project>/`.
 
 ### Step 7 — Customize the scaffolded sample (per user's original intent)
 
@@ -129,14 +130,14 @@ The scaffold is a generic working sample. Edit only what the user's original pro
 
 Typical changes:
 
-- `src/<project>/agent.yaml` — update `description:` to match the user's intent (this also feeds Step 15 eval generation).
+- The agent service's `description:` in `azure.yaml` — update it to match the user's intent (this also feeds Step 15 eval generation).
 - `src/<project>/<entry-point>` — update the system prompt / instructions to match the user's intent.
 
 Only when the user explicitly asked for it:
 
 - Add or modify tool / function-calling code in `<entry-point>`.
 - Add dependencies to `pyproject.toml` / `requirements.txt` (Python), `*.csproj` (.NET), or `package.json` (Node).
-- Change the model in `azure.yaml services.<project>.config.deployments[]` before Step 10 provision.
+- Change the model in `azure.yaml services.ai-project.deployments[]` before Step 10 provision.
 
 If the user's original prompt was generic (no specific agent purpose described), skip customization and ship the sample as-is.
 
@@ -154,14 +155,14 @@ Verify all four before continuing. If any check fails, pick **one** recovery pat
 
 | Check | Expected | If failed |
 |-------|----------|-----------|
-| `azure.yaml services.<project>.config.deployments[]` | Non-empty array with `name`, `model.{name,format,version}`, `sku.{name,capacity}` | Model resolution deferred — use recovery |
-| `src/<project>/agent.yaml` `model_deployment_name:` | Literal name **or** `${AZURE_AI_MODEL_DEPLOYMENT_NAME}` substitution | If literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` (double braces): use recovery |
-| `src/<project>/agent.yaml` `code_configuration.entry_point:` | Matches a real file in `src/<project>/` (e.g. `main.py` and `main.py` exists) | If mismatch (e.g. `entry_point: app.py` but only `main.py` exists): edit `agent.yaml` to the real filename, then re-verify. Most often caused by passing a wrong `--entry-point` in Step 6. |
+| `azure.yaml services.ai-project.deployments[]` | Non-empty array with `name`, `model.{name,format,version}`, `sku.{name,capacity}` | Model resolution deferred — use recovery |
+| Agent service `environmentVariables` `AZURE_AI_MODEL_DEPLOYMENT_NAME` (in `azure.yaml`) | Literal name **or** `${AZURE_AI_MODEL_DEPLOYMENT_NAME}` substitution | If literal `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` (double braces): use recovery |
+| Agent service `codeConfiguration.entryPoint:` (in `azure.yaml`) | Matches a real file in `src/<project>/` (e.g. `main.py` and `main.py` exists) | If mismatch (e.g. `entryPoint: app.py` but only `main.py` exists): edit `azure.yaml` to the real filename, then re-verify. Most often caused by passing a wrong `--entry-point` in Step 6. |
 | `azure.yaml services:` keys | Only one `<project>` entry | If `<project>-2` exists: init was re-run; use recovery |
 
 **Recovery paths** (pick based on whether Step 7 has already customized `src/<project>/`):
 
-1. **Hand-fix in place** *(use when Step 7 customization is already done — preserves user code)* — edit `azure.yaml services.<project>.config.deployments[]` to add the model block, replace `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` in `agent.yaml` with `${AZURE_AI_MODEL_DEPLOYMENT_NAME}`, then `azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME <deployment-name>`.
+1. **Hand-fix in place** *(use when Step 7 customization is already done — preserves user code)* — edit `azure.yaml services.ai-project.deployments[]` to add the model block, replace `{{AZURE_AI_MODEL_DEPLOYMENT_NAME}}` in the agent service's `environmentVariables` with `${AZURE_AI_MODEL_DEPLOYMENT_NAME}`, then `azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME <deployment-name>`.
 2. **Clean re-init** *(use only when Step 7 has not run yet — destructive: deletes `src/<project>/`)* — delete `src/<project>/`, remove the `services.<project>:` block from `azure.yaml`, re-run Step 6.
 3. **Interactive overwrite** *(loses Step 7 edits — re-resolves the model from the original manifest)* — re-run Step 6 *without* `--no-prompt`. When the collision prompt appears, **arrow-up to "Overwrite existing"** (default is *not* overwrite).
 
@@ -271,10 +272,10 @@ azd ai agent invoke "<short representative prompt>"
 
 > ⚠️ **Pre-summary gate.** Do not write the Step 16 final summary until this step has been submitted. The eval suite is part of the deployment artifact; skipping it ships an incomplete result.
 
-Read the `description:` from `src/<project>/agent.yaml` (the value you set in Step 7) and pass it as `--gen-instruction`:
+Read the agent service's `description:` from `azure.yaml` (the value you set in Step 7) and pass it as `--gen-instruction`:
 
 ```bash
-azd ai agent eval generate --gen-instruction "<agent.yaml description>" --no-wait --no-prompt
+azd ai agent eval generate --gen-instruction "<agent service description>" --no-wait --no-prompt
 ```
 
 Expected output:
@@ -294,7 +295,7 @@ Generation runs server-side and takes several minutes. Tell the user:
 
 ### Step 16 — Final summary
 
-Produce a concise summary covering: agent name/version/status/endpoints, a Playground link, the resources created, and the three follow-up commands below. Construct the Playground URL from `azd env get-values` (or read `playground_url` directly from `azd ai agent show --output json` if present):
+Produce a concise summary covering: agent name/version/status/endpoints, a Playground link, the resources created, and the three follow-up commands below. Read `playground_url` directly from `azd ai agent show --output json`. If it is absent, construct the Playground URL from `azd env get-values`:
 
 ```
 https://ai.azure.com/nextgen/r/{encodedSubId},{resourceGroup},,{accountName},{projectName}/build/agents/{agentName}/build?version={agentVersion}
@@ -319,8 +320,8 @@ azd down                                    # tear down all resources when done
 | Symptom | Fix |
 |---------|-----|
 | `azd ai agent init` fails with `--runtime must be one of: python_3_13, python_3_14, dotnet_10` | You passed a bare value like `python`. Use the full runtime token (e.g. `python_3_13`). |
-| `azd ai agent init` fails with `--entry-point is required when using --deploy-mode code with --no-prompt` | Pass `--entry-point <filename>` matching the manifest's `code_configuration.entry_point` from Step 3. |
-| `agent.yaml` `entry_point` doesn't match any file in `src/<project>/` | You guessed the entry-point in Step 6. Edit `agent.yaml` to the real filename (verify with `ls src/<project>/`). No re-init needed. |
+| `azd ai agent init` fails with `--entry-point is required when using --deploy-mode code with --no-prompt` | Pass `--entry-point <filename>` matching the entry-point file the sample declares (from Step 3). |
+| `codeConfiguration.entryPoint` doesn't match any file in `src/<project>/` | You guessed the entry-point in Step 6. Edit the agent service in `azure.yaml` to the real filename (verify with `ls src/<project>/`). No re-init needed. |
 | `azd deploy` postdeploy hook fails with missing `AZURE_TENANT_ID` | Run `az account show --query tenantId -o tsv` and `azd env set AZURE_TENANT_ID <tenant-id>`, then re-run `azd deploy --no-prompt`. The deployed agent version from the first deploy is still valid; the postdeploy hook just registers env vars. |
 | Scaffold sanity check fails (Step 9) | Pick a recovery path from Step 9. If still failing → [create-hosted.md](create-hosted.md). |
 | Local invoke returns model `404` / wrong deployment | Stale `AZURE_AI_MODEL_DEPLOYMENT_NAME` in azd env overrides `.env`. Re-run Step 11 to sync both. |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -136,7 +136,7 @@ Typical changes:
 Only when the user explicitly asked for it:
 
 - Add or modify tool / function-calling code in `<entry-point>`.
-- Add dependencies to `pyproject.toml` / `requirements.txt` (Python), `*.csproj` (.NET), or `package.json` (Node).
+- Add dependencies to `pyproject.toml` / `requirements.txt` (Python) or `*.csproj` (.NET).
 - Change the model in `azure.yaml services.ai-project.deployments[]` before Step 10 provision.
 
 If the user's original prompt was generic (no specific agent purpose described), skip customization and ship the sample as-is.
@@ -219,7 +219,7 @@ python -m pip install uv
 cd -                                             # back to project root for the azd commands below
 ```
 
-**.NET / Node:** no pre-install step — `azd ai agent run` runs `dotnet restore` / `npm install` itself on first start.
+**.NET:** no pre-install step — `azd ai agent run` runs `dotnet restore` itself on first start.
 
 Run the agent locally. For Python, do this **with the service-dir venv still activated** — activation is what lets `azd ai agent run` find `uv` for the fast dependency install. `azd ai agent run` **is** the local server — a foreground process holding port 8088 that must stay alive from start, through every `invoke --local`, until you explicitly stop it.
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/azd-ai-cli.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/azd-ai-cli.md
@@ -107,7 +107,7 @@ services:
 |----------|---------|--------------|
 | `AZURE_AI_PROJECT_ENDPOINT` | Every `azd ai agent` command | `azd env set` or `azd ai project show` |
 | `AZURE_AI_PROJECT_ID` | `azd ai agent show` (playground URL) | `azd env set` |
-| `AZURE_SUBSCRIPTION_ID`, `AZURE_LOCATION` | `azd provision` | `azd config get defaults` |
+| `AZURE_SUBSCRIPTION_ID`, `AZURE_LOCATION` | `azd provision` | `azd init --subscription/-l` (or `azd config set defaults.subscription/location`) |
 | `AGENT_<SVC>_NAME` / `_VERSION` / `_<PROTO>_ENDPOINT` | Auto-written by deploy | Auto |
 | `PARAM_<CONN>_<KEY>` | Connection credentials in `azure.yaml` | `azd env set` |
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/azd-ai-cli.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/azd-ai-cli.md
@@ -11,7 +11,7 @@ azd ai agent doctor                  # full health check, suggests fixes
 
 azd ai agent sample list             # curated catalog -- pick a manifestUrl
 azd ai agent init -m <manifestUrl>   # scaffold from a sample
-azd ai agent init --from-code        # scaffold from existing source
+azd ai agent init --src <dir>        # scaffold from existing source
 
 azd ai agent run                     # start the agent on localhost:8088
 azd ai agent invoke "<msg>"          # remote invoke (billed; gated)
@@ -21,7 +21,7 @@ azd provision                        # core azd; creates Foundry project + infra
 azd deploy                           # core azd; packages + registers new agent version
 azd ai agent endpoint update         # patch agentEndpoint / agentCard in place
 
-azd ai agent connection list / show / create / update / delete
+azd ai connection list / show / create / update / delete
 azd ai toolbox list / show / create / update / delete
 azd ai toolbox connection add / remove / list
 azd ai toolbox version list
@@ -36,80 +36,70 @@ azd ai agent optimize / optimize status / optimize apply / optimize deploy / opt
 
 Read-only commands accept `--output json` and never require `--force`. Write commands are gated by a confirmation envelope (see "Confirmation envelope" below).
 
-## Two files, two schemas
+## The azure.yaml service block
 
-After `azd ai agent init`, every hosted agent is defined by **two** files plus the active azd env. Putting a field in the wrong file is the most common scaffolding failure.
+After `azd ai agent init`, every hosted agent is defined as a **service block in `azure.yaml`** (`host: azure.ai.agent`) plus the active azd env; init consolidates the sample's definition into `azure.yaml`.
 
-| File | What it holds |
+| Location | What it holds |
 |------|---------------|
-| `<service-dir>/agent.yaml` | The flat `ContainerAgent`: `kind`, `name`, `protocols`, `environment_variables`, `agentEndpoint`, `agentCard`, `code_configuration` / `image`, container `resources` (cpu, memory). |
-| `azure.yaml services.<name>.config` | Model deployments, project connections, toolboxes, tool resources, container settings, `startupCommand`. |
+| `azure.yaml services.<name>` (the agent) | `host: azure.ai.agent`, `kind`, `name`, `project`, `language`, `uses`, `protocols`, `environmentVariables`, `codeConfiguration` / `docker` / `image`, `container.resources`, `description`, `agentEndpoint`, `agentCard`, `startupCommand`. |
+| `azure.yaml services.ai-project` | Model `deployments[]` (`host: azure.ai.project`). The agent links to it via `uses: [ai-project]`. |
 | `.azure/<env>/.env` (`azd env set`) | Secrets and `PARAM_<CONN>_<KEY>` credential values referenced from `azure.yaml`. |
 
-`azd deploy` reads `agent.yaml` and creates a new immutable agent version. `azd provision` reads `config.deployments[]` and `config.connections[]` and applies them via Bicep.
+`azd deploy` reads the agent service block and creates a new immutable agent version. `azd provision` reads `services.ai-project.deployments[]` (and any connection/toolbox services) and applies them via Bicep.
 
-`agent.manifest.yaml` (the file passed to `-m`) is the seed format -- it is NOT on disk after init. Init splits its `parameters:` / `resources:` blocks across the three files above. Don't reintroduce the `template:` wrapper into `agent.yaml`.
+`agent.manifest.yaml` (the file passed to `-m`) is the seed format -- it is NOT on disk after init. Init folds its `parameters:` / `resources:` blocks into the `azure.yaml` service block and the azd env.
 
-### Minimal `agent.yaml` (hosted)
+> **Local vs API field names.** Local `azure.yaml` uses **camelCase** (`codeConfiguration`, `entryPoint`, `dependencyResolution`, `environmentVariables`). The deployed definition returned by `azd ai agent show` / the Foundry `agent_get` API uses **snake_case** (`code_configuration`, `entry_point` as an array, `environment_variables`). Don't mix the two.
 
-```yaml
-# yaml-language-server: $schema=https://raw.githubusercontent.com/microsoft/AgentSchema/refs/heads/main/schemas/v1.0/ContainerAgent.yaml
-kind: hosted
-name: my-agent
-protocols:
-  - protocol: responses
-    version: "1.0.0"
-resources:
-  cpu: "0.25"
-  memory: "0.5Gi"
-environment_variables:
-  - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
-    value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
-code_configuration:
-  runtime: python_3_13
-  entry_point: app.py
-  dependency_resolution: remote_build   # or "bundled"
-```
-
-- `protocols` -- `responses` (OpenAI), `invocations` (A2A). Editing requires `azd deploy`.
-- `resources` -- valid tiers: `0.25/0.5Gi`, `1/2Gi`, `2/4Gi`.
-- `environment_variables` -- `${VAR}` resolves from the active azd env. Not for secrets.
-- `code_configuration` present -> direct code deploy (ZIP, Foundry builds). Absent -> container/ACR deploy (Dockerfile + `docker:` in `azure.yaml`). `image:` skips the Dockerfile build.
-- In non-interactive mode, `azd ai agent init` defaults to container deploy. Pass `--deploy-mode code --runtime <runtime> --entry-point <file>` during init to get `code_configuration`.
-- `agentEndpoint` / `agentCard` -- patch in place with `azd ai agent endpoint update` (no new version).
-
-### Minimal `azure.yaml` service config
+### Hosted agent service block (code deploy)
 
 ```yaml
 services:
+  ai-project:
+    host: azure.ai.project
+    deployments:
+      - name: gpt-4.1-mini
+        model:
+          format: OpenAI
+          name: gpt-4.1-mini
+          version: "2024-04-09"
+        sku:
+          name: GlobalStandard
+          capacity: 50
   my-agent:
-    project: ./src/my-agent
+    project: src/my-agent
     host: azure.ai.agent
     language: python
-    config:
-      startupCommand: "python -m main"
-      container:
-        resources:
-          cpu: "0.5"
-          memory: "1Gi"
-      deployments:
-        - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
-          model:
-            name: gpt-4.1-mini
-            format: OpenAI
-            version: "2024-04-09"
-          sku:
-            name: GlobalStandard
-            capacity: 50
-      connections: [...]        # see tools.md
-      toolboxes: [...]          # see tools.md
+    uses:
+      - ai-project
+    kind: hosted
+    name: my-agent
+    description: A hosted agent.
+    codeConfiguration:
+      runtime: python_3_13
+      entryPoint: main.py
+      dependencyResolution: remote_build   # or "bundled"
+    container:
+      resources:
+        cpu: "0.5"
+        memory: 1Gi
+    environmentVariables:
+      - name: AZURE_AI_MODEL_DEPLOYMENT_NAME
+        value: ${AZURE_AI_MODEL_DEPLOYMENT_NAME}
+    protocols:
+      - protocol: responses
+        version: 1.0.0
 ```
 
-- `startupCommand` -- what `azd ai agent run` executes locally. Auto-detected at init.
-- `config.container.resources` -- deployment-time CPU/memory. Keep this aligned with `agent.yaml resources`; this value can override the agent file.
-- `deployments[]` -- model deployments provisioned via Bicep. `name` is the env var the agent reads.
-- `connections[]` -- project connections provisioned via Bicep. Use `PARAM_<CONN>_<KEY>` env-var references for secrets.
-- `toolboxes[]` -- declarative record of intent; today you still drive the toolbox CLI to materialize them on Foundry. See [tools](tools.md).
+- `protocols` -- `responses` (OpenAI), `invocations` (A2A), `invocations_ws`. Editing requires `azd deploy`.
+- `container.resources` -- valid tiers: `0.25/0.5Gi`, `1/2Gi`, `2/4Gi`.
+- `environmentVariables` -- `${VAR}` resolves from the active azd env. Not for secrets.
+- `codeConfiguration` present -> direct code deploy (ZIP, Foundry builds). Absent -> container/ACR deploy: the service uses `language: docker` + `docker.remoteBuild: true` + `startupCommand` (and `image:` skips the Dockerfile build).
+- In non-interactive mode, `azd ai agent init` defaults to container deploy. Pass `--deploy-mode code --runtime <runtime> --entry-point <file>` during init to get `codeConfiguration`.
+- `agentEndpoint` / `agentCard` -- patch in place with `azd ai agent endpoint update` (no new version).
+- `deployments[]` (under the `ai-project` service) -- model deployments provisioned via Bicep. `name` is the literal Azure deployment resource name the agent references through `AZURE_AI_MODEL_DEPLOYMENT_NAME`.
+- Connections/toolboxes -- created with `azd ai connection` / `azd ai toolbox` and consumed via a `TOOLBOX_<NAME>_MCP_ENDPOINT` env var (see [tools](tools.md)). The emerging declarative form models them as top-level `azure.ai.connection` / `azure.ai.toolbox` services linked via `uses:`.
 
 ## State (azd env vars)
 
@@ -123,7 +113,7 @@ services:
 
 Manage with `azd env get-values`, `azd env set`, `azd env list`, `azd env new`, `azd env select`.
 
-The platform also injects `FOUNDRY_*` and `AGENT_*` into the running container at runtime. **Never** put these in the agent.yaml environment_variables section.
+The platform also injects `FOUNDRY_*` and `AGENT_*` into the running container at runtime. **Never** put these in the agent service's `environmentVariables` section.
 
 ## Resolving subscription / location
 
@@ -141,8 +131,8 @@ For the Foundry project ARM ID (`--project-id`), ask the user: "New project, or 
 - `not_logged_in` / `login_expired` -- ask the user to run `azd auth login`.
 - `missing_project_endpoint` -- run `azd provision`, or `azd env set AZURE_AI_PROJECT_ENDPOINT <url>`.
 - `project_not_found` -- cwd has no `azure.yaml`. Move to project root or run init.
-- `invalid_agent_manifest` -- `agent.yaml` is malformed. Run `azd ai agent doctor` and read the named field.
-- `invalid_connection` -- inspect with `azd ai agent connection show <name>`.
+- `invalid_agent_manifest` -- the agent service block is malformed. Run `azd ai agent doctor` and read the named field.
+- `invalid_connection` -- inspect with `azd ai connection show <name>`.
 - `eval_config_invalid` -- `eval.yaml` failed validation. Run `azd ai agent doctor`.
 - `agent_definition_not_found` -- deployed name doesn't match `azure.yaml`. Re-deploy from project root.
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/local-run.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/local-run.md
@@ -42,7 +42,7 @@ azd ai agent run
 What this does:
 
 1. Resolves the agent service from `azure.yaml` (auto-picks when only one exists).
-2. Detects the project type (Python, .NET, Node.js) from files in the service source dir.
+2. Detects the project type (Python, .NET) from files in the service source dir.
 3. Installs dependencies if needed. For Python, `azd ai agent run` installs `requirements.txt` itself and uses `uv` from the active local environment when available.
 4. Starts the agent in the foreground on `localhost:8088` (default).
 5. Opens **Agent Inspector** in your browser (unless `--no-inspector`).

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/local-run.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/local-run.md
@@ -21,7 +21,7 @@ Use this when iterating on a hosted agent before deploying.
 
 ## Prepare the local environment
 
-For Python agents, prepare the environment from the **agent's service source directory** -- the folder that contains `requirements.txt` and `agent.yaml` (typically `<repo>/src/<service-name>/`, not the azd project root). `azd ai agent run` resolves the venv relative to this folder; a `.venv` created in the project root is ignored and azd silently creates a second one without `uv`.
+For Python agents, prepare the environment from the **agent's service source directory** -- the folder that contains `requirements.txt` and the agent source (typically `<repo>/src/<service-name>/`, not the azd project root). `azd ai agent run` resolves the venv relative to this folder; a `.venv` created in the project root is ignored and azd silently creates a second one without `uv`.
 
 1. `cd` into the service source directory.
 2. Create a venv, for example `python -m venv .venv`.
@@ -126,7 +126,7 @@ After the local invocation completes, stop the `azd ai agent run` process you st
 
 Local dev validates code shape; remote validates infra + identity + Foundry binding. Move to deploy when:
 
-- You changed `agent.yaml` `model:`, `tools:`, `connections:`, or `protocols:`. Those only take effect on the deployed agent.
+- You changed the agent's `model`, `tools`, `connections`, or `protocols` in `azure.yaml`. Those only take effect on the deployed agent.
 - You need to test against real Foundry connections (search indexes, Bing, MCP, A2A) that have no local mock.
 - You are ready to publish a new immutable agent version.
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/tools.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/tools.md
@@ -1,6 +1,6 @@
 # Tools and Toolboxes (azd ai)
 
-How to attach tools (web search, Azure AI Search, MCP, A2A) to a hosted agent using `azd ai toolbox` and `azd ai agent connection`.
+How to attach tools (web search, Azure AI Search, MCP, A2A) to a hosted agent using `azd ai toolbox` and `azd ai connection`.
 
 A **toolbox** is a curated bundle of connection-backed tools that Foundry exposes as a single MCP-compatible endpoint. The agent connects to one URL and discovers every tool inside. `azd deploy` does NOT auto-create toolboxes -- you drive the lifecycle explicitly.
 
@@ -14,11 +14,11 @@ azd extension install azure.ai.toolboxes
 
 ## The flow (every recipe)
 
-1. Create the **connection** (`azd ai agent connection create ...`).
+1. Create the **connection** (`azd ai connection create ...`).
 2. Create or update the **toolbox** (`azd ai toolbox create` / `connection add`).
 3. Read the endpoint (`azd ai toolbox show <name> --output json`).
 4. `azd env set TOOLBOX_<NAME>_MCP_ENDPOINT "<endpoint>"`.
-5. Reference it in `<service-dir>/agent.yaml` `environment_variables[]`.
+5. Reference it in the agent service's `environmentVariables` in `azure.yaml`.
 6. `azd deploy`.
 
 ## Env var naming convention
@@ -65,7 +65,7 @@ connections:
 
 ```bash
 # 1. Connection
-azd ai agent connection create github-mcp-conn \
+azd ai connection create github-mcp-conn \
   --kind remote-tool \
   --target https://api.githubcopilot.com/mcp \
   --auth-type custom-keys \
@@ -82,10 +82,10 @@ ENDPOINT=$(azd ai toolbox show agent-tools --output json | jq -r .endpoint)
 azd env set TOOLBOX_AGENT_TOOLS_MCP_ENDPOINT "$ENDPOINT"
 ```
 
-Add the env var to `<service-dir>/agent.yaml`:
+Add the env var to the agent service's `environmentVariables` in `azure.yaml`:
 
 ```yaml
-environment_variables:
+environmentVariables:
   - name: TOOLBOX_AGENT_TOOLS_MCP_ENDPOINT
     value: ${TOOLBOX_AGENT_TOOLS_MCP_ENDPOINT}
 ```
@@ -95,7 +95,7 @@ Then `azd deploy`.
 ## Recipe: Azure AI Search RAG
 
 ```bash
-azd ai agent connection create my-search-conn \
+azd ai connection create my-search-conn \
   --kind cognitive-search \
   --target https://my-search.search.windows.net/ \
   --auth-type api-key --key "<search-admin-key>"
@@ -108,7 +108,7 @@ For multiple indexes, add multiple entries with different `index` values.
 ## Recipe: A2A peer agent
 
 ```bash
-azd ai agent connection create peer-agent-conn \
+azd ai connection create peer-agent-conn \
   --kind remote-a2a \
   --target https://other-agent.foundry-account.westus2.azure.com/ \
   --auth-type none
@@ -201,7 +201,7 @@ azd ai agent invoke "list the tools you have access to"
 | Symptom | Likely cause |
 |---------|--------------|
 | `TOOLBOX_<NAME>_MCP_ENDPOINT` not set | Run `azd ai toolbox show` + `azd env set`. |
-| Env var missing in deployed agent | Add to `agent.yaml` `environment_variables[]`, `azd deploy`. |
+| Env var missing in deployed agent | Add to the agent service's `environmentVariables` in `azure.yaml`, `azd deploy`. |
 | `400` mentioning `Toolboxes` | Missing `Foundry-Features: Toolboxes=V1Preview` header. |
 | `401` on MCP calls | Expired / wrong-scope token. Use `https://ai.azure.com/.default`; refresh per request. |
 | `403 Forbidden` | Caller missing `Foundry User` role. |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-skills-in-hosted-agent.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-skills-in-hosted-agent.md
@@ -95,10 +95,10 @@ azd ai skill create escalation-policy --file ./skills/escalation-policy/ --force
 azd env set SKILL_NAMES "support-style,escalation-policy"
 ```
 
-`agent.yaml`:
+Agent service `environmentVariables` in `azure.yaml`:
 
 ```yaml
-environment_variables:
+environmentVariables:
   - name: SKILL_NAMES
     value: ${SKILL_NAMES}
 ```
@@ -123,10 +123,10 @@ ENDPOINT=$(azd ai toolbox show agent-tools -o json | jq -r .endpoint)
 azd env set TOOLBOX_ENDPOINT "$ENDPOINT"
 ```
 
-`agent.yaml`:
+Agent service `environmentVariables` in `azure.yaml`:
 
 ```yaml
-environment_variables:
+environmentVariables:
   - name: TOOLBOX_ENDPOINT
     value: ${TOOLBOX_ENDPOINT}
 ```
@@ -171,7 +171,7 @@ azd ai agent invoke --local "Hi, can I return my tent within 30 days?"
 | `asyncio.TimeoutError` (Python) | Slow network or large packages | Increase bootstrap timeout (default 60s) |
 | `allow_preview` error (Python) | SDK client missing preview flag | `AIProjectClient(allow_preview=True)` |
 | HTTP 500 on skill download (C#) | Missing feature header | Add `FoundryFeaturesPolicy` for `Skills=V1Preview` |
-| `SKILL_NAMES` not in deployed agent | Env var missing from `agent.yaml` | Add to `environment_variables[]`, redeploy |
+| `SKILL_NAMES` not in deployed agent | Env var missing from `azure.yaml` | Add to the agent service's `environmentVariables`, redeploy |
 | MCP timeout (Toolbox) | Auth token expired or wrong scope | Use `https://ai.azure.com/.default`; refresh per request |
 | Skills not discovered from toolbox | New version not published | `azd ai toolbox publish <toolbox> <version>` |
 | `Invalid skill name 'xxx:download'` | SDK bug in beta.2 | Use CLI or `agent-framework-foundry` wrapper |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-toolbox-in-hosted-agent.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-toolbox-in-hosted-agent.md
@@ -186,7 +186,7 @@ See [azd `params` reference](https://learn.microsoft.com/azure/developer/azure-d
 
 ## Operational helpers via `azd ai` CLI
 
-> The `azd ai` CLI also exposes `agent connection create`, `toolbox create`, `toolbox list`, and `toolbox delete`. Prefer **Foundry Toolkit (VS Code)** or the **Foundry Portal** for those — the UI gives you tool browsing, connection wizards, and validation. The two commands below are the ones the skill should still drive directly because they're *operational*, not setup.
+> The `azd ai` CLI also exposes `connection create`, `toolbox create`, `toolbox list`, and `toolbox delete`. Prefer **Foundry Toolkit (VS Code)** or the **Foundry Portal** for those — the UI gives you tool browsing, connection wizards, and validation. The two commands below are the ones the skill should still drive directly because they're *operational*, not setup.
 
 > All commands require `--project-endpoint <PROJECT_ENDPOINT>` (the value of `PROJECT_ENDPOINT`, e.g. `https://<account>.services.ai.azure.com/api/projects/<project>`). To avoid repeating it, export it once:
 >

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.ps1
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.ps1
@@ -125,11 +125,11 @@ Note-Ok "Azure CLI installed (version $azVersion)."
 
 # 2. Required azd extensions
 try {
-    $extRaw = (& azd extension list --output json 2>$null) -join "`n"
+    $extRaw = (& azd extension list --installed --output json 2>$null) -join "`n"
 } catch {
     $extRaw = ""
 }
-foreach ($ext in @("azure.ai.agents", "azure.ai.projects")) {
+foreach ($ext in @("azure.ai.agents", "azure.ai.projects", "microsoft.foundry")) {
     if ($extRaw -match [regex]::Escape($ext)) {
         Note-Ok "Extension '$ext' is installed."
     } else {

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.sh
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.sh
@@ -52,8 +52,8 @@ AZ_VERSION="$(az version --query '"azure-cli"' -o tsv 2>/dev/null || echo unknow
 note_ok "Azure CLI installed (version ${AZ_VERSION})."
 
 # 2. Required azd extensions
-EXT_JSON="$(azd extension list --output json 2>/dev/null || echo '[]')"
-for ext in azure.ai.agents azure.ai.projects; do
+EXT_JSON="$(azd extension list --installed --output json 2>/dev/null || echo '[]')"
+for ext in azure.ai.agents azure.ai.projects microsoft.foundry; do
   if printf '%s' "$EXT_JSON" | grep -q "$ext"; then
     note_ok "Extension '$ext' is installed."
   else

--- a/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
@@ -19,7 +19,7 @@ For **prompt agents** (LLM + instructions, no custom code), use the Foundry MCP 
 
 ## Hosted vs Prompt
 
-- Shipping Python / .NET / Node code -> **Hosted** (azd workflow below).
+- Shipping Python / .NET code -> **Hosted** (azd workflow below).
 - Updating only model / instructions / tools -> **Prompt** (MCP workflow below).
 
 ## Deployment Method Selection -- Hosted agents

--- a/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/deploy/deploy.md
@@ -2,7 +2,7 @@
 
 Provision Azure resources when needed, deploy the agent, and smoke-test it.
 
-For **hosted agents** (custom container or code), use `azd deploy`. Prefer **direct code deployment through azd** (no Docker/ACR required): `agent.yaml` must contain `code_configuration:`, so `azd deploy` will use direct code deployment and zip the source and let Foundry build it. Use container/ACR deployment only when the agent truly needs a Dockerfile, custom system packages, or a pre-built image.
+For **hosted agents** (custom container or code), use `azd deploy`. Prefer **direct code deployment through azd** (no Docker/ACR required): the agent's `azure.yaml` service block must contain `codeConfiguration:`, so `azd deploy` will use direct code deployment and zip the source and let Foundry build it. Use container/ACR deployment only when the agent truly needs a Dockerfile, custom system packages, or a pre-built image.
 
 For **prompt agents** (LLM + instructions, no custom code), use the Foundry MCP `agent_update` tool.
 
@@ -10,8 +10,8 @@ For **prompt agents** (LLM + instructions, no custom code), use the Foundry MCP 
 
 | Property | Value |
 |----------|-------|
-| Hosted (recommended) | `azd provision` when needed, direct code deployment via `azd deploy` (`code_configuration` present), `azd ai agent invoke` |
-| Hosted (container) | `azd provision` when needed, container/ACR deployment via `azd deploy` (requires Docker/Podman + ACR, no `code_configuration:` in agent.yaml) |
+| Hosted (recommended) | `azd provision` when needed, direct code deployment via `azd deploy` (`codeConfiguration` present), `azd ai agent invoke` |
+| Hosted (container) | `azd provision` when needed, container/ACR deployment via `azd deploy` (requires Docker/Podman + ACR, no `codeConfiguration:` in the `azure.yaml` service block) |
 | Prompt MCP | `agent_definition_schema_get`, `agent_update`, `agent_get`, `agent_delete` |
 | Versioning | Each successful `azd deploy` creates an immutable agent version |
 | Endpoint-only patch | `azd ai agent endpoint update` (no new version) |
@@ -24,23 +24,26 @@ For **prompt agents** (LLM + instructions, no custom code), use the Foundry MCP 
 
 ## Deployment Method Selection -- Hosted agents
 
-Before running `azd deploy`, inspect `<service-dir>/agent.yaml`.
+Before running `azd deploy`, inspect the agent's service block in `azure.yaml`.
 
-| Agent YAML state | Deployment path |
+| Service block state | Deployment path |
 |------------------|-----------------|
-| `code_configuration:` present | **Direct code deploy** through `azd deploy`; no Docker/ACR build. |
-| No `code_configuration:` | **Container/ACR deploy** through `azd deploy`; builds/pushes an image or uses a pre-built `image:`. |
+| `codeConfiguration:` present | **Direct code deploy** through `azd deploy`; no Docker/ACR build. |
+| No `codeConfiguration:` | **Container/ACR deploy** through `azd deploy`; builds/pushes an image or uses a pre-built `image:`. |
 
-`code_configuration:` example in agent.yaml:
+`codeConfiguration:` example in the `azure.yaml` service block:
 
 ```yaml
-code_configuration:
-  runtime: python_3_13
-  entry_point: main.py
-  dependency_resolution: remote_build
+services:
+  <agent-name>:
+    host: azure.ai.agent
+    codeConfiguration:
+      runtime: python_3_13
+      entryPoint: main.py
+      dependencyResolution: remote_build
 ```
 
-Default to direct code for standard hosted-agent code. If `azd deploy` prints `Packaging container` for an agent that does not need container-specific behavior, add or fix `code_configuration` and retry. Use the container path when the agent depends on Dockerfile behavior, system packages, or a pre-built image.
+Default to direct code for standard hosted-agent code. If `azd deploy` prints `Packaging container` for an agent that does not need container-specific behavior, add or fix `codeConfiguration` and retry. Use the container path when the agent depends on Dockerfile behavior, system packages, or a pre-built image.
 
 ## Workflow -- Hosted agent (azd)
 
@@ -66,7 +69,7 @@ azd ai agent show --output json
 
 Branch on output: `not_deployed` -> Step 2. `active` / `deployed` -> redeploy (skip Step 2, go to Step 3). If `azd ai project show` fails with `missing_project_endpoint`, do Step 2 first -- `azd provision` will create the project.
 
-> **Important:** Before deploy, also make sure `agent.yaml` and the azd environment are aligned with the user's provided configuration values.
+> **Important:** Before deploy, also make sure the agent's `azure.yaml` service block and the azd environment are aligned with the user's provided configuration values.
 
 ### Step 2 -- Provision Azure resources (one-time per env)
 
@@ -87,7 +90,7 @@ azd provision --no-prompt
 What this does:
 
 - Creates the Foundry project (if not present) and supporting resources under `infra/`.
-- Creates project connections declared in `azure.yaml services.<name>.config.connections[]`. `${PARAM_*}` placeholders resolve from the active azd env.
+- Creates any connections/toolboxes declared as top-level `azure.ai.connection` / `azure.ai.toolbox` services (linked from the agent via `uses:`). Most agents instead reference an existing toolbox through a `TOOLBOX_<NAME>_MCP_ENDPOINT` environment variable created with `azd ai connection` / `azd ai toolbox`. `${PARAM_*}` placeholders resolve from the active azd env.
 - Wires model deployments, AI Search, ACR, etc. `infra/layers/` provision in parallel when present.
 
 This is a core `azd` command. Skip provision when the user gave you an existing `AZURE_AI_PROJECT_ENDPOINT` via `azd env set` -- the extension uses the existing project as-is.
@@ -104,15 +107,15 @@ azd deploy <service-name> --no-prompt
 
 What deploy does:
 
-- Reads `<service-dir>/agent.yaml`, packages the agent, uploads it, and registers a new immutable version.
-- **Direct code deploy** (`code_configuration` present): zips source, excludes `.agentignore`, and lets Foundry build the runtime image.
-- **Container deploy** (no code configuration): builds the `Dockerfile`, pushes to the project's ACR, registers the version. When `agent.yaml` has `image:` set, `azd` reuses the pre-built image.
+- Reads the agent's `azure.yaml` service block, packages the agent, uploads it, and registers a new immutable version.
+- **Direct code deploy** (`codeConfiguration` present): zips source, excludes `.agentignore`, and lets Foundry build the runtime image.
+- **Container deploy** (no code configuration): builds the `Dockerfile`, pushes to the project's ACR, registers the version. When the service block has `image:` set, `azd` reuses the pre-built image.
 
 After deploy, azd writes `AGENT_<SVC>_NAME`, `AGENT_<SVC>_VERSION`, and `AGENT_<SVC>_<PROTO>_ENDPOINT` (one per protocol) into the active env.
 
 Re-deploying an identical build still creates a new version; `azd` prints `Agent version <n> is already active.` and skips the poll.
 
-If deploy reports `Done` for the service and then fails only in `postdeploy` with `Agent <service-name> with version <n> not found`, the service key and `agent.yaml name` were mismatched. Rename the `azure.yaml services` key to the deployed agent name and rerun `azd deploy --no-prompt`; do not switch deployment method.
+If deploy reports `Done` for the service and then fails only in `postdeploy` with `Agent <service-name> with version <n> not found`, the `azure.yaml` service key and the service's `name:` were mismatched. Rename the `azure.yaml services` key to the deployed agent name and rerun `azd deploy --no-prompt`; do not switch deployment method.
 
 ### Step 4 -- Verify and invoke
 
@@ -140,7 +143,7 @@ This step runs automatically after deploy. Ask the user which source to use and 
 
 | Choice | Command | What's next |
 |---|---|---|
-| (a) Agent instructions | `azd ai agent eval generate --gen-instruction "<agent purpose>" --no-wait --no-prompt` — `--gen-instruction` is required (hosted agents don't auto-derive it); use `agent.yaml` `description:`. | Generation runs server-side. Tell the user: *"Suite submitted. Run `azd ai agent eval run` whenever you're ready — it'll finalize `eval.yaml` and execute the eval in one step."* |
+| (a) Agent instructions | `azd ai agent eval generate --gen-instruction "<agent purpose>" --no-wait --no-prompt` — `--gen-instruction` is required (hosted agents don't auto-derive it); use the service's `description:` in `azure.yaml`. | Generation runs server-side. Tell the user: *"Suite submitted. Run `azd ai agent eval run` whenever you're ready — it'll finalize `eval.yaml` and execute the eval in one step."* |
 | (b) Historical traces | `azd ai agent eval generate --trace-days 3 --max-samples 50 --no-wait --no-prompt` | Same as (a). |
 | (c) Existing `eval.yaml` | Skip `generate`. | Tell the user: *"Using existing `eval.yaml`. Run `azd ai agent eval run` when ready."* |
 | (d) No / later | Skip. | Tell the user: *"You can run `azd ai agent eval generate` (and then `eval run`) anytime."* |
@@ -162,11 +165,11 @@ Then proceed to Step 6. See [After Deployment — Auto-Generate Evaluation Suite
 
 ## Endpoint or card edits -- no new version
 
-When only `agentEndpoint:` or `agentCard:` changed in `agent.yaml`:
+When only `agentEndpoint:` or `agentCard:` changed in the `azure.yaml` service block:
 
 ```bash
-azd ai agent endpoint update --dry-run # preview
-azd ai agent endpoint update --force # apply
+azd ai agent endpoint update          # patch in place
+azd ai agent endpoint update --force  # skip confirmation for breaking changes
 ```
 
 Idempotent.
@@ -187,14 +190,14 @@ Each env has its own `AGENT_<SVC>_*` vars.
 |-------|-----|
 | `missing_project_endpoint` | Run `azd env set AZURE_AI_PROJECT_ENDPOINT <url>`, or run `azd provision` for a new project. |
 | `invalid_agent_manifest` | `azd ai agent doctor`; fix the named field. |
-| `invalid_connection` | Inspect with `azd ai agent connection show <name>`. |
-| Docker daemon not running | You are on the container path. Add/fix `code_configuration` and retry direct code deploy. Only install Docker or try remote image build if you specifically need container deploy. |
+| `invalid_connection` | Inspect with `azd ai connection show <name>`. |
+| Docker daemon not running | You are on the container path. Add/fix `codeConfiguration` and retry direct code deploy. Only install Docker or try remote image build if you specifically need container deploy. |
 | ACR push 403 | Foundry project RBAC is missing `AcrPush` for your identity. Consider switching to direct code deployment to avoid ACR entirely. |
 | `container registry endpoint not found` | ACR is not configured. Use `azd env set AZURE_CONTAINER_REGISTRY_ENDPOINT <url>`, or switch to direct code deployment. |
 | Agent version poll times out | Build still running; retry `azd ai agent show` after a minute. |
 | `session_not_ready` (424) | Cold start or readiness delay. Wait 15-30 seconds and retry. If persistent, use `1` CPU / `2Gi` memory minimum, verify the model deployment name, capability host, and agent identity role. |
 | `invalid value "json" for --output` from `azd ai agent invoke` | Invoke supports only `default` and `raw` currently. Retry without `--output json`. |
-| `could not resolve agent service in azd project: no azure.ai.agent service named '<agentName>' found in azure.yaml` from `azd ai agent invoke` | Name mismatch. Use the service name, update `agent.yaml`, or invoke through the Foundry MCP `agent_invoke` tool. |
+| `could not resolve agent service in azd project: no azure.ai.agent service named '<agentName>' found in azure.yaml` from `azd ai agent invoke` | Name mismatch. Use the service name, update the `azure.yaml` service block, or invoke through the Foundry MCP `agent_invoke` tool. |
 | `subscription quota exceeded` | Ask user to request quota; do not auto-retry. |
 | Bicep deploy errors | Forward `error.details[]` verbatim to the user. |
 | `RoleAssignmentUpdateNotPermitted` during provision | A role assignment already exists but conflicts. Check for existing role assignments with `az role assignment list --scope <resource-scope>`. The provision may have succeeded for all resources except RBAC — verify with `azd ai project show` and manually assign the `Cognitive Services User` role to the agent identity if needed. |

--- a/plugin/skills/microsoft-foundry/foundry-agent/eval-datasets/references/generate-seed-dataset.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/eval-datasets/references/generate-seed-dataset.md
@@ -12,7 +12,7 @@ Generate a seed evaluation dataset for a Foundry agent by producing realistic, d
 
 ## Prerequisites
 
-- Agent deployed and running (or local `agent.yaml` available with instructions and tool definitions)
+- Agent deployed and running (or the local agent source / `azure.yaml` service block available with instructions and tool definitions)
 - Selected `.foundry/agent-metadata*.yaml` file resolved with `projectEndpoint` and `agentName`
 
 ## Dataset Row Schema
@@ -34,13 +34,13 @@ Example row:
 
 ## Step 1 — Gather Agent Context
 
-Collect the agent's full context from `agent_get` or local `agent.yaml` in the selected agent root:
+Collect the agent's full context from `agent_get` or the local `azure.yaml` service block in the selected agent root:
 
 - **Agent name** — from the selected metadata file
 - **Instructions** — the system prompt / instructions field
 - **Tools** — list of tools with names, descriptions, and parameter schemas
 - **Protocols** — supported protocols (e.g. `responses`, `invocations`, `invocations_ws`, `a2a`, `mcp`)
-- **Example messages** — from `agent.yaml` metadata if available
+- **Example messages** — from the `azure.yaml` service metadata if available
 
 ## Step 2 — Generate Test Queries
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/invocations-ws.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/invocations-ws.md
@@ -9,7 +9,7 @@ Build, deploy, and connect to Foundry hosted agents that expose a **duplex WebSo
 | Property | Value |
 |----------|-------|
 | Agent type | Hosted (Bring Your Own container) only |
-| Protocol id (`agent.yaml`) | `invocations_ws` |
+| Protocol id (`azure.yaml`) | `invocations_ws` |
 | Recommended version | `1.0.0` |
 | Container route | `WS /invocations_ws` (served by `azure-ai-agentserver-invocations`; the host binds the port and probes for you) |
 | Foundry-side URL | `wss://{account}.services.ai.azure.com/api/projects/agents/endpoint/protocols/invocations_ws?project_name={project}&agent_name={agentName}&agent_session_id={sessionId}&foundry_features=HostedAgents=V1Preview` |
@@ -63,21 +63,27 @@ Inside the handler, read the session id from `FOUNDRY_AGENT_SESSION_ID` (env var
 
 See [Invocations WebSocket Protocol Guide](references/invocations-ws-protocol.md) for the framing model, the `agent_session_id` query parameter, control-vs-data frame patterns, and discovery guidance.
 
-### Step 2: Declare the Protocol in `agent.yaml`
+### Step 2: Declare the Protocol in `azure.yaml`
+
+In the agent's service block (`host: azure.ai.agent`):
 
 ```yaml
-kind: hosted
-name: my-ws-agent
-protocols:
-  - protocol: invocations_ws
-    version: 1.0.0
-resources:
-  cpu: "1"          # voice/media: at least 1 vCPU / 2 GiB; up to 2 vCPU / 4 GiB
-  memory: 2Gi
-environment_variables:
-  - name: SOME_SECRET
-    value: ${SOME_SECRET}
-  # Resolve every secret from the azd environment; do not bake values into the image.
+services:
+  my-ws-agent:
+    host: azure.ai.agent
+    kind: hosted
+    name: my-ws-agent
+    protocols:
+      - protocol: invocations_ws
+        version: 1.0.0
+    container:
+      resources:
+        cpu: "1"          # voice/media: at least 1 vCPU / 2 GiB; up to 2 vCPU / 4 GiB
+        memory: 2Gi
+    environmentVariables:
+      - name: SOME_SECRET
+        value: ${SOME_SECRET}
+      # Resolve every secret from the azd environment; do not bake values into the image.
 ```
 
 The matching `agent.manifest.yaml` declares the same `protocol: invocations_ws` under `template.protocols`.
@@ -91,7 +97,7 @@ Use the standard hosted-agent flow from the [`deploy`](../deploy/deploy.md) skil
 ```bash
 mkdir ~/azd-deploys/my-ws-agent && cd ~/azd-deploys/my-ws-agent
 azd ai agent init -m <path>/agent.manifest.yaml -p <project-resource-id> --no-prompt
-# azd env set ... for every variable referenced in agent.yaml
+# azd env set ... for every variable referenced in azure.yaml
 azd deploy my-ws-agent
 ```
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/references/invocations-ws-protocol.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/references/invocations-ws-protocol.md
@@ -28,7 +28,7 @@ wss://{account}.services.ai.azure.com
 | Query parameter | Required | Notes |
 |-----------------|----------|-------|
 | `project_name` | ✅ | Foundry project name (the segment after `/api/projects/` in the project endpoint) |
-| `agent_name` | ✅ | Hosted agent name as declared in `agent.yaml` |
+| `agent_name` | ✅ | Hosted agent name as declared in `azure.yaml` |
 | `agent_session_id` | ❌ | Per-connection identifier — see [Session Management](../../invoke/references/session-management.md). If omitted, the platform (or the container) generates a random id |
 | `foundry_features` | ✅ (preview) | Must be `HostedAgents=V1Preview` while the protocol is in preview. May alternatively be sent as the `Foundry-Features` request header. |
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/observe/references/deploy-and-setup.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/observe/references/deploy-and-setup.md
@@ -8,7 +8,7 @@ After deployment, immediately prepare a Foundry evaluation suite and local refer
 
 ### 1. Resolve Context
 
-Use [Common Project Context Resolution](../../../SKILL.md#agent-common-project-context-resolution) to compute effective context. In azd projects, prefer `azd env get-values` for deployment context and use the selected `.foundry/agent-metadata*.yaml` file only as an overlay/cache. Use `agent_get`, local `agent.yaml`, and matching `eval.yaml` as needed to resolve:
+Use [Common Project Context Resolution](../../../SKILL.md#agent-common-project-context-resolution) to compute effective context. In azd projects, prefer `azd env get-values` for deployment context and use the selected `.foundry/agent-metadata*.yaml` file only as an overlay/cache. Use `agent_get`, the local `azure.yaml` service block, and matching `eval.yaml` as needed to resolve:
 
 | Value | Source |
 |-------|--------|

--- a/plugin/skills/microsoft-foundry/models/deploy-model/SKILL.md
+++ b/plugin/skills/microsoft-foundry/models/deploy-model/SKILL.md
@@ -9,7 +9,7 @@ metadata:
 
 # Deploy Model
 
-> **Scope — read this first.** This skill creates model deployments **out-of-band** via Azure CLI / MCP / portal. For azd-managed Foundry projects (those scaffolded from `azd-ai-starter-basic` or via `azd ai agent init`), declare deployments in `azure.yaml services.<name>.config.deployments[]` instead — `azd ai agent init` writes the entry from the sample manifest and `azd provision` creates the deployment through Bicep. See [foundry-agent/create/create-hosted.md](../../foundry-agent/create/create-hosted.md) for the Golden Path. Use this skill only for: (a) Foundry projects not managed by an azd project, (b) ad-hoc deployments outside the azd lifecycle.
+> **Scope — read this first.** This skill creates model deployments **out-of-band** via Azure CLI / MCP / portal. For azd-managed Foundry projects (those scaffolded from `azd-ai-starter-basic` or via `azd ai agent init`), declare deployments in `azure.yaml services.ai-project.deployments[]` instead — `azd ai agent init` writes the entry from the sample manifest and `azd provision` creates the deployment through Bicep. See [foundry-agent/create/create-hosted.md](../../foundry-agent/create/create-hosted.md) for the Golden Path. Use this skill only for: (a) Foundry projects not managed by an azd project, (b) ad-hoc deployments outside the azd lifecycle.
 
 Unified entry point for all Azure OpenAI model deployment workflows. Analyzes user intent and routes to the appropriate deployment mode.
 

--- a/plugin/skills/microsoft-foundry/project/create/create-foundry-project.md
+++ b/plugin/skills/microsoft-foundry/project/create/create-foundry-project.md
@@ -125,7 +125,7 @@ Capture `AZURE_AI_PROJECT_ID`, `AZURE_AI_PROJECT_ENDPOINT`, and `AZURE_RESOURCE_
 > azd ai agent init -m <manifest-url> --no-prompt --deploy-mode code --runtime python_3_13 --entry-point main.py
 > ```
 >
-> Core `azd init` accepts `--subscription` and `-l/--location`; `azd ai agent init` does not. `azd ai agent init` then resolves the model from the chosen sample's manifest and writes it into `azure.yaml services.<name>.config.deployments[]`; the next `azd provision` creates the deployment through Bicep. **You do not need to deploy a model separately for this path** — no `az cognitiveservices` calls, no `azd env set AI_PROJECT_DEPLOYMENTS`.
+> Core `azd init` accepts `--subscription` and `-l/--location`; `azd ai agent init` does not. `azd ai agent init` then resolves the model from the chosen sample's manifest and writes it into `azure.yaml services.ai-project.deployments[]`; the next `azd provision` creates the deployment through Bicep. **You do not need to deploy a model separately for this path** — no `az cognitiveservices` calls, no `azd env set AI_PROJECT_DEPLOYMENTS`.
 >
 > Use [models/deploy-model](../../models/deploy-model/SKILL.md) **only** for out-of-band scenarios: adding models to a Foundry project that is not managed by this azd project, or ad-hoc deployments outside the azd lifecycle.
 

--- a/plugin/skills/microsoft-foundry/references/agent-metadata-contract.md
+++ b/plugin/skills/microsoft-foundry/references/agent-metadata-contract.md
@@ -28,7 +28,7 @@ Resolve deployment and evaluation context by layering sources in this order:
 | Agent root | `azure.yaml` service `project` for `host: azure.ai.agent` | `.foundry` discovery, user path | Do not write except to initialize cache |
 | Environment | user/session, then azd env/default | metadata `defaultEnvironment` | Store azd binding only when useful |
 | Project endpoint | `azd env get-values` | metadata, user input | Do not duplicate azd values |
-| Agent name/version | azd `AGENT_<SERVICE>_*` vars | `agent.yaml`, metadata, user input | Do not duplicate azd values |
+| Agent name/version | azd `AGENT_<SERVICE>_*` vars | `azure.yaml`, metadata, user input | Do not duplicate azd values |
 | ACR | azd registry vars | metadata, user input | Do not duplicate azd values |
 | Observability | azd App Insights vars | metadata, user input | Do not copy secrets if azd has them |
 | Local eval draft | `eval.yaml` | metadata, user input | Sync to `.foundry` only after remote lookup/registration |
@@ -122,7 +122,7 @@ Persist eval.yaml-derived suite metadata only after the relevant dataset/evaluat
 ## Workflow Rules
 
 1. Prefer azd service discovery before `.foundry` discovery when `azure.yaml` has `host: azure.ai.agent`.
-2. Once an agent root is selected, use only that root's `.foundry`, source tree, `agent.yaml`, and `eval.yaml` unless the user switches roots.
+2. Once an agent root is selected, use only that root's `.foundry`, source tree, `azure.yaml`, and `eval.yaml` unless the user switches roots.
 3. Select metadata files in this order: explicit file/path, environment sidecar, `.foundry/agent-metadata.yaml`, then prompt if ambiguous.
 4. Resolve environment from user/session, azd env/default, single-environment metadata, then `defaultEnvironment`.
 5. Keep the selected root, environment, metadata overlay file, and primary context source visible in deploy/eval/trace summaries.

--- a/tests/microsoft-foundry/foundry-agent/direct-code.unit.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/direct-code.unit.test.ts
@@ -28,8 +28,8 @@ describe("foundry-agent direct-code workflow docs", () => {
     expect(quickStart).toContain("azd ai agent init --no-prompt");
     expect(quickStart).toContain("--deploy-mode code");
     expect(deploy).toContain("Prefer **direct code deployment through azd**");
-    expect(deploy).toContain("`code_configuration:` present | **Direct code deploy** through `azd deploy`; no Docker/ACR build.");
-    expect(deploy).toContain("No `code_configuration:` | **Container/ACR deploy** through `azd deploy`");
+    expect(deploy).toContain("`codeConfiguration:` present | **Direct code deploy** through `azd deploy`; no Docker/ACR build.");
+    expect(deploy).toContain("No `codeConfiguration:` | **Container/ACR deploy** through `azd deploy`");
     expect(deploy).toContain("Default to direct code for standard hosted-agent code.");
   });
 
@@ -50,13 +50,13 @@ describe("foundry-agent direct-code workflow docs", () => {
     const quickStart = await readSkillFile("foundry-agent/create/quick-start-hosted.md");
     const deployModel = await readSkillFile("models/deploy-model/SKILL.md");
 
-    expect(createHosted).toContain("`azure.yaml services.<name>.config.deployments[]` is the **single source of truth**");
+    expect(createHosted).toContain("`azure.yaml services.ai-project.deployments[]` is the **single source of truth**");
     expect(createHosted).toContain("Never `azd env set AI_PROJECT_DEPLOYMENTS '[...]'`");
     expect(createHosted).toContain("never `az cognitiveservices account deployment create ...`");
     expect(quickStart).toContain("Never `azd env set AI_PROJECT_DEPLOYMENTS '[...]'`");
     expect(quickStart).toContain("Never `az cognitiveservices account deployment create`");
     expect(deployModel).toContain("For azd-managed Foundry projects");
-    expect(deployModel).toContain("declare deployments in `azure.yaml services.<name>.config.deployments[]`");
+    expect(deployModel).toContain("declare deployments in `azure.yaml services.ai-project.deployments[]`");
     expect(deployModel).toContain("Use this skill only for: (a) Foundry projects not managed by an azd project");
   });
 


### PR DESCRIPTION
~~**`azd` contract changed (https://github.com/Azure/azure-dev/pull/8818), should merge after new AZD released**~~
**azd.ai.agents 1.0.0-beta.2 released**

## Description

Update the `microsoft-foundry` skill to match the current `azd ai agents` CLI. The hosted-agent definition now lives in an `azure.yaml` service block (no `agent.yaml`), and several CLI command/flag references had drifted.

- Migrate agent definition from `agent.yaml` to the `azure.yaml` service block (camelCase fields; model deployments under the `ai-project` service).
- Fix drifted CLI references: `azd ai connection`, `init --src` (was `--from-code`), Node samples unsupported, read `playground_url` from `azd ai agent show`.
- Update `direct-code.unit.test.ts` assertions to match.

## Checklist

- [X] Tests pass locally (`cd tests && npm test`)
- [X] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [X] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)
