### PR TITLE
eval: add azure-validate Vally eval suites and update integration tests

### DIFF
--- a/evals/azure-validate/e2e-eval.yaml
+++ b/evals/azure-validate/e2e-eval.yaml
@@ -19,7 +19,7 @@ tags:
   type: integration
   skill: azure-validate
 
-config:
+defaults:
   runs: 1
   timeout: "45m"
   executor: integration-test-agent-runner
@@ -63,7 +63,7 @@ stimuli:
       skill: azure-validate
       followUp:
         - "Continue with recommended options until complete."
-      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
     graders:
       # azure-validate WAS invoked
       - type: skill-invocation
@@ -107,7 +107,7 @@ stimuli:
       skill: azure-validate
       followUp:
         - "Continue with recommended options until complete."
-      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
     graders:
       - type: skill-invocation
         config:
@@ -155,7 +155,7 @@ stimuli:
       skill: azure-validate
       followUp:
         - "Continue with recommended options until complete."
-      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
     graders:
       - type: skill-invocation
         config:
@@ -198,7 +198,7 @@ stimuli:
       skill: azure-validate
       followUp:
         - "Continue with recommended options until complete."
-      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(provision|up|deploy)\\b"}]'
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(provision|up|deploy)\\b"}]'
     graders:
       - type: skill-invocation
         config:
@@ -239,7 +239,7 @@ stimuli:
       skill: azure-validate
       followUp:
         - "Continue with recommended options until complete."
-      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(provision|up|deploy)\\b"}]'
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(provision|up|deploy)\\b"}]'
     graders:
       - type: skill-invocation
         config:

--- a/evals/azure-validate/e2e-eval.yaml
+++ b/evals/azure-validate/e2e-eval.yaml
@@ -1,0 +1,258 @@
+# Vally e2e eval suite for azure-validate
+# Source: tests/azure-validate/integration.test.ts
+# Covers: deployment-validation (3 tests) and brownfield-dotnet-validate (2 tests)
+#
+# earlyTerminate fires on azure-deploy skill call, azd up/deploy command, or
+# validation command (success path — agent ran azd provision).
+# NOTE: earlyTerminate tests must NOT use the `completed` grader.
+
+name: azure-validate-e2e-eval
+description: |
+  End-to-end evaluation suite for the azure-validate skill.
+  Tests:
+  - deployment-validation: agent terminates at validation (not deployment) for
+    whiteboard app, portfolio website, and containerized app scenarios.
+  - brownfield-dotnet-validate: correct azd init flags and env-var injection
+    for .NET Aspire brownfield samples from dotnet/aspire-samples.
+
+tags:
+  type: integration
+  skill: azure-validate
+
+config:
+  runs: 1
+  timeout: "45m"
+  executor: integration-test-agent-runner
+  model: claude-sonnet-4.6
+
+scoring:
+  threshold: 1.0
+
+stimuli:
+
+  # ═══════════════════════════════════════════
+  # deployment-validation
+  # Source: describe("deployment-validation")
+  # The agent should invoke azure-validate (azd provision), NOT azure-deploy.
+  # earlyTerminate fires on the validation command (success), azure-deploy skill
+  # call, or azd up/deploy command (failure paths).
+  # ═══════════════════════════════════════════
+
+  # Jest: "terminates at validation for static whiteboard web app"
+  - name: "Terminates at Validation - Whiteboard App"
+    prompt: "My static whiteboard web app is ready. Please validate and prepare it for Azure deployment using azd."
+    environment:
+      files:
+        - src: fixture/whiteboard/index.html
+          dest: index.html
+        - src: fixture/whiteboard/azure.yaml
+          dest: azure.yaml
+        - src: fixture/whiteboard/infra/main.bicep
+          dest: infra/main.bicep
+        - src: fixture/whiteboard/infra/resources.bicep
+          dest: infra/resources.bicep
+        - src: fixture/whiteboard/infra/main.parameters.json
+          dest: infra/main.parameters.json
+    constraints:
+      max_turns: 50
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: behavior
+      skill: azure-validate
+      followUp:
+        - "Continue with recommended options until complete."
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
+    graders:
+      # azure-validate WAS invoked
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      # validate command WAS called; deploy command was NOT called
+      - type: tool-calls
+        config:
+          required:
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+provision\\b.*--preview|az\\s+deployment\\b.*\\bvalidate\\b|terraform\\s+validate"
+          disallowed:
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+(up|deploy)\\b"
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd provision --no-prompt"
+
+  # Jest: "terminates at validation for static portfolio website"
+  - name: "Terminates at Validation - Portfolio Website"
+    prompt: "My static portfolio website is ready. Please validate and prepare it for Azure deployment using azd."
+    environment:
+      files:
+        - src: fixture/portfolio/index.html
+          dest: index.html
+        - src: fixture/portfolio/azure.yaml
+          dest: azure.yaml
+        - src: fixture/portfolio/infra/main.bicep
+          dest: infra/main.bicep
+        - src: fixture/portfolio/infra/resources.bicep
+          dest: infra/resources.bicep
+        - src: fixture/portfolio/infra/main.parameters.json
+          dest: infra/main.parameters.json
+    constraints:
+      max_turns: 50
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: behavior
+      skill: azure-validate
+      followUp:
+        - "Continue with recommended options until complete."
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      - type: tool-calls
+        config:
+          required:
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+provision\\b.*--preview|az\\s+deployment\\b.*\\bvalidate\\b|terraform\\s+validate"
+          disallowed:
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+(up|deploy)\\b"
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd provision --no-prompt"
+
+  # Jest: "terminates at validation for containerized web app on Container Apps"
+  - name: "Terminates at Validation - Containerized App on Container Apps"
+    prompt: "My containerized web application is ready. Please validate and prepare it for deployment to Azure Container Apps using azd."
+    environment:
+      files:
+        - src: fixture/containerized-app/app.js
+          dest: app.js
+        - src: fixture/containerized-app/package.json
+          dest: package.json
+        - src: fixture/containerized-app/Dockerfile
+          dest: Dockerfile
+        - src: fixture/containerized-app/azure.yaml
+          dest: azure.yaml
+        - src: fixture/containerized-app/infra/main.bicep
+          dest: infra/main.bicep
+        - src: fixture/containerized-app/infra/abbreviations.json
+          dest: infra/abbreviations.json
+        - src: fixture/containerized-app/infra/resources.bicep
+          dest: infra/resources.bicep
+        - src: fixture/containerized-app/infra/main.parameters.json
+          dest: infra/main.parameters.json
+    constraints:
+      max_turns: 50
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: behavior
+      skill: azure-validate
+      followUp:
+        - "Continue with recommended options until complete."
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      - type: tool-calls
+        config:
+          required:
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+provision\\b.*--preview|az\\s+deployment\\b.*\\bvalidate\\b|terraform\\s+validate"
+          disallowed:
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+(up|deploy)\\b"
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd provision --no-prompt"
+
+  # ═══════════════════════════════════════════
+  # brownfield-dotnet-validate
+  # Source: describe("brownfield-dotnet-validate")
+  # ═══════════════════════════════════════════
+
+  # Jest: "passes --environment on azd init and sets subscription before provision"
+  - name: "Brownfield - azd init with --environment and subscription"
+    prompt: "Please deploy this application to Azure using azd. Use the eastus2 region. Use my current subscription. This is for a small scale production environment. Use standard SKUs. The app can be found under samples/client-apps-integration."
+    environment:
+      commands:
+        - git init -q
+        - git remote add origin https://github.com/dotnet/aspire-samples
+        - git sparse-checkout init --cone
+        - git fetch -q --depth 1 origin main
+        - git sparse-checkout set samples/client-apps-integration
+        - git checkout -q FETCH_HEAD
+    constraints:
+      max_turns: 50
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: behavior
+      skill: azure-validate
+      followUp:
+        - "Continue with recommended options until complete."
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(provision|up|deploy)\\b"}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      # azd init must include --environment (-e) flag
+      - type: tool-calls
+        config:
+          required:
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+init\\b.*(-e|--environment)\\s+\\S+"
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+env\\s+set\\s+AZURE_SUBSCRIPTION_ID\\s+\\S+"
+          disallowed:
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+(up|deploy)\\b"
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd provision --no-prompt"
+
+  # Jest: "sets AzureWebJobsSecretStorageType for aspire-with-azure-functions"
+  - name: "Brownfield - AzureWebJobsSecretStorageType for Aspire Functions"
+    prompt: "Please deploy this application to Azure using azd. Use the eastus2 region. Use my current subscription. This is for a small scale production environment. Use standard SKUs. The app can be found under samples/aspire-with-azure-functions."
+    environment:
+      commands:
+        - git init -q
+        - git remote add origin https://github.com/dotnet/aspire-samples
+        - git sparse-checkout init --cone
+        - git fetch -q --depth 1 origin main
+        - git sparse-checkout set samples/aspire-with-azure-functions
+        - git checkout -q FETCH_HEAD
+    constraints:
+      max_turns: 50
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: behavior
+      skill: azure-validate
+      followUp:
+        - "Continue with recommended options until complete."
+      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|run_in_terminal","argsPattern":"azd\\s+(provision|up|deploy)\\b"}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      # Agent must edit AppHost.cs to add AzureWebJobsSecretStorageType
+      - type: file-matches
+        config:
+          path: "**/AppHost.cs"
+          pattern: "(?i)AzureWebJobsSecretStorageType"
+      # Deploy command must NOT have run
+      - type: tool-calls
+        config:
+          disallowed:
+            - name: "(?i)^(bash|powershell|pwsh)$"
+              command: "(?i)azd\\s+(provision|up|deploy)\\b"

--- a/evals/azure-validate/e2e-eval.yaml
+++ b/evals/azure-validate/e2e-eval.yaml
@@ -70,6 +70,8 @@ stimuli:
         config:
           required:
             - azure-validate
+          disallowed:
+            - azure-deploy
       # validate command WAS called; deploy command was NOT called
       - type: tool-calls
         config:
@@ -113,6 +115,8 @@ stimuli:
         config:
           required:
             - azure-validate
+          disallowed:
+            - azure-deploy
       - type: tool-calls
         config:
           required:
@@ -161,6 +165,8 @@ stimuli:
         config:
           required:
             - azure-validate
+          disallowed:
+            - azure-deploy
       - type: tool-calls
         config:
           required:

--- a/evals/azure-validate/e2e-eval.yaml
+++ b/evals/azure-validate/e2e-eval.yaml
@@ -63,7 +63,7 @@ stimuli:
       skill: azure-validate
       followUp:
         - "Continue with recommended options until complete."
-      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-deploy"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
     graders:
       # azure-validate WAS invoked
       - type: skill-invocation
@@ -107,7 +107,7 @@ stimuli:
       skill: azure-validate
       followUp:
         - "Continue with recommended options until complete."
-      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-deploy"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
     graders:
       - type: skill-invocation
         config:
@@ -155,7 +155,7 @@ stimuli:
       skill: azure-validate
       followUp:
         - "Continue with recommended options until complete."
-      earlyTerminate: '[{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-deploy"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd\\s+(up|deploy)\\b"},{"type":"tool-call-match","toolPattern":"bash|powershell|pwsh|run_in_terminal","argsPattern":"azd provision --no-prompt"}]'
     graders:
       - type: skill-invocation
         config:
@@ -255,4 +255,4 @@ stimuli:
         config:
           disallowed:
             - name: "(?i)^(bash|powershell|pwsh)$"
-              command: "(?i)azd\\s+(provision|up|deploy)\\b"
+              command: "(?i)azd\\s+(up|deploy)\\b"

--- a/evals/azure-validate/fixture/containerized-app/Dockerfile
+++ b/evals/azure-validate/fixture/containerized-app/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --omit=dev
+COPY . .
+EXPOSE 3000
+CMD ["node", "app.js"]

--- a/evals/azure-validate/fixture/containerized-app/app.js
+++ b/evals/azure-validate/fixture/containerized-app/app.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get("/", (req, res) => {
+  res.send("<h1>Hello from containerized web app</h1>");
+});
+
+app.get("/health", (req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/evals/azure-validate/fixture/containerized-app/azure.yaml
+++ b/evals/azure-validate/fixture/containerized-app/azure.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: containerized-web-app
+services:
+  web:
+    project: .
+    host: containerapp
+    docker:
+      path: ./Dockerfile
+infra:
+  provider: bicep

--- a/evals/azure-validate/fixture/containerized-app/infra/abbreviations.json
+++ b/evals/azure-validate/fixture/containerized-app/infra/abbreviations.json
@@ -1,0 +1,6 @@
+{
+  "containerRegistries": "cr",
+  "managedEnvironments": "cae",
+  "containerApps": "ca",
+  "userAssignedIdentities": "id"
+}

--- a/evals/azure-validate/fixture/containerized-app/infra/main.bicep
+++ b/evals/azure-validate/fixture/containerized-app/infra/main.bicep
@@ -1,0 +1,37 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the environment that can be used as part of naming resource convention')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources')
+param location string
+
+var tags = { 'azd-env-name': environmentName }
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+var abbrs = loadJsonContent('./abbreviations.json')
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module containerApps './resources.bicep' = {
+  name: 'containerApps'
+  scope: rg
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+    abbrs: abbrs
+  }
+}
+
+output AZURE_LOCATION string = location
+output AZURE_TENANT_ID string = tenant().tenantId
+output AZURE_RESOURCE_GROUP string = rg.name
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerApps.outputs.AZURE_CONTAINER_REGISTRY_ENDPOINT
+output WEB_URL string = containerApps.outputs.WEB_URL

--- a/evals/azure-validate/fixture/containerized-app/infra/main.parameters.json
+++ b/evals/azure-validate/fixture/containerized-app/infra/main.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    }
+  }
+}

--- a/evals/azure-validate/fixture/containerized-app/infra/resources.bicep
+++ b/evals/azure-validate/fixture/containerized-app/infra/resources.bicep
@@ -1,0 +1,74 @@
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+param tags object = {}
+param resourceToken string
+param abbrs object
+
+resource userIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: '${abbrs.userAssignedIdentities}${resourceToken}'
+  location: location
+  tags: tags
+}
+
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-01-01-preview' = {
+  name: '${abbrs.containerRegistries}${resourceToken}'
+  location: location
+  tags: tags
+  sku: { name: 'Basic' }
+  properties: { adminUserEnabled: false }
+}
+
+resource roleAcrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(containerRegistry.id, userIdentity.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d'))
+  scope: containerRegistry
+  properties: {
+    principalId: userIdentity.properties.principalId
+    principalType: 'ServicePrincipal'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  }
+}
+
+resource containerAppsEnv 'Microsoft.App/managedEnvironments@2023-05-01' = {
+  name: '${abbrs.managedEnvironments}${resourceToken}'
+  location: location
+  tags: tags
+  properties: {}
+}
+
+resource containerApp 'Microsoft.App/containerApps@2023-05-01' = {
+  name: '${abbrs.containerApps}${resourceToken}'
+  location: location
+  tags: union(tags, { 'azd-service-name': 'web' })
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${userIdentity.id}': {} }
+  }
+  properties: {
+    managedEnvironmentId: containerAppsEnv.id
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 3000
+      }
+      registries: [
+        {
+          server: containerRegistry.properties.loginServer
+          identity: userIdentity.id
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'web'
+          image: '${containerRegistry.properties.loginServer}/web:latest'
+          resources: { cpu: json('0.5'), memory: '1Gi' }
+        }
+      ]
+    }
+  }
+}
+
+output AZURE_CONTAINER_REGISTRY_ENDPOINT string = containerRegistry.properties.loginServer
+output WEB_URL string = 'https://${containerApp.properties.configuration.ingress.fqdn}'

--- a/evals/azure-validate/fixture/containerized-app/package.json
+++ b/evals/azure-validate/fixture/containerized-app/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "containerized-web-app",
+  "version": "1.0.0",
+  "main": "app.js",
+  "scripts": { "start": "node app.js" },
+  "dependencies": { "express": "^4.18.2" }
+}

--- a/evals/azure-validate/fixture/portfolio/azure.yaml
+++ b/evals/azure-validate/fixture/portfolio/azure.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: portfolio-site
+services:
+  web:
+    project: .
+    language: js
+    host: staticwebapp
+infra:
+  provider: bicep

--- a/evals/azure-validate/fixture/portfolio/index.html
+++ b/evals/azure-validate/fixture/portfolio/index.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>My Portfolio</title><style>
+  body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 2rem; }
+  h1 { color: #333; }
+  .project { border: 1px solid #ddd; padding: 1rem; margin: 1rem 0; border-radius: 4px; }
+</style></head>
+<body>
+  <h1>Jane Doe — Developer Portfolio</h1>
+  <section>
+    <h2>Projects</h2>
+    <div class="project"><h3>Project Alpha</h3><p>A web application built with Node.js and React.</p></div>
+    <div class="project"><h3>Project Beta</h3><p>Data pipeline using Python and Azure Functions.</p></div>
+  </section>
+  <section><h2>Contact</h2><p>jane@example.com</p></section>
+</body>
+</html>

--- a/evals/azure-validate/fixture/portfolio/infra/main.bicep
+++ b/evals/azure-validate/fixture/portfolio/infra/main.bicep
@@ -1,0 +1,32 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the environment that can be used as part of naming resource convention')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources')
+param location string
+
+var tags = { 'azd-env-name': environmentName }
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module web './resources.bicep' = {
+  name: 'web'
+  scope: rg
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+  }
+}
+
+output AZURE_LOCATION string = location
+output AZURE_TENANT_ID string = tenant().tenantId

--- a/evals/azure-validate/fixture/portfolio/infra/main.parameters.json
+++ b/evals/azure-validate/fixture/portfolio/infra/main.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    }
+  }
+}

--- a/evals/azure-validate/fixture/portfolio/infra/resources.bicep
+++ b/evals/azure-validate/fixture/portfolio/infra/resources.bicep
@@ -1,0 +1,18 @@
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+param tags object = {}
+param resourceToken string
+
+resource staticWebApp 'Microsoft.Web/staticSites@2022-09-01' = {
+  name: 'swa-${resourceToken}'
+  location: location
+  tags: union(tags, { 'azd-service-name': 'web' })
+  sku: {
+    name: 'Free'
+    tier: 'Free'
+  }
+  properties: {}
+}
+
+output STATIC_WEB_APP_URL string = staticWebApp.properties.defaultHostname

--- a/evals/azure-validate/fixture/whiteboard/azure.yaml
+++ b/evals/azure-validate/fixture/whiteboard/azure.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/Azure/azure-dev/main/schemas/v1.0/azure.yaml.json
+
+name: whiteboard-app
+services:
+  web:
+    project: .
+    language: js
+    host: staticwebapp
+infra:
+  provider: bicep

--- a/evals/azure-validate/fixture/whiteboard/index.html
+++ b/evals/azure-validate/fixture/whiteboard/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Whiteboard</title><style>
+  body { margin: 0; }
+  canvas { display: block; cursor: crosshair; }
+</style></head>
+<body>
+<canvas id="board"></canvas>
+<script>
+  const canvas = document.getElementById("board");
+  const ctx = canvas.getContext("2d");
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+  let drawing = false;
+  canvas.addEventListener("mousedown", e => { drawing = true; ctx.beginPath(); ctx.moveTo(e.clientX, e.clientY); });
+  canvas.addEventListener("mousemove", e => { if (!drawing) return; ctx.lineTo(e.clientX, e.clientY); ctx.stroke(); });
+  canvas.addEventListener("mouseup", () => drawing = false);
+</script>
+</body>
+</html>

--- a/evals/azure-validate/fixture/whiteboard/infra/main.bicep
+++ b/evals/azure-validate/fixture/whiteboard/infra/main.bicep
@@ -1,0 +1,32 @@
+targetScope = 'subscription'
+
+@minLength(1)
+@maxLength(64)
+@description('Name of the environment that can be used as part of naming resource convention')
+param environmentName string
+
+@minLength(1)
+@description('Primary location for all resources')
+param location string
+
+var tags = { 'azd-env-name': environmentName }
+var resourceToken = toLower(uniqueString(subscription().id, environmentName, location))
+
+resource rg 'Microsoft.Resources/resourceGroups@2022-09-01' = {
+  name: 'rg-${environmentName}'
+  location: location
+  tags: tags
+}
+
+module web './resources.bicep' = {
+  name: 'web'
+  scope: rg
+  params: {
+    location: location
+    tags: tags
+    resourceToken: resourceToken
+  }
+}
+
+output AZURE_LOCATION string = location
+output AZURE_TENANT_ID string = tenant().tenantId

--- a/evals/azure-validate/fixture/whiteboard/infra/main.parameters.json
+++ b/evals/azure-validate/fixture/whiteboard/infra/main.parameters.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "environmentName": {
+      "value": "${AZURE_ENV_NAME}"
+    },
+    "location": {
+      "value": "${AZURE_LOCATION}"
+    }
+  }
+}

--- a/evals/azure-validate/fixture/whiteboard/infra/resources.bicep
+++ b/evals/azure-validate/fixture/whiteboard/infra/resources.bicep
@@ -1,0 +1,18 @@
+@description('Location for all resources')
+param location string = resourceGroup().location
+
+param tags object = {}
+param resourceToken string
+
+resource staticWebApp 'Microsoft.Web/staticSites@2022-09-01' = {
+  name: 'swa-${resourceToken}'
+  location: location
+  tags: union(tags, { 'azd-service-name': 'web' })
+  sku: {
+    name: 'Free'
+    tier: 'Free'
+  }
+  properties: {}
+}
+
+output STATIC_WEB_APP_URL string = staticWebApp.properties.defaultHostname

--- a/evals/azure-validate/routing-eval.yaml
+++ b/evals/azure-validate/routing-eval.yaml
@@ -1,0 +1,177 @@
+# Vally eval config — migrated from Jest integration tests
+# Source: tests/azure-validate/integration.test.ts
+# Migration: Jest skill-invocation tests → Vally routing stimuli
+#
+# Stimuli with earlyTerminate tags do not use the completed grader.
+
+name: azure-validate-routing-eval
+description: |
+  Integration evaluation for azure-validate skill — migrated from Jest skill-invocation tests.
+  Tests routing for Azure Validate prompts using invocation rate measurement.
+
+tags:
+  type: integration
+  skill: azure-validate
+
+config:
+  runs: 5
+  timeout: "10m"
+  executor: integration-test-agent-runner
+  model: claude-sonnet-4.6
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  # ═══════════════════════════════════════════
+  # Skill routing prompts
+  # ═══════════════════════════════════════════
+# Jest: "invokes azure-validate skill for deployment readiness check"
+  - name: "Deployment Readiness Check"
+    prompt: "Check if my azd app is ready to deploy to Azure"
+    environment:
+      commands:
+        - git init -q
+        - git remote add origin https://github.com/Azure-Samples/azd-starter-bicep
+        - git fetch -q --depth 1 origin main
+        - git checkout -q FETCH_HEAD -- .
+    tags:
+      type: integration
+      tier: smoke
+      cost: llm
+      area: routing
+      skill: azure-validate
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-validate"},{"type":"tool-call-count","count":10}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # Jest: "invokes azure-validate skill for azure.yaml validation prompt"
+  - name: "Azure.Yaml Validation"
+    prompt: "Validate my azure.yaml configuration before deploying"
+    environment:
+      commands:
+        - git init -q
+        - git remote add origin https://github.com/Azure-Samples/azd-starter-bicep
+        - git fetch -q --depth 1 origin main
+        - git checkout -q FETCH_HEAD -- .
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: routing
+      skill: azure-validate
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-validate"},{"type":"tool-call-count","count":10}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # Jest: "invokes azure-validate skill for Bicep validation prompt"
+  - name: "Bicep Validation"
+    prompt: "Validate my Bicep template for my azd project before deploying to Azure"
+    environment:
+      commands:
+        - git init -q
+        - git remote add origin https://github.com/Azure-Samples/azd-starter-bicep
+        - git fetch -q --depth 1 origin main
+        - git checkout -q FETCH_HEAD -- .
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: routing
+      skill: azure-validate
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-validate"},{"type":"tool-call-count","count":10}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # Jest: "invokes azure-validate skill for what-if analysis prompt"
+  - name: "What-If Analysis"
+    prompt: "Run a what-if analysis to preview changes before deploying my azd infrastructure"
+    environment:
+      commands:
+        - git init -q
+        - git remote add origin https://github.com/Azure-Samples/azd-starter-bicep
+        - git fetch -q --depth 1 origin main
+        - git checkout -q FETCH_HEAD -- .
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: routing
+      skill: azure-validate
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-validate"},{"type":"tool-call-count","count":10}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # Jest: "invokes azure-validate skill for RBAC role verification prompt"
+  - name: "RBAC Role Verification"
+    prompt: "Verify the RBAC role assignments in my Bicep templates for my azd project before deploying to Azure"
+    environment:
+      commands:
+        - git init -q
+        - git remote add origin https://github.com/Azure-Samples/functions-quickstart-dotnet-azd
+        - git fetch -q --depth 1 origin main
+        - git checkout -q FETCH_HEAD -- .
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: routing
+      skill: azure-validate
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-validate"},{"type":"tool-call-count","count":10}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # Jest: "invokes azure-validate skill for managed identity permissions check prompt"
+  - name: "Managed Identity Permissions Check"
+    prompt: "Validate the managed identity RBAC role assignments in my Bicep templates for my azd project before deploying to Azure"
+    environment:
+      commands:
+        - git init -q
+        - git remote add origin https://github.com/Azure-Samples/functions-quickstart-dotnet-azd
+        - git fetch -q --depth 1 origin main
+        - git checkout -q FETCH_HEAD -- .
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: routing
+      skill: azure-validate
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-validate"},{"type":"tool-call-count","count":10}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-validate
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"

--- a/evals/azure-validate/routing-eval.yaml
+++ b/evals/azure-validate/routing-eval.yaml
@@ -13,7 +13,7 @@ tags:
   type: integration
   skill: azure-validate
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/tests/azure-validate/integration.test.ts
+++ b/tests/azure-validate/integration.test.ts
@@ -20,11 +20,9 @@ import {
   matchesFileEdit,
 } from "./utils";
 import { cloneRepo } from "../utils/git-clone";
-import { matchesCommand, softCheckSkill, isSkillInvoked, shouldEarlyTerminateForSkillInvocation, withTestResult } from "../utils/evaluate";
+import { matchesCommand, isSkillInvoked, withTestResult } from "../utils/evaluate";
 
 const SKILL_NAME = "azure-validate";
-const RUNS_PER_PROMPT = 1;
-const invocationRateThreshold = 0.8;
 const aspireEnvVarTestTimeoutMs = 2700000; // 45 minutes
 
 // Check if integration tests should be skipped at module level
@@ -44,123 +42,12 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     useJest: true
   });
 
-  describe("skill-invocation", () => {
-    test("invokes azure-validate skill for deployment readiness check", () => withTestResult(async ({ setSkillInvocationRate }) => {
-      let invocationCount = 0;
-      for (let i = 0; i < RUNS_PER_PROMPT; i++) {
-        const agentMetadata = await agent.run({
-          prompt: "Check if my app is ready to deploy to Azure",
-          shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
-        });
-
-        softCheckSkill(agentMetadata, SKILL_NAME);
-        if (isSkillInvoked(agentMetadata, SKILL_NAME)) {
-          invocationCount += 1;
-        }
-      }
-      const rate = invocationCount / RUNS_PER_PROMPT;
-      setSkillInvocationRate(rate);
-      expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-    }));
-
-    test("invokes azure-validate skill for azure.yaml validation prompt", () => withTestResult(async ({ setSkillInvocationRate }) => {
-      let invocationCount = 0;
-      for (let i = 0; i < RUNS_PER_PROMPT; i++) {
-        const agentMetadata = await agent.run({
-          prompt: "Validate my azure.yaml configuration before deploying",
-          shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
-        });
-
-        softCheckSkill(agentMetadata, SKILL_NAME);
-        if (isSkillInvoked(agentMetadata, SKILL_NAME)) {
-          invocationCount += 1;
-        }
-      }
-      const rate = invocationCount / RUNS_PER_PROMPT;
-      setSkillInvocationRate(rate);
-      expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-    }));
-
-    // Preflight validation tests (formerly azure-deployment-preflight)
-    test("invokes azure-validate skill for Bicep validation prompt", () => withTestResult(async ({ setSkillInvocationRate }) => {
-      let invocationCount = 0;
-      for (let i = 0; i < RUNS_PER_PROMPT; i++) {
-        const agentMetadata = await agent.run({
-          prompt: "Validate my Bicep template before deploying to Azure",
-          shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
-        });
-
-        softCheckSkill(agentMetadata, SKILL_NAME);
-        if (isSkillInvoked(agentMetadata, SKILL_NAME)) {
-          invocationCount += 1;
-        }
-      }
-      const rate = invocationCount / RUNS_PER_PROMPT;
-      setSkillInvocationRate(rate);
-      expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-    }));
-
-    test("invokes azure-validate skill for what-if analysis prompt", () => withTestResult(async ({ setSkillInvocationRate }) => {
-      let invocationCount = 0;
-      for (let i = 0; i < RUNS_PER_PROMPT; i++) {
-        const agentMetadata = await agent.run({
-          prompt: "Run a what-if analysis to preview changes before deploying my infrastructure",
-          shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
-        });
-
-        softCheckSkill(agentMetadata, SKILL_NAME);
-        if (isSkillInvoked(agentMetadata, SKILL_NAME)) {
-          invocationCount += 1;
-        }
-      }
-      const rate = invocationCount / RUNS_PER_PROMPT;
-      setSkillInvocationRate(rate);
-      expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-    }));
-
-    test("invokes azure-validate skill for RBAC role verification prompt", () => withTestResult(async ({ setSkillInvocationRate }) => {
-      let invocationCount = 0;
-      for (let i = 0; i < RUNS_PER_PROMPT; i++) {
-        const agentMetadata = await agent.run({
-          prompt: "Verify the RBAC role assignments in my Bicep templates before deploying to Azure",
-          shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
-        });
-
-        softCheckSkill(agentMetadata, SKILL_NAME);
-        if (isSkillInvoked(agentMetadata, SKILL_NAME)) {
-          invocationCount += 1;
-        }
-      }
-      const rate = invocationCount / RUNS_PER_PROMPT;
-      setSkillInvocationRate(rate);
-      expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-    }));
-
-    test("invokes azure-validate skill for managed identity permissions check prompt", () => withTestResult(async ({ setSkillInvocationRate }) => {
-      let invocationCount = 0;
-      for (let i = 0; i < RUNS_PER_PROMPT; i++) {
-        const agentMetadata = await agent.run({
-          prompt: "Validate the managed identity RBAC role assignments in my Bicep templates before deploying to Azure",
-          shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
-        });
-
-        softCheckSkill(agentMetadata, SKILL_NAME);
-        if (isSkillInvoked(agentMetadata, SKILL_NAME)) {
-          invocationCount += 1;
-        }
-      }
-      const rate = invocationCount / RUNS_PER_PROMPT;
-      setSkillInvocationRate(rate);
-      expect(rate).toBeGreaterThanOrEqual(invocationRateThreshold);
-    }));
-  });
-
   describe("deployment-validation", () => {
     const FOLLOW_UP_PROMPT = ["Continue with recommended options until complete."];
 
     test("terminates at validation for static whiteboard web app", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        prompt: "Create a static whiteboard web app and deploy to Azure.",
+        prompt: "My static whiteboard web app is ready. Please validate and prepare it for Azure deployment using azd.",
         nonInteractive: true,
         followUp: FOLLOW_UP_PROMPT,
         shouldEarlyTerminate: (metadata) =>
@@ -181,7 +68,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
     test("terminates at validation for static portfolio website", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        prompt: "Create a static portfolio website and deploy to Azure.",
+        prompt: "My static portfolio website is ready. Please validate and prepare it for Azure deployment using azd.",
         nonInteractive: true,
         followUp: FOLLOW_UP_PROMPT,
         shouldEarlyTerminate: (metadata) =>
@@ -202,7 +89,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
 
     test("terminates at validation for containerized web app on Container Apps", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        prompt: "Create a containerized web application and deploy to Azure Container Apps.",
+        prompt: "My containerized web application is ready. Please validate and prepare it for deployment to Azure Container Apps using azd.",
         nonInteractive: true,
         followUp: FOLLOW_UP_PROMPT,
         shouldEarlyTerminate: (metadata) =>


### PR DESCRIPTION
## Description

Syncs azure-validate test changes from microsoft/GitHub-Copilot-for-Azure#2706:

- Add `evals/azure-validate/e2e-eval.yaml` with `deployment-validation` and
  `brownfield-dotnet-validate` Vally stimuli migrated from Jest integration tests
- Add `evals/azure-validate/routing-eval.yaml` with 6 routing stimuli migrated
  from the `skill-invocation` Jest describe block
- Add fixture files for whiteboard, portfolio, and containerized-app scenarios
  used by the e2e eval environment seeding
- Update `tests/azure-validate/integration.test.ts`:
  - Remove `skill-invocation` describe block (migrated to `routing-eval.yaml`)
  - Remove unused imports (`softCheckSkill`, `shouldEarlyTerminateForSkillInvocation`)
  - Update `deployment-validation` prompts to match the pre-seeded fixture context

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests

## Related Issues

Synced from microsoft/GitHub-Copilot-for-Azure#2706