### PR TITLE
eval: update Copilot SDK to 1.0.5

### DIFF
--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -11,7 +11,7 @@
         "@azure/data-tables": "^13.3.2",
         "@azure/identity": "^4.13.1",
         "@eslint/js": "^10.0.0",
-        "@github/copilot-sdk": "^1.0.1",
+        "@github/copilot-sdk": "^1.0.4",
         "@microsoft/vally-cli": "^0.6.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.9.3",
@@ -989,33 +989,32 @@
       }
     },
     "node_modules/@github/copilot": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.63.tgz",
-      "integrity": "sha512-e8DRYiWJQc4kepVXsXjC8vpDU2FXS/TfR+Z6p/KAojfcwIUZzKMAfCV5D1lD25hV4CryVH1Z9t7mHqChickj0Q==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.67.tgz",
+      "integrity": "sha512-5YEY9LNXBT9Q8uShjCdYcornJJJhGtdIzSYla2+pjfXYpHsDVibqYubzYjfgffOUKFChyzOpH7n/868+t56iIg==",
       "dev": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "detect-libc": "^2.1.2",
-        "os-theme": "^0.0.8"
+        "detect-libc": "^2.1.2"
       },
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "1.0.63",
-        "@github/copilot-darwin-x64": "1.0.63",
-        "@github/copilot-linux-arm64": "1.0.63",
-        "@github/copilot-linux-x64": "1.0.63",
-        "@github/copilot-linuxmusl-arm64": "1.0.63",
-        "@github/copilot-linuxmusl-x64": "1.0.63",
-        "@github/copilot-win32-arm64": "1.0.63",
-        "@github/copilot-win32-x64": "1.0.63"
+        "@github/copilot-darwin-arm64": "1.0.67",
+        "@github/copilot-darwin-x64": "1.0.67",
+        "@github/copilot-linux-arm64": "1.0.67",
+        "@github/copilot-linux-x64": "1.0.67",
+        "@github/copilot-linuxmusl-arm64": "1.0.67",
+        "@github/copilot-linuxmusl-x64": "1.0.67",
+        "@github/copilot-win32-arm64": "1.0.67",
+        "@github/copilot-win32-x64": "1.0.67"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.63.tgz",
-      "integrity": "sha512-z6CMBxNDlKvT6bvOpqhu4M2bhb0daEbVwSe9SN9WfDUJbt7bpoL7OKKas428iyPSWHoL2WXwxSsy/FjIwSLV6w==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.67.tgz",
+      "integrity": "sha512-CO3mpgFXcN6e7ZsSmjMkt1AKxMfb1+mjdn3yrf2DRnnWIURSK9kGvw+E+E1+YE37D1MBiUn/VOBmhRad5+vl0A==",
       "cpu": [
         "arm64"
       ],
@@ -1030,9 +1029,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.63.tgz",
-      "integrity": "sha512-YKd7cXZgAGxhudzrtWdWh2NS35p2G5bV22Gz3jhEyBTqmq45o4sD4OwO87+UpkvM+3nZpwsHaLd3a+ILYX6OXg==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.67.tgz",
+      "integrity": "sha512-M20Hpn3bOJRkVwAIVRK4ZlX66AqtmGfXZRxZBRFQC045QIwcfmVUP45sTSgXDb4uHWeK0cZgdTdniHwKGtMplw==",
       "cpu": [
         "x64"
       ],
@@ -1047,9 +1046,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.63.tgz",
-      "integrity": "sha512-A3DOeEfmsJH9j1N+QLc7WXmESBskbezmhDyhyAJcHkw0ngRbKctuWQf/evUHFMh/kgwy1Lr/+9jXJm3NZqr0MA==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.67.tgz",
+      "integrity": "sha512-b4ePtFBow+Ior+aVLKA1hHxhR5wF+ql5CD7TSg/NHGYgc1kwD+3a9uKSENy05J5Lit/G/DZ9C6JwowvvdMWSKg==",
       "cpu": [
         "arm64"
       ],
@@ -1064,9 +1063,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.63.tgz",
-      "integrity": "sha512-OMKfZJRoDaJOV7vuWX/nFPNdLa9/H+nhajdE83v4YT9mKLXr86aWrkXE3pPoDYsKWvgQFHg4APA6oZPao0Fyow==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.67.tgz",
+      "integrity": "sha512-4ynZyfKnWAdvEPAFDDBIz1wpFttcOTJu4Y8Mlz5oXCBA0NM/rwr8K4l7Adp8UzwbfmdrMJ9y+zivqRBMDbPInA==",
       "cpu": [
         "x64"
       ],
@@ -1081,9 +1080,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-arm64": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.63.tgz",
-      "integrity": "sha512-jcIo6B3uHgcOluNfUHp+6atShKKrXYBPLaRyF6aDT699lwI83gW9KTDuEvDs5FDg8qWsWFfOl+al2dkWDYD3CQ==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-arm64/-/copilot-linuxmusl-arm64-1.0.67.tgz",
+      "integrity": "sha512-IjezxBU8fYUr/b5hEiniXqzwoOrJ4egrQSBbG96M+roLTqd9txP0MgxZtcRtKV7phRIdIGE109wwrn4H6hSqmA==",
       "cpu": [
         "arm64"
       ],
@@ -1098,9 +1097,9 @@
       }
     },
     "node_modules/@github/copilot-linuxmusl-x64": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.63.tgz",
-      "integrity": "sha512-BEdBbEF3fG7VqXzuaAY4JtmbdGSkpJFeb2ZQYaMpq7OP3aS7ssGe1cCX8ehZNegcMM/eb4GC6PXNXsvl3X/PAQ==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linuxmusl-x64/-/copilot-linuxmusl-x64-1.0.67.tgz",
+      "integrity": "sha512-Zy/rbja1lnhzDoNfn051H0EybCseCvjvH7WmbcHCayjXUjzXeKF6OmAt4hvqFZH87ttT3KbKtQ8/6oDUhhM2YQ==",
       "cpu": [
         "x64"
       ],
@@ -1115,13 +1114,13 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.1.tgz",
-      "integrity": "sha512-w6AaS0WqqTE/3iyUrZznvgCLQhsUF7ZmEVCneacuHCfOzlH0r6ww9WUmyA0zgqmXO75V0IYrkIcnFke/qJkkDg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.4.tgz",
+      "integrity": "sha512-c6/gpatP7LAuP9stlc2uXXOrB+TJMFSs3Jrzu9FG8lJJYFGmdzbBvGz2UdL1jww84fp6D7cohEZa4UGq1+iuyA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.61",
+        "@github/copilot": "^1.0.65",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -1130,9 +1129,9 @@
       }
     },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.63.tgz",
-      "integrity": "sha512-7FqUwOmtoeBoOn4zkKQqRL+WGFwektVRSr5Po2FvPAbKxGXGyFXApZTmRLqVcHhMKDRzMb8KLST1LU1TMTY/wg==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.67.tgz",
+      "integrity": "sha512-O3VFRS5v9NXRP8o+N1SvcFbBqECDzZP7XQBeBj2Vcrma80gdJc5GQub/w2mwmr1w5UbwgzJkRasm0Ec/jxbcoA==",
       "cpu": [
         "arm64"
       ],
@@ -1147,9 +1146,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "1.0.63",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.63.tgz",
-      "integrity": "sha512-RC/6y9KHdw/YRCrCEksF2RzbeblfBUNE7bkYZxygaQGYThuv1GeZL2YD2jVqxC2LxKzsUmWGvwEMxerfR6pmeQ==",
+      "version": "1.0.67",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.67.tgz",
+      "integrity": "sha512-td5tQ/nve5dB7RPvNglBZwa/6DJqiOBgacXXa1GpYcohqpCzoI8gONNkeaeyr6oF4iu5wXJ9krUNr6QXL4yB5Q==",
       "cpu": [
         "x64"
       ],
@@ -1161,36 +1160,6 @@
       ],
       "bin": {
         "copilot-win32-x64": "copilot.exe"
-      }
-    },
-    "node_modules/@github/copilot/node_modules/os-theme": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/os-theme/-/os-theme-0.0.8.tgz",
-      "integrity": "sha512-u1q3bLSv5uMHNIiPItkfDrHXu6ZFs2juwqxWREFM/uVBa+7Kkhy2v49LmJev2JcinGwqiEccElB/XsH9gwasuA==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "@os-theme/darwin-arm64": "0.0.8",
-        "@os-theme/linux-x64": "0.0.8",
-        "@os-theme/win32-x64": "0.0.8"
-      },
-      "peerDependencies": {
-        "typescript": "^5"
-      }
-    },
-    "node_modules/@github/copilot/node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "node_modules/@hono/node-server": {
@@ -1804,48 +1773,6 @@
         }
       ],
       "license": "MIT"
-    },
-    "node_modules/@os-theme/darwin-arm64": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@os-theme/darwin-arm64/-/darwin-arm64-0.0.8.tgz",
-      "integrity": "sha512-gMsOs+8Ju396a5yyMWigkbA0dMTxD78U3HzG3mlpiAyn6hfd5dbyI4VGP+sfTB82KGgWLzIhWWTFX5UYY6iX0A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@os-theme/linux-x64": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@os-theme/linux-x64/-/linux-x64-0.0.8.tgz",
-      "integrity": "sha512-zvjmBUiSQPjM1RbhpsfCDYMJxW4eLlGmkFPnpteC/03X2lz6CjiX2hfbN2EWLxXjNnIje3Jqaen8IsqEnWrRBg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@os-theme/win32-x64": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@os-theme/win32-x64/-/win32-x64-0.0.8.tgz",
-      "integrity": "sha512-N3yxKNbVl2IBa/ncDuq55QhwqwUjnYLJxDKMEmYeJbLIV950qZNojPw3scXA6PbfxPZfIiRa8iz1pzNg9XxP8w==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
     },
     "node_modules/@package-json/types": {
       "version": "0.0.12",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -11,7 +11,7 @@
         "@azure/data-tables": "^13.3.2",
         "@azure/identity": "^4.13.1",
         "@eslint/js": "^10.0.0",
-        "@github/copilot-sdk": "^1.0.4",
+        "@github/copilot-sdk": "^1.0.5",
         "@microsoft/vally-cli": "^0.6.0",
         "@types/jest": "^30.0.0",
         "@types/node": "^25.9.3",
@@ -1114,13 +1114,13 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.4.tgz",
-      "integrity": "sha512-c6/gpatP7LAuP9stlc2uXXOrB+TJMFSs3Jrzu9FG8lJJYFGmdzbBvGz2UdL1jww84fp6D7cohEZa4UGq1+iuyA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-1.0.5.tgz",
+      "integrity": "sha512-N6Yk2DcpM9orYXWGBcQs5R0FdiVYrCn7UHQ206cUkfJengKYjgcd3f78BvVB6Dot3j0TvO04FnQ85K9/kbRRag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^1.0.65",
+        "@github/copilot": "^1.0.67",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },

--- a/tests/package.json
+++ b/tests/package.json
@@ -32,7 +32,7 @@
     "@azure/data-tables": "^13.3.2",
     "@azure/identity": "^4.13.1",
     "@eslint/js": "^10.0.0",
-    "@github/copilot-sdk": "^1.0.4",
+    "@github/copilot-sdk": "^1.0.5",
     "@microsoft/vally-cli": "^0.6.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.9.3",

--- a/tests/package.json
+++ b/tests/package.json
@@ -32,7 +32,7 @@
     "@azure/data-tables": "^13.3.2",
     "@azure/identity": "^4.13.1",
     "@eslint/js": "^10.0.0",
-    "@github/copilot-sdk": "^1.0.1",
+    "@github/copilot-sdk": "^1.0.4",
     "@microsoft/vally-cli": "^0.6.0",
     "@types/jest": "^30.0.0",
     "@types/node": "^25.9.3",


### PR DESCRIPTION
## Description

Updates the Copilot SDK dependency used by the test project to version 1.0.5 and refreshes the corresponding package lockfile.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

None.