### PR TITLE
eval: fix early terminate in agent runner

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -958,8 +958,13 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
               );
               isComplete = true;
               isAborted = true;
-              await session.abort();
-              resolve();
+              try {
+                await session.abort();
+              } catch (error) {
+                console.error(`session.abort failed ${error instanceof Error ? error.message : String(error)}`);
+              } finally {
+                resolve();
+              }
               return;
             }
           }
@@ -967,8 +972,13 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
           if (runConfig.shouldEarlyTerminate?.(agentMetadata)) {
             isComplete = true;
             isAborted = true;
-            await session.abort();
-            resolve();
+            try {
+              await session.abort();
+            } catch (error) {
+              console.error(`session.abort failed ${error instanceof Error ? error.message : String(error)}`);
+            } finally {
+              resolve();
+            }
             return;
           }
         });

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -958,8 +958,8 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
               );
               isComplete = true;
               isAborted = true;
+              await session.abort();
               resolve();
-              void session.abort();
               return;
             }
           }
@@ -967,8 +967,8 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
           if (runConfig.shouldEarlyTerminate?.(agentMetadata)) {
             isComplete = true;
             isAborted = true;
+            await session.abort();
             resolve();
-            void session.abort();
             return;
           }
         });


### PR DESCRIPTION
## Description

The calls to session.abort() starts throwing session not found error for unclear reason after upgrading to Copilot SDK 1.0.5. This PR fixes the issue by writing the code in a way that is less subject to potential Promise timing issues. When Promise.resolve() is called, it immediately starts executing its thenables, which in our case, involves calling `session.disconnect()`. `session.abort` is an asynchronous function. Its JS comment clearly says it will throw if `session.disconnect()` has been called before it. Copilot SDK 1.0.5 may have introduced changes causing it to yield at some point and letting the session.disconnect() to go through.

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
