### PR TITLE
eval: add tool-call-result early terminate condition

### DIFF
--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -538,6 +538,36 @@ export function getToolCalls(agentMetadata: AgentMetadata, toolName?: string): A
   return calls;
 }
 
+/**
+ * Get the result content strings from tool execution completions.
+ * Optionally filter by tool name pattern by correlating with start events.
+ */
+export function getToolCallResults(agentMetadata: AgentMetadata, toolPattern?: RegExp): string[] {
+  // Build a map from toolCallId to toolName using start events
+  const toolNameById = new Map<string, string>();
+  for (const event of agentMetadata.events) {
+    if (event.type === "tool.execution_start") {
+      const data = event.data as { toolCallId?: string; toolName?: string };
+      if (data.toolCallId && data.toolName) {
+        toolNameById.set(data.toolCallId, data.toolName);
+      }
+    }
+  }
+
+  const results: string[] = [];
+  for (const event of agentMetadata.events) {
+    if (event.type !== "tool.execution_complete") continue;
+    const data = event.data as { toolCallId?: string; result?: { content?: string }; error?: { message?: string } };
+    if (toolPattern) {
+      const toolName = data.toolCallId ? toolNameById.get(data.toolCallId) : undefined;
+      if (!toolName || !toolPattern.test(toolName)) continue;
+    }
+    if (data.result?.content) results.push(data.result.content);
+    if (data.error?.message) results.push(data.error.message);
+  }
+  return results;
+}
+
 /** Get combined text of all tool args and results for scanning */
 export function getAllToolText(metadata: AgentMetadata): string {
   const parts: string[] = [];

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -538,36 +538,6 @@ export function getToolCalls(agentMetadata: AgentMetadata, toolName?: string): A
   return calls;
 }
 
-/**
- * Get the result content strings from tool execution completions.
- * Optionally filter by tool name pattern by correlating with start events.
- */
-export function getToolCallResults(agentMetadata: AgentMetadata, toolPattern?: RegExp): string[] {
-  // Build a map from toolCallId to toolName using start events
-  const toolNameById = new Map<string, string>();
-  for (const event of agentMetadata.events) {
-    if (event.type === "tool.execution_start") {
-      const data = event.data as { toolCallId?: string; toolName?: string };
-      if (data.toolCallId && data.toolName) {
-        toolNameById.set(data.toolCallId, data.toolName);
-      }
-    }
-  }
-
-  const results: string[] = [];
-  for (const event of agentMetadata.events) {
-    if (event.type !== "tool.execution_complete") continue;
-    const data = event.data as { toolCallId?: string; result?: { content?: string }; error?: { message?: string } };
-    if (toolPattern) {
-      const toolName = data.toolCallId ? toolNameById.get(data.toolCallId) : undefined;
-      if (!toolName || !toolPattern.test(toolName)) continue;
-    }
-    if (data.result?.content) results.push(data.result.content);
-    if (data.error?.message) results.push(data.error.message);
-  }
-  return results;
-}
-
 /** Get combined text of all tool args and results for scanning */
 export function getAllToolText(metadata: AgentMetadata): string {
   const parts: string[] = [];

--- a/tests/vally/tag-helpers.ts
+++ b/tests/vally/tag-helpers.ts
@@ -133,9 +133,9 @@ export function getEarlyTerminateCondition(tags: Record<string, string[] | strin
             const argsPattern = condition.argsPattern ? new RegExp(condition.argsPattern) : undefined;
             const completedIds = new Set(
               agentMetadata.events
-                .filter((event) => { return event.type === "tool.execution_complete"; })
-                .map((event) => { return (event.data as { toolCallId?: string }).toolCallId; })
-                .filter((id): id is string => { return id !== undefined; })
+                .filter((event) => event.type === "tool.execution_complete")
+                .map((event) => event.data.toolCallId)
+                .filter((id) => id !== undefined)
             );
             const matched = getToolCalls(agentMetadata).some((event) => {
               return toolPattern.test(event.data.toolName)

--- a/tests/vally/tag-helpers.ts
+++ b/tests/vally/tag-helpers.ts
@@ -3,7 +3,7 @@
  */
 import type { SystemMessageConfig } from "@github/copilot-sdk";
 import type { AgentMetadata } from "../utils/agent-runner.ts";
-import { isSkillInvoked, getToolCalls, getAllAssistantMessages, argsString } from "../utils/evaluate.ts";
+import { isSkillInvoked, getToolCalls, getAllAssistantMessages, argsString, getToolCallResults } from "../utils/evaluate.ts";
 
 /**
  * When any of the early termination condition is satisfied,
@@ -39,6 +39,17 @@ export type EarlyTerminateCondition = {
    * A regex pattern matching the serialized tool argument.
    */
   argsPattern: string;
+} | {
+  type: "tool-call-result";
+  /**
+   * An optional regex pattern matching the tool name.
+   * When omitted, all tool results are considered.
+   */
+  toolPattern?: string;
+  /**
+   * A regex pattern matching the tool result content.
+   */
+  resultPattern: string;
 };
 
 export type TakeScreenshotCondition = {
@@ -110,6 +121,17 @@ export function getEarlyTerminateCondition(tags: Record<string, string[] | strin
             );
             if (matched) {
               agentMetadata.testComments.push(`Early terminate due to tool call matching pattern: tool ${condition.toolPattern}, args ${condition.argsPattern}`);
+              return true;
+            }
+          } else if (condition.type === "tool-call-result") {
+            const toolPattern = condition.toolPattern ? new RegExp(condition.toolPattern) : undefined;
+            const resultPattern = new RegExp(condition.resultPattern);
+            const matched = getToolCallResults(agentMetadata, toolPattern).some((result) =>
+              resultPattern.test(result)
+            );
+            if (matched) {
+              const toolDesc = condition.toolPattern ? ` (tool: ${condition.toolPattern})` : "";
+              agentMetadata.testComments.push(`Early terminate due to tool call result matching pattern: ${condition.resultPattern}${toolDesc}`);
               return true;
             }
           }

--- a/tests/vally/tag-helpers.ts
+++ b/tests/vally/tag-helpers.ts
@@ -3,7 +3,7 @@
  */
 import type { SystemMessageConfig } from "@github/copilot-sdk";
 import type { AgentMetadata } from "../utils/agent-runner.ts";
-import { isSkillInvoked, getToolCalls, getAllAssistantMessages, argsString, getToolCallResults } from "../utils/evaluate.ts";
+import { isSkillInvoked, getToolCalls, getAllAssistantMessages, argsString } from "../utils/evaluate.ts";
 
 /**
  * When any of the early termination condition is satisfied,
@@ -30,6 +30,9 @@ export type EarlyTerminateCondition = {
    */
   contentPattern: string;
 } | {
+  /**
+   * Terminates when a tool call matching toolPattern and argsPattern is started.
+   */
   type: "tool-call-match";
   /**
    * A regex pattern matching the tool name.
@@ -40,16 +43,18 @@ export type EarlyTerminateCondition = {
    */
   argsPattern: string;
 } | {
+  /**
+   * Terminates when a tool call matching toolPattern and argsPattern has completed (produced a result).
+   */
   type: "tool-call-result";
   /**
-   * An optional regex pattern matching the tool name.
-   * When omitted, all tool results are considered.
+   * A regex pattern matching the tool name.
    */
-  toolPattern?: string;
+  toolPattern: string;
   /**
-   * A regex pattern matching the tool result content.
+   * An optional regex pattern matching the serialized tool argument.
    */
-  resultPattern: string;
+  argsPattern?: string;
 };
 
 export type TakeScreenshotCondition = {
@@ -115,23 +120,30 @@ export function getEarlyTerminateCondition(tags: Record<string, string[] | strin
           } else if (condition.type === "tool-call-match") {
             const toolPattern = new RegExp(condition.toolPattern);
             const argsPattern = new RegExp(condition.argsPattern);
-            const matched = getToolCalls(agentMetadata).some((event) =>
-              toolPattern.test(event.data.toolName)
-              && argsPattern.test(argsString(event))
-            );
+            const matched = getToolCalls(agentMetadata).some((event) => {
+              return toolPattern.test(event.data.toolName)
+                && argsPattern.test(argsString(event));
+            });
             if (matched) {
               agentMetadata.testComments.push(`Early terminate due to tool call matching pattern: tool ${condition.toolPattern}, args ${condition.argsPattern}`);
               return true;
             }
           } else if (condition.type === "tool-call-result") {
-            const toolPattern = condition.toolPattern ? new RegExp(condition.toolPattern) : undefined;
-            const resultPattern = new RegExp(condition.resultPattern);
-            const matched = getToolCallResults(agentMetadata, toolPattern).some((result) =>
-              resultPattern.test(result)
+            const toolPattern = new RegExp(condition.toolPattern);
+            const argsPattern = condition.argsPattern ? new RegExp(condition.argsPattern) : undefined;
+            const completedIds = new Set(
+              agentMetadata.events
+                .filter((event) => { return event.type === "tool.execution_complete"; })
+                .map((event) => { return (event.data as { toolCallId?: string }).toolCallId; })
+                .filter((id): id is string => { return id !== undefined; })
             );
+            const matched = getToolCalls(agentMetadata).some((event) => {
+              return toolPattern.test(event.data.toolName)
+                && (argsPattern === undefined || argsPattern.test(argsString(event)))
+                && completedIds.has(event.data.toolCallId);
+            });
             if (matched) {
-              const toolDesc = condition.toolPattern ? ` (tool: ${condition.toolPattern})` : "";
-              agentMetadata.testComments.push(`Early terminate due to tool call result matching pattern: ${condition.resultPattern}${toolDesc}`);
+              agentMetadata.testComments.push(`Early terminate due to tool call result matching pattern: tool ${condition.toolPattern}, args ${condition.argsPattern ?? "*"}`);
               return true;
             }
           }


### PR DESCRIPTION
## Description

Existing tool-call-match early terminate condition terminates when a matching tool call's execute starts. However, vally's tool-calls grader only look for tool calls that have returned result. The new tool-call-result early terminate condition allows eval suites to terminate runs when an expected tool call got its result so a tool-calls grader can validate it.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
