### PR TITLE
chore: limit vally worker count

### DIFF
--- a/tests/run-vally-test.ts
+++ b/tests/run-vally-test.ts
@@ -311,6 +311,7 @@ async function main(): Promise<void> {
   const forwardedArgs = [...options.forwardedArgs];
 
   // default options
+  forwardedArgs.splice(0, 0, "--workers", "2");
   forwardedArgs.splice(0, 0, "--output-dir", "./results");
   forwardedArgs.splice(0, 0, "--executor-plugin", path.join(__dirname, "vally", "vally-executor.ts"));
   forwardedArgs.splice(0, 0, "--grader-plugin", path.join(__dirname, "vally", "vally-graders.ts"));

--- a/tests/run-vally-test.ts
+++ b/tests/run-vally-test.ts
@@ -311,7 +311,10 @@ async function main(): Promise<void> {
   const forwardedArgs = [...options.forwardedArgs];
 
   // default options
-  forwardedArgs.splice(0, 0, "--workers", "2");
+  const hasWorkersArg = forwardedArgs.some(arg => arg === "--workers" || arg.startsWith("--workers="));
+  if (!hasWorkersArg) {
+    forwardedArgs.splice(0, 0, "--workers", "2");
+  }
   forwardedArgs.splice(0, 0, "--output-dir", "./results");
   forwardedArgs.splice(0, 0, "--executor-plugin", path.join(__dirname, "vally", "vally-executor.ts"));
   forwardedArgs.splice(0, 0, "--grader-plugin", path.join(__dirname, "vally", "vally-graders.ts"));


### PR DESCRIPTION
## Description

Running 5 (default) concurrent vally workers with resource intensive tests is a little too much for local runs and can significantly slow down the machine. Limit it to 2 so people can better work on other stuff while running vally tests locally.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
