### PR TITLE
chore: ignore @types/node in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
   - dependency-name: "*"
     update-types:
     - version-update:semver-patch
+  - dependency-name: "@types/node" # @types/node versions mirror Node.js versions; pin manually
   open-pull-requests-limit: 10
   package-ecosystem: npm
   schedule:
@@ -22,6 +23,7 @@ updates:
   - dependency-name: "*"
     update-types:
     - version-update:semver-patch
+  - dependency-name: "@types/node" # @types/node versions mirror Node.js versions; pin manually
   open-pull-requests-limit: 5
   package-ecosystem: npm
   schedule:
@@ -36,6 +38,7 @@ updates:
   - dependency-name: "*"
     update-types:
     - version-update:semver-patch
+  - dependency-name: "@types/node" # @types/node versions mirror Node.js versions; pin manually
   open-pull-requests-limit: 5
   package-ecosystem: npm
   schedule:


### PR DESCRIPTION
## Description

Add a Dependabot ignore rule for `@types/node` across all three npm package ecosystem entries (`/`, `/scripts`, `/tests`). `@types/node` versions mirror Node.js major versions and should be pinned/updated manually rather than auto-bumped by Dependabot.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests

## Related Issues

Closes #2716
Closes #2714
Closes #2712