### PR TITLE
feat: add skill onboarding request issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/skill_extension_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_extension_request.yml
@@ -59,7 +59,7 @@ body:
     id: timeline
     attributes:
       label: Timeline
-      description: Your desired delivery timeline (e.g., November 2025, Q1 2026, TBD).
+      description: Your desired delivery timeline (e.g., Q3 2026, Q4 2026, TBD).
       placeholder: TBD
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/skill_extension_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_extension_request.yml
@@ -1,0 +1,71 @@
+name: Add Capability to an Existing Skill
+description: Partner teams - request adding new capability to an existing skill in the Azure Skills Plugin.
+title: "[Add Capability]: "
+labels:
+  - "onboarding"
+  - "skills"
+  - "needs-triage"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the **Azure Skills Plugin**!
+
+        This repo packages [agent skills](https://agentskills.io/specification) (markdown-based knowledge packages) that teach Copilot how to help customers with Azure services. Use this template to request **extending the capability of an existing skill** (new scenarios, additional MCP tools, broader coverage, etc.).
+
+        > 💡 Extending an existing skill is usually preferred over adding a new one — the char-count budget for skill descriptions is close to the Copilot CLI limit, so adding new skills risks truncation. If you instead need a brand new standalone skill, use the [New Skill Onboarding](https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/new?template=skill_onboarding_request.yml) template.
+        >
+        > Before submitting, please review the [skill authoring guide](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/.github/skills/skill-authoring/SKILL.md) and the [internal skill onboarding guide](https://aka.ms/azure-skills/onboarding).
+
+  - type: input
+    id: existing-skill
+    attributes:
+      label: Existing Skill to Extend
+      description: Which skill do you want to extend? (See `plugin/skills/`.)
+      placeholder: ex. azure-prepare
+    validations:
+      required: true
+
+  - type: input
+    id: contacts
+    attributes:
+      label: Contacts
+      description: List of contacts who own the requested extension.
+      placeholder: ex. Bob Dylan (bdylan)
+    validations:
+      required: true
+
+  - type: textarea
+    id: current-behavior
+    attributes:
+      label: Current Behavior / Gap
+      description: What does the skill do today, and what capability is missing or insufficient?
+      placeholder: Describe the current behavior and the gap you want to close.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scenarios
+    attributes:
+      label: Intended Agent Scenarios
+      description: What new customer scenarios should the extended skill solve? Describe the tasks a user would ask Copilot to do and the value delivered.
+      placeholder: |
+        ex. "Add Redis caching to my existing app and deploy it to Azure"
+        ex. "Configure managed identity for an already-provisioned Container App"
+    validations:
+      required: true
+
+  - type: textarea
+    id: timeline
+    attributes:
+      label: Timeline
+      description: Your desired delivery timeline (e.g., November 2025, Q1 2026, TBD).
+      placeholder: TBD
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Anything else that helps us understand the request - related skills, dependencies, regional considerations, etc.

--- a/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
@@ -15,14 +15,14 @@ body:
 
         > ⚠️ The char-count budget for skill descriptions is close to the Copilot CLI limit. **Adding new skills risks truncation — consider extending an existing skill first.**
         >
-        > Before submitting, please review the [skill authoring guide](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/.github/skills/skill-authoring/SKILL.md) and the [internal skills onboarding guide](https://eng.ms/docs/cloud-ai-platform/devdiv/developer-ai-lukehoban/developer-ai-kvenkatrajan/azure-github-copilot-extension-for-vs-code-backend/github-copilot-for-azure/partnerhub/vscodeext).
+        > Before submitting, please review the [skill authoring guide](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/.github/skills/skill-authoring/SKILL.md) and the [internal skill onboarding guide](https://eng.ms/docs/cloud-ai-platform/devdiv/developer-ai-lukehoban/developer-ai-kvenkatrajan/azure-github-copilot-extension-for-vs-code-backend/github-copilot-for-azure/partnerhub/vscodeext).
 
   - type: input
     id: skill-name
     attributes:
       label: Skill Name
       description: Name of the capability you want to onboard as a skill.
-      placeholder: ex. azure-prepare, azure-deploy
+      placeholder: ex. azure-prepare
     validations:
       required: true
 
@@ -31,7 +31,7 @@ body:
     attributes:
       label: Contacts
       description: List of contacts who own the skill being onboarded.
-      placeholder: ex. Alice Cooper (alcoop), Bob Dylan (bdylan)
+      placeholder: ex. Bob Dylan (bdylan)
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
@@ -1,5 +1,5 @@
 name: Request Skill Onboarding
-description: Partner teams - request onboarding a new skill to the **Azure Skills Plugin**.
+description: Partner teams - request onboarding a new skill to the Azure Skills Plugin.
 title: "[Onboard]: "
 labels:
   - "onboarding"
@@ -60,8 +60,9 @@ body:
       label: Intended Agent Scenarios
       description: What customer scenarios should this skill solve? Describe the tasks a user would ask Copilot to do and the value delivered.
       placeholder: |
-        ex. "Deploy my containerized app to Azure Container Apps"
-        ex. "Diagnose why my container app revision is failing"
+        ex. "Create a web app and deploy it to Azure"
+        ex. "Generate Bicep/Terraform infrastructure for my app and host it on Azure App Service or Container Apps"
+        ex. "Modernize my existing application and add Key Vault and managed identity"
     validations:
       required: true
 

--- a/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
@@ -1,6 +1,6 @@
-name: Request Skill Onboarding
-description: Partner teams - request onboarding a new skill to the Azure Skills Plugin.
-title: "[Onboard]: "
+name: Request New Skill Onboarding
+description: Partner teams - request onboarding a brand new skill to the Azure Skills Plugin.
+title: "[New Skill]: "
 labels:
   - "onboarding"
   - "skills"
@@ -9,19 +9,19 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for your interest in onboarding a skill to the **Azure Skills Plugin**!
+        Thanks for your interest in onboarding a **new skill** to the **Azure Skills Plugin**!
 
-        This repo packages [agent skills](https://agentskills.io/specification) (markdown-based knowledge packages) that teach Copilot how to help customers with Azure services. Use this template to request a new skill or to extend an existing one.
+        This repo packages [agent skills](https://agentskills.io/specification) (markdown-based knowledge packages) that teach Copilot how to help customers with Azure services. Use this template to request a **brand new skill**.
 
-        > ⚠️ The char-count budget for skill descriptions is close to the Copilot CLI limit. **Adding new skills risks truncation — consider extending an existing skill first.**
+        > ⚠️ The char-count budget for skill descriptions is close to the Copilot CLI limit. **Adding new skills risks truncation — if your capability fits an existing skill, please use the [Add Capability to an Existing Skill](https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/new?template=skill_extension_request.yml) template instead.**
         >
-        > Before submitting, please review the [skill authoring guide](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/.github/skills/skill-authoring/SKILL.md) and the [internal skill onboarding guide](https://eng.ms/docs/cloud-ai-platform/devdiv/developer-ai-lukehoban/developer-ai-kvenkatrajan/azure-github-copilot-extension-for-vs-code-backend/github-copilot-for-azure/partnerhub/vscodeext).
+        > Before submitting, please review the [skill authoring guide](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/.github/skills/skill-authoring/SKILL.md) and the [internal skill onboarding guide](https://aka.ms/azure-skills/onboarding).
 
   - type: input
     id: skill-name
     attributes:
       label: Skill Name
-      description: Name of the capability you want to onboard as a skill.
+      description: Proposed name for the new skill (lowercase, hyphens only).
       placeholder: ex. azure-prepare
     validations:
       required: true
@@ -34,25 +34,6 @@ body:
       placeholder: ex. Bob Dylan (bdylan)
     validations:
       required: true
-
-  - type: dropdown
-    id: request-type
-    attributes:
-      label: Request Type
-      description: Are you adding a brand new skill or extending an existing one?
-      options:
-        - New skill
-        - Extend an existing skill
-        - Not sure
-    validations:
-      required: true
-
-  - type: input
-    id: existing-skill
-    attributes:
-      label: Existing Skill to Extend
-      description: If extending an existing skill, which one? (See `plugin/skills/`.)
-      placeholder: ex. azure-prepare
 
   - type: textarea
     id: scenarios

--- a/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
@@ -70,7 +70,7 @@ body:
     id: timeline
     attributes:
       label: Timeline
-      description: Your desired onboarding timeline (e.g., November 2025, Q1 2026, TBD).
+      description: Your desired onboarding timeline (e.g., Q3 2026, Q4 2026, TBD).
       placeholder: TBD
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
+++ b/.github/ISSUE_TEMPLATE/skill_onboarding_request.yml
@@ -1,0 +1,81 @@
+name: Request Skill Onboarding
+description: Partner teams - request onboarding a new skill to the **Azure Skills Plugin**.
+title: "[Onboard]: "
+labels:
+  - "onboarding"
+  - "skills"
+  - "needs-triage"
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for your interest in onboarding a skill to the **Azure Skills Plugin**!
+
+        This repo packages [agent skills](https://agentskills.io/specification) (markdown-based knowledge packages) that teach Copilot how to help customers with Azure services. Use this template to request a new skill or to extend an existing one.
+
+        > ⚠️ The char-count budget for skill descriptions is close to the Copilot CLI limit. **Adding new skills risks truncation — consider extending an existing skill first.**
+        >
+        > Before submitting, please review the [skill authoring guide](https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/main/.github/skills/skill-authoring/SKILL.md) and the [internal skills onboarding guide](https://eng.ms/docs/cloud-ai-platform/devdiv/developer-ai-lukehoban/developer-ai-kvenkatrajan/azure-github-copilot-extension-for-vs-code-backend/github-copilot-for-azure/partnerhub/vscodeext).
+
+  - type: input
+    id: skill-name
+    attributes:
+      label: Skill Name
+      description: Name of the capability you want to onboard as a skill.
+      placeholder: ex. azure-prepare, azure-deploy
+    validations:
+      required: true
+
+  - type: input
+    id: contacts
+    attributes:
+      label: Contacts
+      description: List of contacts who own the skill being onboarded.
+      placeholder: ex. Alice Cooper (alcoop), Bob Dylan (bdylan)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: request-type
+    attributes:
+      label: Request Type
+      description: Are you adding a brand new skill or extending an existing one?
+      options:
+        - New skill
+        - Extend an existing skill
+        - Not sure
+    validations:
+      required: true
+
+  - type: input
+    id: existing-skill
+    attributes:
+      label: Existing Skill to Extend
+      description: If extending an existing skill, which one? (See `plugin/skills/`.)
+      placeholder: ex. azure-prepare
+
+  - type: textarea
+    id: scenarios
+    attributes:
+      label: Intended Agent Scenarios
+      description: What customer scenarios should this skill solve? Describe the tasks a user would ask Copilot to do and the value delivered.
+      placeholder: |
+        ex. "Deploy my containerized app to Azure Container Apps"
+        ex. "Diagnose why my container app revision is failing"
+    validations:
+      required: true
+
+  - type: textarea
+    id: timeline
+    attributes:
+      label: Timeline
+      description: Your desired onboarding timeline (e.g., November 2025, Q1 2026, TBD).
+      placeholder: TBD
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional Context
+      description: Anything else that helps us understand the request - related skills, dependencies, regional considerations, etc.


### PR DESCRIPTION
## Summary

Adds two GitHub issue form templates for partner teams working with the Azure Skills Plugin, splitting the original single form into two clear, focused intents:

1. **Request New Skill Onboarding** (skill_onboarding_request.yml) — request a brand new standalone skill.
2. **Add Capability to an Existing Skill** (skill_extension_request.yml) — request extending an existing skill with new scenarios/coverage.

Both are service-agnostic and modeled on the [Azure MCP onboarding request form](https://github.com/microsoft/mcp/blob/main/.github/ISSUE_TEMPLATE/05_azure_mcp_onboard_request.yml), adapted to this repo's skill-based conventions. They cross-link each other so requesters land on the right form, and both warn that the skill-description char budget is near the Copilot CLI limit — nudging teams to extend an existing skill before adding a new one.

## Templates & Fields

**New Skill Onboarding:** Skill Name · Contacts · Intended Agent Scenarios · Timeline · Additional Context

**Add Capability to an Existing Skill:** Existing Skill to Extend · Contacts · Current Behavior / Gap · Intended Agent Scenarios · Timeline · Additional Context

Each includes links to the authoring and internal onboarding guides.

## Validation
- Both YAML forms parse cleanly
- All field IDs valid (`^[a-zA-Z0-9_-]+$`) and non-duplicate; every field labeled