### PR TITLE
feat: add guardrails reference docs for hosted agent creation

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -214,7 +214,9 @@ This project was built with the microsoft-foundry skill. Before working on or an
 
 Read and follow [local-run](references/local-run.md). Complete one representative local invocation before deploying.
 
-### Step 7 -- Add tools (optional)
+### Step 7 -- Add capabilities (optional)
+
+### Step 7a -- Add tools (optional)
 
 Tools attach through **toolboxes** -- bundled MCP-compatible endpoints.
 
@@ -231,6 +233,10 @@ Flow (only when the user asks you to create the toolbox):
 5. `azd deploy`.
 
 Full recipes (GitHub MCP, Azure AI Search, A2A, Bing Custom) in [tools](references/tools.md).
+
+### Step 7b -- Add guardrails (optional)
+
+Attach a content-safety guardrail to the agent or its toolbox. See [guardrail-manage](references/guardrails/guardrail-manage.md) for creating policies and [guardrail-attach](references/guardrails/guardrail-attach.md) for wiring them to agents, model deployments, or toolboxes.
 
 ### Step 8 -- Hand off to deploy
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -216,6 +216,8 @@ Read and follow [local-run](references/local-run.md). Complete one representativ
 
 ### Step 7 -- Add capabilities (optional)
 
+Optionally add toolboxes (tools) and guardrails (content safety) before deploying.
+
 ### Step 7a -- Add tools (optional)
 
 Tools attach through **toolboxes** -- bundled MCP-compatible endpoints.

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-api-create.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-api-create.md
@@ -27,6 +27,24 @@ az rest --method GET \
 
 ## Step 3: Create a Guardrail
 
+Minimal example — `guardrail-policy.json`:
+
+```json
+{
+  "properties": {
+    "basePolicyName": "Microsoft.DefaultV2",
+    "mode": "Asynchronous_filter",
+    "contentFilters": [
+      { "name": "Hate", "enabled": true, "blocking": true, "severityThreshold": "Medium", "source": "Prompt" },
+      { "name": "Hate", "enabled": true, "blocking": true, "severityThreshold": "Medium", "source": "Completion" },
+      { "name": "Violence", "enabled": true, "blocking": true, "severityThreshold": "Low", "source": "Prompt" },
+      { "name": "Violence", "enabled": true, "blocking": true, "severityThreshold": "Low", "source": "Completion" },
+      { "name": "Jailbreak", "enabled": true, "blocking": true, "source": "Prompt" }
+    ]
+  }
+}
+```
+
 ```bash
 az rest --method PUT \
   --url "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.CognitiveServices/accounts/${ACCOUNT_NAME}/raiPolicies/${POLICY_NAME}?api-version=2024-10-01" \
@@ -36,7 +54,7 @@ az rest --method PUT \
 - `200 OK` — policy updated
 - `201 Created` — policy created for the first time
 
-For the request body schema (`contentFilters[]`, `basePolicyName`, `mode`, `customBlocklists`), see the [RAI Policies - Create Or Update API reference](https://learn.microsoft.com/rest/api/aiservices/accountmanagement/rai-policies/create-or-update).
+For the full request body schema (`contentFilters[]`, `basePolicyName`, `mode`, `customBlocklists`), see the [RAI Policies - Create Or Update API reference](https://learn.microsoft.com/rest/api/aiservices/accountmanagement/rai-policies/create-or-update).
 
 ## Step 4: Verify via CLI
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-api-create.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-api-create.md
@@ -32,7 +32,7 @@ Minimal example — `guardrail-policy.json`:
 ```json
 {
   "properties": {
-    "basePolicyName": "Microsoft.DefaultV2",
+    "basePolicyName": "Microsoft.Default",
     "mode": "Asynchronous_filter",
     "contentFilters": [
       { "name": "Hate", "enabled": true, "blocking": true, "severityThreshold": "Medium", "source": "Prompt" },

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-api-create.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-api-create.md
@@ -1,0 +1,68 @@
+# Create a Guardrail via the REST API (`az rest`)
+
+> Use this path only when the user explicitly asks for programmatic/CLI/CI/CD creation. Otherwise, guide them to the [portal](guardrail-manage.md#default-path-portal).
+
+## Prerequisites
+
+- Azure CLI installed and logged in (`az login`)
+- **Foundry Account Owner** role (or higher) on the Azure AI resource
+- The Azure AI Services account name, resource group, and subscription ID
+
+## Step 1: Set Variables
+
+```bash
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+RESOURCE_GROUP="<your-resource-group>"
+ACCOUNT_NAME="<your-ai-services-account>"
+POLICY_NAME="my-custom-guardrail"
+```
+
+## Step 2: List Existing Guardrails
+
+```bash
+az rest --method GET \
+  --url "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.CognitiveServices/accounts/${ACCOUNT_NAME}/raiPolicies?api-version=2024-10-01"
+```
+
+
+## Step 3: Create a Guardrail
+
+```bash
+az rest --method PUT \
+  --url "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.CognitiveServices/accounts/${ACCOUNT_NAME}/raiPolicies/${POLICY_NAME}?api-version=2024-10-01" \
+  --body @guardrail-policy.json
+```
+
+- `200 OK` — policy updated
+- `201 Created` — policy created for the first time
+
+For the request body schema (`contentFilters[]`, `basePolicyName`, `mode`, `customBlocklists`), see the [RAI Policies - Create Or Update API reference](https://learn.microsoft.com/rest/api/aiservices/accountmanagement/rai-policies/create-or-update).
+
+## Step 4: Verify via CLI
+
+```bash
+az rest --method GET \
+  --url "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.CognitiveServices/accounts/${ACCOUNT_NAME}/raiPolicies/${POLICY_NAME}?api-version=2024-10-01"
+```
+
+Confirm `contentFilters[]` matches your intended configuration.
+
+## Step 5: Assign to Targets
+
+After creating a guardrail, assign it to a hosted agent, model deployment, or toolbox → [guardrail-attach.md](guardrail-attach.md)
+
+## Delete a Guardrail
+
+> Remove all model/agent assignments before deleting (portal: edit guardrail → deselect all targets → save).
+
+```bash
+az rest --method DELETE \
+  --url "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.CognitiveServices/accounts/${ACCOUNT_NAME}/raiPolicies/${POLICY_NAME}?api-version=2024-10-01"
+```
+
+## References
+
+- [RAI Policies - Create Or Update (REST API)](https://learn.microsoft.com/rest/api/aiservices/accountmanagement/rai-policies/create-or-update) — full schema, parameters, response codes
+- [RAI Policies - List](https://learn.microsoft.com/rest/api/aiservices/accountmanagement/rai-policies/list) — list all policies on an account
+- [Blocklists API](https://learn.microsoft.com/rest/api/aiservices/accountmanagement/rai-blocklists) — custom blocklists (created separately)
+- [How to configure guardrails (Microsoft Learn)](https://learn.microsoft.com/azure/foundry/guardrails/how-to-create-guardrails) — portal walkthrough

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-attach.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-attach.md
@@ -12,7 +12,15 @@ After creating a guardrail (via [portal](guardrail-manage.md) or [REST API](guar
 
 A guardrail assigned to an agent **fully overrides** the underlying model deployment's guardrail. If no guardrail is assigned, the agent inherits the model deployment's guardrail.
 
-Add a `policies` block to `agent.yaml` with the guardrail's full ARM resource ID. See the [`16-content-safety-guardrail` sample](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/agent-framework/responses/16-content-safety-guardrail) for the complete `agent.yaml` example.
+Add a `policies` block to `agent.yaml` with the guardrail's full ARM resource ID:
+
+```yaml
+policies:
+  - type: rai_policy
+    rai_policy_name: /subscriptions/<sub-id>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<account>/raiPolicies/<policy-name>
+```
+
+See the [`16-content-safety-guardrail` sample](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/agent-framework/responses/16-content-safety-guardrail) for a complete working example.
 
 > `rai_policy_name` must be the **full ARM resource ID**, not just the policy name. This differs from the toolbox and model deployment paths which use just the name.
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-attach.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-attach.md
@@ -23,6 +23,9 @@ Add a `policies` block to `agent.yaml` with the guardrail's full ARM resource ID
 ### Assign via REST API
 
 ```bash
+SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+RESOURCE_GROUP="<your-resource-group>"
+ACCOUNT_NAME="<your-ai-services-account>"
 DEPLOYMENT_NAME="<your-model-deployment>"
 
 az rest --method PATCH \
@@ -37,6 +40,10 @@ az rest --method PATCH \
 Override the deployment-level guardrail per request using the `x-policy-id` header:
 
 ```bash
+ENDPOINT="https://<your-resource-name>.openai.azure.com"
+DEPLOYMENT_NAME="<your-model-deployment>"
+API_KEY="<your-api-key>"
+
 curl --request POST \
   --url "${ENDPOINT}/openai/deployments/${DEPLOYMENT_NAME}/chat/completions?api-version=2024-10-21" \
   --header "Content-Type: application/json" \

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-attach.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-attach.md
@@ -1,0 +1,88 @@
+# Attach a Guardrail
+
+After creating a guardrail (via [portal](guardrail-manage.md) or [REST API](guardrail-api-create.md)), attach it to one of three targets:
+
+- [Hosted Agent](#hosted-agent) — `agent.yaml` `policies` block
+- [Model Deployment](#model-deployment) — REST API or request-time header
+- [Toolbox](#toolbox) — `policies.rai_config.rai_policy_name` in toolbox definition
+
+---
+
+## Hosted Agent
+
+A guardrail assigned to an agent **fully overrides** the underlying model deployment's guardrail. If no guardrail is assigned, the agent inherits the model deployment's guardrail.
+
+Add a `policies` block to `agent.yaml` with the guardrail's full ARM resource ID. See the [`16-content-safety-guardrail` sample](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/agent-framework/responses/16-content-safety-guardrail) for the complete `agent.yaml` example.
+
+> `rai_policy_name` must be the **full ARM resource ID**, not just the policy name. This differs from the toolbox and model deployment paths which use just the name.
+
+---
+
+## Model Deployment
+
+### Assign via REST API
+
+```bash
+DEPLOYMENT_NAME="<your-model-deployment>"
+
+az rest --method PATCH \
+  --url "https://management.azure.com/subscriptions/${SUBSCRIPTION_ID}/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.CognitiveServices/accounts/${ACCOUNT_NAME}/deployments/${DEPLOYMENT_NAME}?api-version=2024-10-01" \
+  --body '{"properties": {"raiPolicyName": "my-custom-guardrail"}}'
+```
+
+> `raiPolicyName` is the guardrail name (not the full ARM resource ID). It must match a guardrail that exists on the AI Services account.
+
+### Request-Time Override
+
+Override the deployment-level guardrail per request using the `x-policy-id` header:
+
+```bash
+curl --request POST \
+  --url "${ENDPOINT}/openai/deployments/${DEPLOYMENT_NAME}/chat/completions?api-version=2024-10-21" \
+  --header "Content-Type: application/json" \
+  --header "api-key: ${API_KEY}" \
+  --header "x-policy-id: my-custom-guardrail" \
+  --data '{
+    "messages": [
+      {"role": "system", "content": "You are a helpful assistant."},
+      {"role": "user", "content": "Hello!"}
+    ]
+  }'
+```
+
+> Request-time override is not available for image input scenarios.
+
+---
+
+## Toolbox
+
+Add `policies.rai_config.rai_policy_name` to the toolbox definition file, then create the toolbox with `azd ai toolbox create`.
+
+```yaml
+description: My toolbox
+connections:
+  - name: my-mcp-server
+tools:
+  - type: web_search
+    name: web
+policies:
+  rai_config:
+    rai_policy_name: my-custom-guardrail
+```
+
+> `rai_policy_name` must match a guardrail that exists on the AI Services account. Use `Microsoft.Default`, `Microsoft.DefaultV2`, or a custom name created via [portal or API](guardrail-api-create.md).
+
+```bash
+azd ai toolbox create my-toolbox --from-file ./toolbox.yaml
+```
+
+There is no command to change the guardrail on an existing toolbox version. To update, delete and recreate the toolbox.
+
+---
+
+## References
+
+- [Guardrails overview](guardrail-manage.md) — create guardrails, default policies, intervention points
+- [API create](guardrail-api-create.md) — create guardrails via REST API
+- [Guardrails overview (Microsoft Learn)](https://learn.microsoft.com/azure/foundry/guardrails/guardrails-overview)
+- [How to configure guardrails (Microsoft Learn)](https://learn.microsoft.com/azure/foundry/guardrails/how-to-create-guardrails)

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-manage.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/guardrails/guardrail-manage.md
@@ -1,0 +1,58 @@
+# Guardrails (RAI Content-Filter Policies)
+
+Guardrails are Responsible AI (RAI) content-filter policies that control what content is allowed through model deployments and agents in Microsoft Foundry.
+
+## When to Use
+
+- Create or manage a guardrail (content-filter policy) for a Foundry project
+- Attach a guardrail to a hosted agent, model deployment, or toolbox → [guardrail-attach.md](guardrail-attach.md)
+- Create a guardrail via REST API → [guardrail-api-create.md](guardrail-api-create.md)
+
+## Default Path: Portal
+
+By default, guide the user to the Foundry portal to create guardrails interactively.
+
+**Construct and show this URL to the user:**
+
+```
+https://ai.azure.com/nextgen/r/{encodedSubId},{resourceGroup},,{accountName},{projectName}/build/guardrails
+```
+
+Where:
+- `{encodedSubId}` — subscription GUID as URL-safe base64 (no `=` padding):
+  ```bash
+  python -c "import base64,uuid;print(base64.urlsafe_b64encode(uuid.UUID('<SUBSCRIPTION_ID>').bytes).rstrip(b'=').decode())"
+  ```
+- `{resourceGroup}` — resource group name
+- `{accountName}` — AI Services account name
+- `{projectName}` — Foundry project name
+
+If resource details are unknown, use the generic URL and instruct the user to navigate manually:
+
+```
+https://ai.azure.com
+```
+
+Then navigate: select your project → **Build** → **Guardrails** → **Create Guardrail**.
+
+> Use the API path ([guardrail-api-create.md](guardrail-api-create.md)) only when the user explicitly asks for programmatic/CLI/CI/CD creation.
+
+## Intervention Points
+
+| Intervention Point | Models | Agents (Preview) | Toolbox |
+|---|---|---|---|
+| User input | Yes | Yes | No |
+| Tool call | No | Yes | Yes |
+| Tool response | No | Yes | Yes |
+| Output | Yes | Yes | No |
+
+Tool call and tool response are agent-only (and toolbox). An agent's guardrail fully overrides its model deployment's guardrail at all intervention points.
+
+## Default Guardrails
+
+| Policy Name | Description | Editable |
+|-------------|-------------|----------|
+| `Microsoft.Default` | Base default policy (4 categories) | No |
+| `Microsoft.DefaultV2` | Updated default with jailbreak + protected material | No |
+| Custom policies | User-created policies | Yes |
+


### PR DESCRIPTION
## Description
Add three guardrail reference files covering create, attach, and manage workflows. Integrate guardrails as Step 7b in the create-hosted workflow.

- guardrail-manage.md: overview, portal creation, intervention points
- guardrail-api-create.md: create guardrails via REST API (az rest)
- guardrail-attach.md: attach to hosted agent, model deployment, or toolbox

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)


