### PR TITLE
feat: support foundry routine and add it as a sub-skill

### DIFF
--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -25,7 +25,7 @@ This skill includes specialized sub-skills for specific workflows. **Use these i
 |-----------|-------------|-----------|
 | **deploy** | Deploy hosted agents to Foundry, smoke-test a deployment, create or update prompt agents, and manage agent versions and multi-environment deploys. | [deploy](foundry-agent/deploy/deploy.md) |
 | **invoke** | Send messages to an agent, single or multi-turn conversations | [invoke](foundry-agent/invoke/invoke.md) |
-| **routine** | Schedule or event-drive an agent with azd — create/read/update/delete Foundry **routines** (timer, recurring cron, GitHub issue, custom event) via `azd ai routine`, plus enable/disable/dispatch/run history and declarative `host: azure.ai.routine` services in `azure.yaml`. All operations go through azd. | [routine](foundry-agent/routine/routine.md) |
+| **routine** | Schedule or event-trigger Foundry agents with routines; use `azd ai routine` for CRUD, enable/disable, manual dispatch, and viewing past runs, or define routines in `azure.yaml`. | [routine](foundry-agent/routine/routine.md) |
 | **invocations-ws** | Build, deploy, and connect to hosted agents that speak the `invocations_ws` duplex WebSocket protocol — voice agents, real-time streams, and signaling for out-of-band media transports. | [invocations-ws](foundry-agent/invocations-ws/invocations-ws.md) |
 | **observe** | Evaluate agent quality, run batch evals, analyze failures, optimize prompts, improve agent instructions, compare versions, set up CI/CD monitoring, and enable continuous production evaluation | [observe](foundry-agent/observe/observe.md) |
 | **trace** | Query traces, analyze latency/failures, correlate eval results to specific responses via App Insights `customEvents` | [trace](foundry-agent/trace/trace.md) |

--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -25,7 +25,7 @@ This skill includes specialized sub-skills for specific workflows. **Use these i
 |-----------|-------------|-----------|
 | **deploy** | Deploy hosted agents to Foundry, smoke-test a deployment, create or update prompt agents, and manage agent versions and multi-environment deploys. | [deploy](foundry-agent/deploy/deploy.md) |
 | **invoke** | Send messages to an agent, single or multi-turn conversations | [invoke](foundry-agent/invoke/invoke.md) |
-| **routine** | Schedule or event-trigger Foundry agents with routines; use `azd ai routine` for CRUD, enable/disable, manual dispatch, and viewing past runs, or define routines in `azure.yaml`. | [routine](foundry-agent/routine/routine.md) |
+| **routine** | Schedule or event-trigger Foundry agents with routines; use `azd` for CRUD, enable/disable, manual dispatch, and viewing past runs, or define routines in `azure.yaml`. | [routine](foundry-agent/routine/routine.md) |
 | **invocations-ws** | Build, deploy, and connect to hosted agents that speak the `invocations_ws` duplex WebSocket protocol — voice agents, real-time streams, and signaling for out-of-band media transports. | [invocations-ws](foundry-agent/invocations-ws/invocations-ws.md) |
 | **observe** | Evaluate agent quality, run batch evals, analyze failures, optimize prompts, improve agent instructions, compare versions, set up CI/CD monitoring, and enable continuous production evaluation | [observe](foundry-agent/observe/observe.md) |
 | **trace** | Query traces, analyze latency/failures, correlate eval results to specific responses via App Insights `customEvents` | [trace](foundry-agent/trace/trace.md) |

--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -25,6 +25,7 @@ This skill includes specialized sub-skills for specific workflows. **Use these i
 |-----------|-------------|-----------|
 | **deploy** | Deploy hosted agents to Foundry, smoke-test a deployment, create or update prompt agents, and manage agent versions and multi-environment deploys. | [deploy](foundry-agent/deploy/deploy.md) |
 | **invoke** | Send messages to an agent, single or multi-turn conversations | [invoke](foundry-agent/invoke/invoke.md) |
+| **routine** | Schedule or event-drive an agent with azd — create/read/update/delete Foundry **routines** (timer, recurring cron, GitHub issue, custom event) via `azd ai routine`, plus enable/disable/dispatch/run history and declarative `host: azure.ai.routine` services in `azure.yaml`. All operations go through azd. | [routine](foundry-agent/routine/routine.md) |
 | **invocations-ws** | Build, deploy, and connect to hosted agents that speak the `invocations_ws` duplex WebSocket protocol — voice agents, real-time streams, and signaling for out-of-band media transports. | [invocations-ws](foundry-agent/invocations-ws/invocations-ws.md) |
 | **observe** | Evaluate agent quality, run batch evals, analyze failures, optimize prompts, improve agent instructions, compare versions, set up CI/CD monitoring, and enable continuous production evaluation | [observe](foundry-agent/observe/observe.md) |
 | **trace** | Query traces, analyze latency/failures, correlate eval results to specific responses via App Insights `customEvents` | [trace](foundry-agent/trace/trace.md) |
@@ -72,6 +73,7 @@ Match user intent to the correct agent workflow. Read each sub-skill in order be
 | Deploy an agent (code already exists) | deploy (includes eval-suite setup) → invoke → observe (evaluate/optimize) |
 | Update/redeploy an agent after code changes | deploy (includes eval-suite setup) → invoke → observe (evaluate/optimize) |
 | Invoke/test/chat with an agent | invoke |
+| Schedule/event-trigger an agent, or CRUD/enable/disable/dispatch a routine | routine |
 | Optimize / improve agent prompt or instructions | observe (Step 4: Optimize) |
 | Evaluate and optimize agent (full loop) | observe |
 | Enable continuous evaluation monitoring | observe (Step 6: CI/CD & Monitoring) |

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/references/azure-yaml.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/references/azure-yaml.md
@@ -1,6 +1,6 @@
 # Declarative Routines
 
-The routines extension registers a service target so routines can live in source control and be upserted by `azd up` / `azd deploy`. Declare the routine as a service with `host: azure.ai.routine`; the service key is the routine name, and its keys bind to the routine model.
+The routines extension registers a service target so routines can live in source control and be upserted by `azd up` / `azd deploy`. Declare each routine as a service with `host: azure.ai.routine`: the **service key is the routine name**, and the keys under it bind directly to the routine model.
 
 ```yaml
 # azure.yaml
@@ -9,20 +9,20 @@ services:
     host: azure.ai.agent
     # ... agent service block ...
 
-  daily-digest:
+  daily-digest:                 # service key = routine name
     host: azure.ai.routine
     uses:
-      - my-agent
+      - my-agent                # order the agent ahead of the routine that invokes it
     description: Daily 8am digest
     enabled: true
     triggers:
       default:
-        type: schedule
+        type: schedule          # recurring cron; see type table below
         cron_expression: "0 8 * * *"
         time_zone: America/New_York
     action:
-      type: invoke_agent_responses_api
-      agent_name: my-agent
+      type: invoke_agent_responses_api   # see type table below
+      agent_name: my-agent      # target agent (distinct from the routine name)
       input: "Summarize activity for ${AZURE_ENV_NAME}"
 ```
 
@@ -33,10 +33,26 @@ azd deploy daily-digest --no-prompt
 azd up
 ```
 
-## Behavior Notes
+## Trigger and action `type` values
 
-- `azd deploy` PUTs the routine idempotently; package and publish are no-ops.
-- Put the target agent service in `uses` so azd orders the agent before the routine that invokes it.
-- String values in `action.input` resolve `${VAR}` against the active azd env; Foundry server-side `${{...}}` expressions are left untouched.
-- Removing the service block from `azure.yaml` stops azd managing the routine but does not delete it from Foundry. Delete explicitly with `azd ai routine delete <name>`.
-- In `azure.yaml`, use wire values: trigger `type` is `schedule`, `timer`, `github_issue`, or `custom`; action `type` is `invoke_agent_responses_api` or `invoke_agent_invocations_api`. CLI flags use friendly aliases such as `recurring`, `github-issue`, `agent-response`, and `agent-invoke`.
+`azure.yaml` (like a `--file` manifest) uses the raw wire `type:` value, **not** the CLI alias:
+
+- Trigger `type`: `schedule` (recurring cron), `timer` (one-shot), `github_issue`, or `custom`.
+- Action `type`: `invoke_agent_responses_api` (resume with `conversation`) or `invoke_agent_invocations_api` (resume with `session_id`).
+
+The `azd ai routine` CLI accepts friendlier aliases (`recurring`, `github-issue`, `agent-response`, `agent-invoke`) for the same values. See the full alias-to-wire mapping and per-trigger key fields in [CLI CRUD and Operations](cli-crud.md#vocabulary-cli-aliases-vs-manifest-values).
+
+## `action.input`
+
+Put the prompt or payload sent to the agent in `action.input`:
+
+- `invoke_agent_responses_api` (`agent-response`): a string prompt.
+- `invoke_agent_invocations_api` (`agent-invoke`): an object/array/scalar matching the target agent's expected input.
+
+## Behavior notes
+
+- `azd deploy` PUTs the routine idempotently; package and publish are no-ops (a routine has no build artifact).
+- The routine name always comes from the service key; any `name:` inside the block is ignored.
+- Put the target agent service in `uses:` so azd orders the agent before the routine that invokes it.
+- String values resolve `${VAR}` against the active azd env at deploy time; Foundry server-side `${{...}}` expressions are left untouched.
+- Removing the service block stops azd managing the routine but does **not** delete it from Foundry. Delete explicitly with `azd ai routine delete <name>`.

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/references/azure-yaml.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/references/azure-yaml.md
@@ -1,0 +1,42 @@
+# Declarative Routines
+
+The routines extension registers a service target so routines can live in source control and be upserted by `azd up` / `azd deploy`. Declare the routine as a service with `host: azure.ai.routine`; the service key is the routine name, and its keys bind to the routine model.
+
+```yaml
+# azure.yaml
+services:
+  my-agent:
+    host: azure.ai.agent
+    # ... agent service block ...
+
+  daily-digest:
+    host: azure.ai.routine
+    uses:
+      - my-agent
+    description: Daily 8am digest
+    enabled: true
+    triggers:
+      default:
+        type: schedule
+        cron_expression: "0 8 * * *"
+        time_zone: America/New_York
+    action:
+      type: invoke_agent_responses_api
+      agent_name: my-agent
+      input: "Summarize activity for ${AZURE_ENV_NAME}"
+```
+
+Then:
+
+```bash
+azd deploy daily-digest --no-prompt
+azd up
+```
+
+## Behavior Notes
+
+- `azd deploy` PUTs the routine idempotently; package and publish are no-ops.
+- Put the target agent service in `uses` so azd orders the agent before the routine that invokes it.
+- String values in `action.input` resolve `${VAR}` against the active azd env; Foundry server-side `${{...}}` expressions are left untouched.
+- Removing the service block from `azure.yaml` stops azd managing the routine but does not delete it from Foundry. Delete explicitly with `azd ai routine delete <name>`.
+- In `azure.yaml`, use wire values: trigger `type` is `schedule`, `timer`, `github_issue`, or `custom`; action `type` is `invoke_agent_responses_api` or `invoke_agent_invocations_api`. CLI flags use friendly aliases such as `recurring`, `github-issue`, `agent-response`, and `agent-invoke`.

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/references/cli-crud.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/references/cli-crud.md
@@ -1,0 +1,103 @@
+# CLI CRUD and Operations
+
+Use `azd ai routine` for imperative routine CRUD and operations. All verbs accept `--output json` or `--output table` (default). Add `-p <endpoint>` to override the resolved project endpoint.
+
+## Create
+
+Create from flags, or supply a `--file` manifest (`--file` and `--trigger` are mutually exclusive).
+
+```bash
+# One-shot timer -> agent
+azd ai routine create nightly-report \
+  --trigger timer --at <YYYY-MM-DDTHH:MM:SSZ> \
+  --action agent-response --agent-name my-agent
+
+# Recurring cron schedule
+azd ai routine create daily-digest \
+  --trigger recurring --cron "0 8 * * *" --time-zone America/New_York \
+  --action agent-response --agent-name my-agent \
+  --description "Daily 8am digest"
+
+# GitHub issue event -> agent
+azd ai routine create triage-on-open \
+  --trigger github-issue \
+  --connection-id <workspace-connection-id> --owner Azure --repository azure-dev \
+  --issue-event opened \
+  --action agent-invoke --agent-name triage-agent
+
+# Custom event
+azd ai routine create on-custom-event \
+  --trigger custom --provider <provider-id> --event-name <event> \
+  --parameters '{"key":"value"}' \
+  --action agent-response --agent-name my-agent
+
+# Manifest file
+azd ai routine create my-routine --file routine.yaml
+```
+
+## Create Flags
+
+| Flag | Applies to | Notes |
+|------|------------|-------|
+| `--trigger` | all | `timer` \| `recurring` \| `github-issue` \| `custom` (required unless `--file`) |
+| `--at` | timer | ISO 8601 UTC datetime, e.g. `<YYYY-MM-DDTHH:MM:SSZ>` |
+| `--cron` | recurring | 5-field cron; minimum interval 5 minutes |
+| `--time-zone` | recurring | IANA zone, e.g. `America/New_York` (default `UTC`; not valid for timer) |
+| `--connection-id`, `--owner`, `--repository`, `--issue-event` | github-issue | all four required; `--issue-event` is `opened` or `closed` |
+| `--provider`, `--event-name`, `--parameters` | custom | `--provider` and JSON-object `--parameters` required |
+| `--action` | all | `agent-response` (default) \| `agent-invoke` |
+| `--agent-name` \| `--agent-endpoint-id` | action | exactly one; identifies the target agent |
+| `--conversation-id` | agent-response | continue an existing conversation (preview) |
+| `--session-id` | agent-invoke | continue an existing hosted-agent session |
+| `--description` | all | free-text description |
+| `--enabled` | all | enabled by default; pass `--enabled=false` to create disabled |
+| `--force` | all | overwrite an existing routine of the same name (upsert) |
+
+## Read
+
+```bash
+azd ai routine list
+azd ai routine list --output json
+
+azd ai routine show nightly-report
+azd ai routine show nightly-report --output json
+```
+
+## Update
+
+`update` changes only passed fields; everything else is preserved. Supply named flags and/or a `--file` manifest.
+
+```bash
+azd ai routine update daily-digest --cron "30 9 * * *"
+azd ai routine update daily-digest --agent-name another-agent --description "New owner"
+azd ai routine update daily-digest --file routine.yaml
+```
+
+Trigger and action **types** are immutable. `--trigger` / `--action` are rejected on `update`; delete and recreate to change them.
+
+## Delete
+
+```bash
+azd ai routine delete daily-digest
+azd ai routine delete daily-digest --force
+```
+
+Use `--force` for non-interactive deletes, including `--no-prompt`.
+
+## Routine Operations
+
+```bash
+azd ai routine enable daily-digest
+azd ai routine disable daily-digest
+
+# Manually fire a routine once
+azd ai routine dispatch daily-digest
+azd ai routine dispatch daily-digest --input '{"foo":"bar"}'
+azd ai routine dispatch daily-digest --async
+
+# Inspect past runs
+azd ai routine run list daily-digest
+azd ai routine run list daily-digest --top 20 --filter "<odata-filter>"
+```
+
+`dispatch` prints a Dispatch ID and Action Correlation ID; use `run list` to see the resulting status and phase.

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/references/cli-crud.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/references/cli-crud.md
@@ -1,10 +1,48 @@
 # CLI CRUD and Operations
 
-Use `azd ai routine` for imperative routine CRUD and operations. All verbs accept `--output json` or `--output table` (default). Add `-p <endpoint>` to override the resolved project endpoint.
+Use `azd ai routine` for imperative routine CRUD and operations. Every verb accepts `--output json` or `--output table` (default), and `-p <endpoint>` to override the resolved project endpoint.
+
+## Vocabulary: CLI aliases vs. manifest values
+
+A routine is a **trigger** (when it fires) plus an **action** (what it does). There are two spellings for each type: the CLI flags accept a short **alias**, while a `--file` manifest (and `azure.yaml`) use the raw **wire `type:` value**. They mean the same thing.
+
+**Triggers**
+
+| Fires on | `--trigger` alias | manifest `type:` | Key fields |
+|----------|-------------------|------------------|------------|
+| A single moment (one-shot) | `timer` | `timer` | `at` (ISO 8601 UTC) |
+| A recurring cron schedule | `recurring` | `schedule` | `cron_expression`, `time_zone` |
+| A GitHub issue event | `github-issue` | `github_issue` | `connection_id`, `owner`, `repository`, `issue_event` |
+| A custom external event | `custom` | `custom` | `provider`, `event_name`, `parameters` |
+
+**Actions** — both invoke the target agent; they differ only in which agent API is called and which field resumes prior context.
+
+| Calls the agent via | `--action` alias | manifest `type:` | Resume field |
+|---------------------|------------------|------------------|--------------|
+| Responses API (prompt in → response out) | `agent-response` (default) | `invoke_agent_responses_api` | `conversation` |
+| Invocations API (hosted-agent session) | `agent-invoke` | `invoke_agent_invocations_api` | `session_id` |
 
 ## Create
 
-Create from flags, or supply a `--file` manifest (`--file` and `--trigger` are mutually exclusive).
+Put the prompt or payload the routine sends to the agent in `action.input`. What it should contain depends on the action type you chose (the `--action` alias / action `type:` from the table above): when the action is `agent-response` (`invoke_agent_responses_api`), `action.input` is the natural-language prompt; when the action is `agent-invoke` (`invoke_agent_invocations_api`), it is the hosted agent's expected request payload. `azd ai routine create` has **no `--input` flag**, so any routine that needs `action.input` must be created from a manifest:
+
+```yaml
+# routine.yaml
+triggers:
+  default:
+    type: schedule          # wire value; --trigger alias is "recurring"
+    cron_expression: "0 * * * *"
+action:
+  type: invoke_agent_responses_api   # wire value; --action alias is "agent-response"
+  agent_name: my-agent
+  input: "Say hi."
+```
+
+```bash
+azd ai routine create hourly-hello --file routine.yaml
+```
+
+Flag-only create works only when the target agent needs no stored input. `--file` and `--trigger` are mutually exclusive.
 
 ```bash
 # One-shot timer -> agent
@@ -25,14 +63,11 @@ azd ai routine create triage-on-open \
   --issue-event opened \
   --action agent-invoke --agent-name triage-agent
 
-# Custom event
+# Custom event -> agent
 azd ai routine create on-custom-event \
   --trigger custom --provider <provider-id> --event-name <event> \
   --parameters '{"key":"value"}' \
   --action agent-response --agent-name my-agent
-
-# Manifest file
-azd ai routine create my-routine --file routine.yaml
 ```
 
 ## Create Flags
@@ -65,7 +100,7 @@ azd ai routine show nightly-report --output json
 
 ## Update
 
-`update` changes only passed fields; everything else is preserved. Supply named flags and/or a `--file` manifest.
+`update` changes only the fields you pass; everything else is preserved. Supply named flags and/or a `--file` manifest.
 
 ```bash
 azd ai routine update daily-digest --cron "30 9 * * *"
@@ -73,7 +108,7 @@ azd ai routine update daily-digest --agent-name another-agent --description "New
 azd ai routine update daily-digest --file routine.yaml
 ```
 
-Trigger and action **types** are immutable. `--trigger` / `--action` are rejected on `update`; delete and recreate to change them.
+The trigger and action **types** are immutable: `--trigger` / `--action` are rejected on `update`. To change a type, delete the routine and recreate it.
 
 ## Delete
 
@@ -82,7 +117,7 @@ azd ai routine delete daily-digest
 azd ai routine delete daily-digest --force
 ```
 
-Use `--force` for non-interactive deletes, including `--no-prompt`.
+Use `--force` for non-interactive deletes, including under `--no-prompt`.
 
 ## Routine Operations
 
@@ -90,7 +125,7 @@ Use `--force` for non-interactive deletes, including `--no-prompt`.
 azd ai routine enable daily-digest
 azd ai routine disable daily-digest
 
-# Manually fire a routine once
+# Fire a routine once, now
 azd ai routine dispatch daily-digest
 azd ai routine dispatch daily-digest --input '{"foo":"bar"}'
 azd ai routine dispatch daily-digest --async
@@ -100,4 +135,4 @@ azd ai routine run list daily-digest
 azd ai routine run list daily-digest --top 20 --filter "<odata-filter>"
 ```
 
-`dispatch` prints a Dispatch ID and Action Correlation ID; use `run list` to see the resulting status and phase.
+`dispatch --input` is a one-time override for that manual run only; it does not change the routine's stored `action.input`. `dispatch` prints a Dispatch ID and Action Correlation ID — use `run list` to see the resulting status and phase.

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/references/cli-crud.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/references/cli-crud.md
@@ -15,12 +15,12 @@ A routine is a **trigger** (when it fires) plus an **action** (what it does). Th
 | A GitHub issue event | `github-issue` | `github_issue` | `connection_id`, `owner`, `repository`, `issue_event` |
 | A custom external event | `custom` | `custom` | `provider`, `event_name`, `parameters` |
 
-**Actions** — both invoke the target agent; they differ only in which agent API is called and which field resumes prior context.
+**Actions** — both invoke the target agent; they differ only in which agent protocol is called and which field resumes prior context.
 
-| Calls the agent via | `--action` alias | manifest `type:` | Resume field |
-|---------------------|------------------|------------------|--------------|
-| Responses API (prompt in → response out) | `agent-response` (default) | `invoke_agent_responses_api` | `conversation` |
-| Invocations API (hosted-agent session) | `agent-invoke` | `invoke_agent_invocations_api` | `session_id` |
+| Invokes the agent using | `--action` alias | manifest `type:` | Resume field |
+|-------------------------|------------------|------------------|--------------|
+| the agent `responses` protocol | `agent-response` (default) | `invoke_agent_responses_api` | `conversation` |
+| the agent `invocations` protocol | `agent-invoke` | `invoke_agent_invocations_api` | `session_id` |
 
 ## Create
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/references/cli-crud.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/references/cli-crud.md
@@ -27,13 +27,13 @@ A routine is a **trigger** (when it fires) plus an **action** (what it does). Th
 Put the prompt or payload the routine sends to the agent in `action.input`. What it should contain depends on the action type you chose (the `--action` alias / action `type:` from the table above): when the action is `agent-response` (`invoke_agent_responses_api`), `action.input` is the natural-language prompt; when the action is `agent-invoke` (`invoke_agent_invocations_api`), it is the hosted agent's expected request payload. `azd ai routine create` has **no `--input` flag**, so any routine that needs `action.input` must be created from a manifest:
 
 ```yaml
-# routine.yaml
+# routine.yaml — the type: fields take the manifest value from the table above
 triggers:
   default:
-    type: schedule          # wire value; --trigger alias is "recurring"
+    type: schedule
     cron_expression: "0 * * * *"
 action:
-  type: invoke_agent_responses_api   # wire value; --action alias is "agent-response"
+  type: invoke_agent_responses_api
   agent_name: my-agent
   input: "Say hi."
 ```

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
@@ -254,6 +254,7 @@ Behavior notes:
 | `--force is required when --no-prompt is set` on delete | Non-interactive delete without confirmation | Add `--force` |
 | `routine "<name>" not found` | Wrong name or wrong project | `azd ai routine list` to confirm the name and the resolved endpoint |
 | `host "..." is not a recognized Foundry host` | Endpoint host invalid | Use `https://<account>.services.ai.azure.com/api/projects/<project>` (no port) |
+| `json: cannot unmarshal number into Go struct field Routine.created_at of type string` | `azd ai routine extension` could not decode a routine response after the service call | Do not assume the operation failed. Check with `show <name>` and `list`; if `show` returns the same decode error, the routine likely exists but cannot be decoded. `list` can also be affected, so do not rely on it alone. |
 | Network isolation / `PublicNetworkAccessDisabled` / `403` | Project has public access disabled | See [Network Isolation Errors](../../SKILL.md#network-isolation-errors) |
 
 ## Additional Resources

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
@@ -13,6 +13,7 @@ Create, read, update, and delete Microsoft Foundry **routines** with the Azure D
 | CRUD verbs | `create`, `list`, `show`, `update`, `delete` |
 | Routine operations | `enable`, `disable`, `dispatch`, `run list` |
 | Declarative form | `azure.yaml` service with `host: azure.ai.routine`, upserted by `azd deploy` / `azd up` |
+| Agent prompt/input | Set `action.input` in a routine manifest or `azure.yaml`; use a string for the agent `responses` protocol and the target payload for the agent `invocations` protocol. `azd ai routine create` flags do not include `--input` |
 | Project endpoint | `--project-endpoint`, then `AZURE_AI_PROJECT_ENDPOINT`, global `azd ai project set`, then `FOUNDRY_PROJECT_ENDPOINT` |
 | Output format | `--output json` or `--output table` (default) |
 
@@ -86,16 +87,27 @@ azd ai project set "https://<account>.services.ai.azure.com/api/projects/<projec
 
 The endpoint host must end with `.services.ai.azure.com` and use `https` with no explicit port.
 
-## Choose the Routine Management Path
+## Two Ways to Create a Routine
 
-| Situation | Use |
-|-----------|-----|
-| Quick one-off, exploration, scripting, CI ad-hoc | `azd ai routine <verb>` |
-| Routine should be versioned with the agent and reproduced per environment | `azure.yaml` service + `azd deploy` |
-| Enable, disable, manually dispatch, or inspect past runs | `azd ai routine enable/disable/dispatch/run list` |
-| Delete | `azd ai routine delete` (declarative removal never deletes) |
+A routine is the same Foundry resource — keyed by its name — no matter how you create it. Both paths go through `azd` and PUT idempotently against the same project, so a routine created one way can later be managed the other way. Pick a path, then read its reference doc for exact examples.
 
-For exact command examples, trigger/action flags, update rules, dispatch, and past-run inspection, read [CLI CRUD and Operations](references/cli-crud.md). For `azure.yaml` service shape and deploy behavior, read [Declarative Routines](references/azure-yaml.md).
+### Way 1 — Imperative: `azd ai routine create`
+
+Create the routine directly against the Foundry project with a single command — flags, or a `--file` manifest when it must carry a stored prompt/payload (`action.input`; there is no `--input` flag). Best for one-off scheduling, quick experiments, ad-hoc CRUD, and working **outside** an azd project — no `azure.yaml` required. → [CLI CRUD and Operations](references/cli-crud.md)
+
+### Way 2 — Declarative: `azure.yaml` + `azd deploy`
+
+Declare the routine as a `host: azure.ai.routine` service in `azure.yaml`, then let `azd deploy` / `azd up` upsert it. Best when the routine should be **versioned with the agent in source control** and **reproduced per azd environment** — GitOps, multi-env, CI/CD. → [Declarative Routines](references/azure-yaml.md)
+
+### Which path?
+
+| Situation | Path |
+|-----------|------|
+| One-off schedule, quick experiment, or no `azure.yaml` in play | Way 1 — imperative |
+| Routine versioned with the agent, reproduced per environment, GitOps / CI-CD | Way 2 — declarative |
+| Unsure and already in an azd project with the agent | Way 2 — declarative keeps the routine and agent in sync |
+
+Read, update, enable/disable, manually dispatch, inspect past runs, and delete are imperative-only operations that work on a routine regardless of how it was created — see [CLI CRUD and Operations](references/cli-crud.md).
 
 ## Error Handling
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
@@ -89,7 +89,7 @@ The endpoint host must end with `.services.ai.azure.com` and use `https` with no
 
 ## Two Ways to Create a Routine
 
-A routine is the same Foundry resource — keyed by its name — no matter how you create it. Both paths go through `azd` and PUT idempotently against the same project, so a routine created one way can later be managed the other way. Pick a path, then read its reference doc for exact examples.
+A routine is the same Foundry resource — keyed by its name — no matter how you create it. Both paths go through `azd` and act on that same named resource, so a routine created one way can later be managed the other way. Declarative `azd deploy` always upserts idempotently; imperative `azd ai routine create` refuses to overwrite an existing routine unless you pass `--force`. Pick a path, then read its reference doc for exact examples.
 
 ### Way 1 — Imperative: `azd ai routine create`
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
@@ -104,7 +104,7 @@ Declare the routine as a `host: azure.ai.routine` service in `azure.yaml`, then 
 | Situation | Path |
 |-----------|------|
 | One-off schedule, quick experiment, or no `azure.yaml` in play | Way 1 — imperative |
-| Routine versioned with the agent, reproduced per environment, GitOps / CI-CD | Way 2 — declarative |
+| Routine versioned with the agent, reproduced per environment, GitOps / CI/CD | Way 2 — declarative |
 | Unsure and already in an azd project with the agent | Way 2 — declarative keeps the routine and agent in sync |
 
 Read, update, enable/disable, manually dispatch, inspect past runs, and delete are imperative-only operations that work on a routine regardless of how it was created — see [CLI CRUD and Operations](references/cli-crud.md).
@@ -116,7 +116,7 @@ Read, update, enable/disable, manually dispatch, inspect past runs, and delete a
 | `unknown command "routine"` / `unknown command "ai"` | Extension not installed or azd too old | `azd extension install azure.ai.routines`; ensure `azd >= 1.27.0` |
 | Missing project endpoint error | No endpoint resolved | Set `AZURE_AI_PROJECT_ENDPOINT`, run `azd ai project set <url>`, or pass `-p <url>` |
 | `routine "<name>" already exists` on create | Name collision | Re-run with `--force` to upsert, or choose a different name |
-| `--trigger` / `--action cannot be changed on an existing routine` | Trigger/action type is immutable | Delete then create with the new type |
+| `--trigger cannot be changed on an existing routine` (same for `--action`) | Trigger/action type is immutable | Delete then create with the new type |
 | `--force is required when --no-prompt is set` on delete | Non-interactive delete without confirmation | Add `--force` |
 | `routine "<name>" not found` | Wrong name or wrong project | Check the name and resolved endpoint with `show` / `list` |
 | `host "..." is not a recognized Foundry host` | Endpoint host invalid | Use `https://<account>.services.ai.azure.com/api/projects/<project>` (no port) |

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
@@ -1,84 +1,82 @@
 # Manage Foundry Routines (azd ai routine)
 
-Create, read, update, and delete Microsoft Foundry **routines** with the Azure Developer CLI (`azd`). A routine pairs a **trigger** (timer, recurring schedule, GitHub issue, or a custom external event) with an **action** that invokes a Foundry agent. Every operation in this skill goes through `azd` — either the imperative `azd ai routine` commands or the declarative `host: azure.ai.routine` service in `azure.yaml`.
+Create, read, update, and delete Microsoft Foundry **routines** with the Azure Developer CLI (`azd`). A routine pairs a trigger (timer, recurring schedule, GitHub issue, or custom external event) with an action that invokes a Foundry agent. Use only the `azd` path for routine work: imperative `azd ai routine` commands or declarative `host: azure.ai.routine` services in `azure.yaml`.
 
-> **Preview.** Routines ship in the `azure.ai.routines` azd extension (Preview). The command surface is `azd ai routine <verb>`; do not use the Foundry MCP tools, REST, or SDK for routine CRUD in this skill — keep everything on the azd path.
+> **Preview.** Routines ship in the `azure.ai.routines` azd extension. The command surface is `azd ai routine <verb>`; do not use Foundry MCP tools, REST, or SDK for routine CRUD in this skill.
 
 ## Quick Reference
 
 | Property | Value |
 |----------|-------|
-| Primary CLI | `azd ai routine` (from extension `azure.ai.routines`) |
+| Primary CLI | `azd ai routine` (extension `azure.ai.routines`) |
 | Install extension | `azd extension install azure.ai.routines` |
 | CRUD verbs | `create`, `list`, `show`, `update`, `delete` |
-| Routine operation verbs | `enable`, `disable`, `dispatch`, `run list` |
-| Declarative form | `azure.yaml` service with `host: azure.ai.routine` (upserted by `azd deploy` / `azd up`) |
-| Project endpoint | Resolved from `-p/--project-endpoint`, then the active azd env (`AZURE_AI_PROJECT_ENDPOINT`), then global config, then `FOUNDRY_PROJECT_ENDPOINT` |
-| Output format | `--output json` or `--output table` (default `table`) on every verb |
-| Reference docs | [azd-ai-cli](../create/references/azd-ai-cli.md) |
+| Routine operations | `enable`, `disable`, `dispatch`, `run list` |
+| Declarative form | `azure.yaml` service with `host: azure.ai.routine`, upserted by `azd deploy` / `azd up` |
+| Project endpoint | `--project-endpoint`, then `AZURE_AI_PROJECT_ENDPOINT`, global `azd ai project set`, then `FOUNDRY_PROJECT_ENDPOINT` |
+| Output format | `--output json` or `--output table` (default) |
 
 ## When to Use This Skill
 
-- Schedule an agent to run on a timer (one-shot) or a recurring cron schedule.
-- Trigger an agent when a GitHub issue is opened/closed, or on a custom external event.
-- List / inspect / enable / disable / delete existing routines on a Foundry project.
-- Manually fire a routine once (`dispatch`) or inspect its execution history (`run list`).
-- Manage routines declaratively as services in `azure.yaml` so `azd up` / `azd deploy` keeps them in sync.
+- Schedule an agent on a one-shot timer or recurring cron schedule.
+- Trigger an agent from a GitHub issue event or custom external event.
+- List, inspect, update, enable, disable, dispatch, or delete existing routines.
+- Manage routines declaratively in `azure.yaml` so `azd up` / `azd deploy` keeps them in sync.
 
-> A routine **references an agent**, it does not create one. Deploy or identify the target agent first (see [deploy](../deploy/deploy.md) / [create](../create/create-hosted.md)), then attach a routine to it.
+> A routine **references an agent**; it does not create one. Deploy or identify the target agent first (see [deploy](../deploy/deploy.md) / [create](../create/create-hosted.md)), then attach a routine to it.
 
 ## Workflow
 
-### Step 1 — Verify the environment
+### Step 1 - Verify the environment
 
-Before any routine command, run the bundled verification script (shared with the create/deploy flow) to confirm `azd`, `az`, auth, and the base Foundry extensions are ready:
+Before any routine command, run the shared verification script to confirm `azd`, `az`, auth, and the base Foundry extensions are ready:
 
 ```bash
 ../create/scripts/verify-environment.sh     # macOS / Linux
-../create/scripts/verify-environment.ps1     # Windows (pwsh)
+../create/scripts/verify-environment.ps1    # Windows (pwsh)
 ```
 
 Act on the summary prefixes:
 
-- `[OK]` — nothing to do.
-- `[WARN]` — non-blocking; continue.
-- `[ACTION]` — resolve first, then rerun the script. Never run `az login` or `azd auth login` for the user — stop and ask them to log in manually. Missing base extensions (`azure.ai.agents`, `azure.ai.projects`, `microsoft.foundry`) can be installed with `azd extension install <name>`.
+- `[OK]` - nothing to do.
+- `[WARN]` - non-blocking; continue.
+- `[ACTION]` - resolve first, then rerun the script. Never run `az login` or `azd auth login` for the user; stop and ask them to log in manually. Missing base extensions (`azure.ai.agents`, `azure.ai.projects`, `microsoft.foundry`) can be installed with `azd extension install <name>`.
 
-Do not continue past Step 1 while any `[ACTION]` remains.
+Do not continue while any `[ACTION]` remains.
 
-#### Step 1b — Check the routine extension (`azure.ai.routines`)
+### Step 1b - Check the routines extension
 
-The shared script does **not** check the routines extension. Confirm it is installed:
+The shared script does not check `azure.ai.routines`. Confirm it is installed:
 
 ```bash
 azd extension list --installed --output json
 ```
 
-If `azure.ai.routines` is not in the list, install it (ask before installing in interactive mode; install directly in non-interactive mode):
+If missing, install it (ask first in interactive mode; install directly in non-interactive mode):
 
 ```bash
 azd extension install azure.ai.routines
 ```
 
-Verify the command surface is available:
+Verify the command surface:
 
 ```bash
 azd ai routine --help
 ```
 
-> If `azd ai routine` reports an unknown command after install, the azd core is too old. The extension requires `azd >= 1.27.0` — upgrade azd (<https://aka.ms/azd-install>) and retry.
+If `azd ai routine` reports an unknown command after install, the azd core is too old. The extension requires `azd >= 1.27.0`; upgrade azd (<https://aka.ms/azd-install>) and retry.
 
-### Step 2 — Resolve the Foundry project endpoint
+### Step 2 - Resolve the Foundry project endpoint
 
-Every routine command targets a Foundry **project endpoint**. `azd ai routine` resolves it in this order (first match wins):
+Every routine command targets a Foundry project endpoint. `azd ai routine` resolves it in this order:
 
-1. `-p` / `--project-endpoint <url>` flag on the command.
-2. The active azd environment's `AZURE_AI_PROJECT_ENDPOINT` (`azd env get-values`).
-3. Global config written by `azd ai project set <endpoint>`.
-4. The `FOUNDRY_PROJECT_ENDPOINT` environment variable.
+1. `-p` / `--project-endpoint <url>` on the command.
+2. Active azd environment `AZURE_AI_PROJECT_ENDPOINT` (`azd env get-values`).
+3. Global config from `azd ai project set <endpoint>`.
+4. `FOUNDRY_PROJECT_ENDPOINT` environment variable.
 5. Otherwise the command fails with a missing-endpoint error.
 
-Prefer the azd env when you are inside an azd project (it is already set after `azd provision` / `azd ai project show`). Otherwise set it once:
+Prefer the azd env inside an azd project. Otherwise set it once:
 
 ```bash
 azd env set AZURE_AI_PROJECT_ENDPOINT "https://<account>.services.ai.azure.com/api/projects/<project>"
@@ -88,178 +86,36 @@ azd ai project set "https://<account>.services.ai.azure.com/api/projects/<projec
 
 The endpoint host must end with `.services.ai.azure.com` and use `https` with no explicit port.
 
-## CRUD with `azd ai routine`
-
-All verbs accept `--output json` (for scripting) or `--output table` (default). Add `-p <endpoint>` to any command to override the resolved endpoint.
-
-### Create
-
-A routine needs a **trigger** and an **action**. Build them from flags, or supply a `--file` manifest (`--file` and `--trigger` are mutually exclusive).
-
-```bash
-# One-shot timer -> agent (responses API) by project-scoped agent name
-azd ai routine create nightly-report \
-  --trigger timer --at <YYYY-MM-DDTHH:MM:SSZ> \
-  --action agent-response --agent-name my-agent
-
-# Recurring cron schedule (min interval 5 minutes) with a time zone
-azd ai routine create daily-digest \
-  --trigger recurring --cron "0 8 * * *" --time-zone America/New_York \
-  --action agent-response --agent-name my-agent \
-  --description "Daily 8am digest"
-
-# GitHub issue event -> agent (invocations API)
-azd ai routine create triage-on-open \
-  --trigger github-issue \
-  --connection-id <workspace-connection-id> --owner Azure --repository azure-dev \
-  --issue-event opened \
-  --action agent-invoke --agent-name triage-agent
-
-# Custom external-provider event
-azd ai routine create on-custom-event \
-  --trigger custom --provider <provider-id> --event-name <event> \
-  --parameters '{"key":"value"}' \
-  --action agent-response --agent-name my-agent
-
-# From a manifest file (name still comes from the positional arg)
-azd ai routine create my-routine --file routine.yaml
-```
-
-Key flags:
-
-| Flag | Applies to | Notes |
-|------|-----------|-------|
-| `--trigger` | all | `timer` \| `recurring` \| `github-issue` \| `custom` (required unless `--file`) |
-| `--at` | timer | ISO 8601 UTC datetime, e.g. `<YYYY-MM-DDTHH:MM:SSZ>` |
-| `--cron` | recurring | 5-field cron, minimum interval 5 minutes |
-| `--time-zone` | recurring | IANA zone, e.g. `America/New_York` (default `UTC`; not valid for timer) |
-| `--connection-id`, `--owner`, `--repository`, `--issue-event` | github-issue | all four required; `--issue-event` is `opened` or `closed` |
-| `--provider`, `--event-name`, `--parameters` | custom | `--provider` + `--parameters` (JSON object) required |
-| `--action` | all | `agent-response` (default, responses API) \| `agent-invoke` (invocations API) |
-| `--agent-name` \| `--agent-endpoint-id` | action | exactly one; identifies the target agent |
-| `--conversation-id` | agent-response | continue an existing conversation (preview) |
-| `--session-id` | agent-invoke | continue an existing hosted-agent session |
-| `--description` | all | free-text description |
-| `--enabled` | all | enabled by default on creation; pass `--enabled=false` to create disabled |
-| `--force` | all | overwrite an existing routine of the same name (upsert) |
-
-Without `--force`, creating a routine whose name already exists fails — use `--force` to upsert or pick a new name.
-
-### Read (list / show)
-
-```bash
-azd ai routine list                      # NAME / ENABLED / TRIGGER / ACTION
-azd ai routine list --output json
-
-azd ai routine show nightly-report       # full detail for one routine
-azd ai routine show nightly-report --output json
-```
-
-### Update
-
-`update` changes only the fields you pass; everything else is preserved. Supply named flags and/or a `--file` manifest (manifest fields win, then explicit flags override).
-
-```bash
-azd ai routine update daily-digest --cron "30 9 * * *"
-azd ai routine update daily-digest --agent-name another-agent --description "New owner"
-azd ai routine update daily-digest --file routine.yaml
-```
-
-> **Trigger and action *types* are immutable.** `--trigger` / `--action` are rejected on `update`. To change the trigger kind (e.g. timer → recurring) or the action kind (agent-response → agent-invoke), `delete` the routine and `create` it again. You can still update the fields *within* the existing trigger/action type (cron, at, time-zone, agent name, etc.).
-
-### Delete
-
-```bash
-azd ai routine delete daily-digest            # interactive confirmation
-azd ai routine delete daily-digest --force    # skip prompt (required with --no-prompt)
-```
-
-## Routine operations
-
-```bash
-azd ai routine enable  daily-digest    # idempotent; enabling an enabled routine is a no-op
-azd ai routine disable daily-digest    # idempotent
-
-# Manually fire a routine once (runs asynchronously server-side)
-azd ai routine dispatch daily-digest
-azd ai routine dispatch daily-digest --input '{"foo":"bar"}'   # override action input (JSON or plain string)
-azd ai routine dispatch daily-digest --async                    # print only the dispatch ID (scripting)
-
-# Inspect execution history for a routine
-azd ai routine run list daily-digest
-azd ai routine run list daily-digest --top 20 --filter "<odata-filter>"
-```
-
-`dispatch` prints a **Dispatch ID** and **Action Correlation ID**; use `azd ai routine run list <name>` to see the resulting run status/phase.
-
-## Declarative form — routines in `azure.yaml`
-
-The extension also registers a **service target** so routines can live in source control and be upserted by `azd up` / `azd deploy`. Declare the routine as a service with `host: azure.ai.routine`; the **service key is the routine name**, and its keys bind directly to the routine model.
-
-```yaml
-# azure.yaml
-services:
-  my-agent:
-    host: azure.ai.agent
-    # ... agent service block ...
-
-  daily-digest:                 # <- routine name = service key
-    host: azure.ai.routine
-    uses:
-      - my-agent                # order the agent ahead of the routine that invokes it
-    description: Daily 8am digest
-    enabled: true
-    triggers:
-      default:
-        type: schedule          # wire type: schedule=recurring, timer, github_issue, custom
-        cron_expression: "0 8 * * *"
-        time_zone: America/New_York
-    action:
-      type: invoke_agent_responses_api   # or invoke_agent_invocations_api
-      agent_name: my-agent
-      input: "Summarize activity for ${AZURE_ENV_NAME}"   # ${VAR} expands from azd env
-```
-
-Then:
-
-```bash
-azd deploy daily-digest --no-prompt    # upsert just this routine
-azd up                                 # provision + deploy everything, including routines
-```
-
-Behavior notes:
-
-- **Upsert on deploy.** `azd deploy` PUTs the routine idempotently (no build artifact — package/publish are no-ops).
-- **`${VAR}` expansion.** String values in `action.input` resolve against the active azd env; Foundry server-side `${{...}}` expressions are left untouched.
-- **Removing the service does not delete the routine.** Deleting the service block from `azure.yaml` only stops azd managing it — the routine still exists in Foundry. Delete it explicitly with `azd ai routine delete <name>`.
-- **Wire vs CLI names.** In `azure.yaml` use wire type values: trigger `type` is `schedule` (recurring) / `timer` / `github_issue` / `custom`; action `type` is `invoke_agent_responses_api` (agent-response) / `invoke_agent_invocations_api` (agent-invoke). The `azd ai routine create --trigger/--action` flags use the friendly aliases.
-
-## Choosing imperative vs declarative
+## Choose the Routine Management Path
 
 | Situation | Use |
 |-----------|-----|
 | Quick one-off, exploration, scripting, CI ad-hoc | `azd ai routine <verb>` |
 | Routine should be versioned with the agent and reproduced per environment | `azure.yaml` service + `azd deploy` |
-| Enable/disable/dispatch/inspect runs | `azd ai routine enable/disable/dispatch/run list` (no declarative equivalent) |
-| Delete | `azd ai routine delete` (always — declarative removal never deletes) |
+| Enable, disable, manually dispatch, or inspect past runs | `azd ai routine enable/disable/dispatch/run list` |
+| Delete | `azd ai routine delete` (declarative removal never deletes) |
 
-## Error handling
+For exact command examples, trigger/action flags, update rules, dispatch, and past-run inspection, read [CLI CRUD and Operations](references/cli-crud.md). For `azure.yaml` service shape and deploy behavior, read [Declarative Routines](references/azure-yaml.md).
+
+## Error Handling
 
 | Symptom | Cause | Resolution |
 |---------|-------|------------|
 | `unknown command "routine"` / `unknown command "ai"` | Extension not installed or azd too old | `azd extension install azure.ai.routines`; ensure `azd >= 1.27.0` |
-| Missing project endpoint error | No endpoint resolved | Set `AZURE_AI_PROJECT_ENDPOINT` via `azd env set`, run `azd ai project set <url>`, or pass `-p <url>` |
+| Missing project endpoint error | No endpoint resolved | Set `AZURE_AI_PROJECT_ENDPOINT`, run `azd ai project set <url>`, or pass `-p <url>` |
 | `routine "<name>" already exists` on create | Name collision | Re-run with `--force` to upsert, or choose a different name |
-| `--trigger`/`--action cannot be changed on an existing routine` | Trigger/action type is immutable | `delete` then `create` with the new type |
+| `--trigger` / `--action cannot be changed on an existing routine` | Trigger/action type is immutable | Delete then create with the new type |
 | `--force is required when --no-prompt is set` on delete | Non-interactive delete without confirmation | Add `--force` |
-| `routine "<name>" not found` | Wrong name or wrong project | `azd ai routine list` to confirm the name and the resolved endpoint |
+| `routine "<name>" not found` | Wrong name or wrong project | Check the name and resolved endpoint with `show` / `list` |
 | `host "..." is not a recognized Foundry host` | Endpoint host invalid | Use `https://<account>.services.ai.azure.com/api/projects/<project>` (no port) |
-| `json: cannot unmarshal number into Go struct field Routine.created_at of type string` | `azd ai routine extension` could not decode a routine response after the service call | Do not assume the operation failed. Check with `show <name>` and `list`; if `show` returns the same decode error, the routine likely exists but cannot be decoded. `list` can also be affected, so do not rely on it alone. |
+| `json: cannot unmarshal number into Go struct field Routine.created_at of type string` | The routines extension could not decode a routine response after the service call | Do not assume the operation failed. Check with `show <name>` and `list`; if both decode badly, the routine may exist but cannot be decoded by the current extension. |
 | Network isolation / `PublicNetworkAccessDisabled` / `403` | Project has public access disabled | See [Network Isolation Errors](../../SKILL.md#network-isolation-errors) |
 
 ## Additional Resources
 
+- [CLI CRUD and Operations](references/cli-crud.md)
+- [Declarative Routines](references/azure-yaml.md)
 - [azd ai CLI Reference](../create/references/azd-ai-cli.md)
-- [Deploy a Foundry Agent](../deploy/deploy.md) — deploy the agent a routine will invoke
-- [Invoke a Foundry Agent](../invoke/invoke.md) — smoke-test the agent before scheduling it
+- [Deploy a Foundry Agent](../deploy/deploy.md) - deploy the agent a routine will invoke
+- [Invoke a Foundry Agent](../invoke/invoke.md) - smoke-test the agent before scheduling it
 - [Microsoft Foundry Skill (index)](../../SKILL.md)

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
@@ -1,0 +1,264 @@
+# Manage Foundry Routines (azd ai routine)
+
+Create, read, update, and delete Microsoft Foundry **routines** with the Azure Developer CLI (`azd`). A routine pairs a **trigger** (timer, recurring schedule, GitHub issue, or a custom external event) with an **action** that invokes a Foundry agent. Every operation in this skill goes through `azd` — either the imperative `azd ai routine` commands or the declarative `host: azure.ai.routine` service in `azure.yaml`.
+
+> **Preview.** Routines ship in the `azure.ai.routines` azd extension (Preview). The command surface is `azd ai routine <verb>`; do not use the Foundry MCP tools, REST, or SDK for routine CRUD in this skill — keep everything on the azd path.
+
+## Quick Reference
+
+| Property | Value |
+|----------|-------|
+| Primary CLI | `azd ai routine` (from extension `azure.ai.routines`) |
+| Install extension | `azd extension install azure.ai.routines` |
+| CRUD verbs | `create`, `list`, `show`, `update`, `delete` |
+| Lifecycle verbs | `enable`, `disable`, `dispatch`, `run list` |
+| Declarative form | `azure.yaml` service with `host: azure.ai.routine` (upserted by `azd deploy` / `azd up`) |
+| Project endpoint | Resolved from `-p/--project-endpoint`, then the active azd env (`AZURE_AI_PROJECT_ENDPOINT`), then global config, then `FOUNDRY_PROJECT_ENDPOINT` |
+| Output format | `--output json` or `--output table` (default `table`) on every verb |
+| Reference docs | [azd-ai-cli](../create/references/azd-ai-cli.md) |
+
+## When to Use This Skill
+
+- Schedule an agent to run on a timer (one-shot) or a recurring cron schedule.
+- Trigger an agent when a GitHub issue is opened/closed, or on a custom external event.
+- List / inspect / enable / disable / delete existing routines on a Foundry project.
+- Manually fire a routine once (`dispatch`) or inspect its execution history (`run list`).
+- Manage routines declaratively as services in `azure.yaml` so `azd up` / `azd deploy` keeps them in sync.
+
+> A routine **references an agent**, it does not create one. Deploy or identify the target agent first (see [deploy](../deploy/deploy.md) / [create](../create/create-hosted.md)), then attach a routine to it.
+
+## Workflow
+
+### Step 1 — Verify the environment
+
+Before any routine command, run the bundled verification script (shared with the create/deploy flow) to confirm `azd`, `az`, auth, and the base Foundry extensions are ready:
+
+```bash
+../create/scripts/verify-environment.sh     # macOS / Linux
+../create/scripts/verify-environment.ps1     # Windows (pwsh)
+```
+
+Act on the summary prefixes:
+
+- `[OK]` — nothing to do.
+- `[WARN]` — non-blocking; continue.
+- `[ACTION]` — resolve first, then rerun the script. Never run `az login` or `azd auth login` for the user — stop and ask them to log in manually. Missing base extensions (`azure.ai.agents`, `azure.ai.projects`, `microsoft.foundry`) can be installed with `azd extension install <name>`.
+
+Do not continue past Step 1 while any `[ACTION]` remains.
+
+#### Step 1b — Check the routine extension (`azure.ai.routines`)
+
+The shared script does **not** check the routines extension. Confirm it is installed:
+
+```bash
+azd extension list --installed --output json
+```
+
+If `azure.ai.routines` is not in the list, install it (ask before installing in interactive mode; install directly in non-interactive mode):
+
+```bash
+azd extension install azure.ai.routines
+```
+
+Verify the command surface is available:
+
+```bash
+azd ai routine --help
+```
+
+> If `azd ai routine` reports an unknown command after install, the azd core is too old. The extension requires `azd >= 1.27.0` — upgrade azd (<https://aka.ms/azd-install>) and retry.
+
+### Step 2 — Resolve the Foundry project endpoint
+
+Every routine command targets a Foundry **project endpoint**. `azd ai routine` resolves it in this order (first match wins):
+
+1. `-p` / `--project-endpoint <url>` flag on the command.
+2. The active azd environment's `AZURE_AI_PROJECT_ENDPOINT` (`azd env get-values`).
+3. Global config written by `azd ai project set <endpoint>`.
+4. The `FOUNDRY_PROJECT_ENDPOINT` environment variable.
+5. Otherwise the command fails with a missing-endpoint error.
+
+Prefer the azd env when you are inside an azd project (it is already set after `azd provision` / `azd ai project show`). Otherwise set it once:
+
+```bash
+azd env set AZURE_AI_PROJECT_ENDPOINT "https://<account>.services.ai.azure.com/api/projects/<project>"
+# or, outside an azd project:
+azd ai project set "https://<account>.services.ai.azure.com/api/projects/<project>"
+```
+
+The endpoint host must end with `.services.ai.azure.com` and use `https` with no explicit port.
+
+## CRUD with `azd ai routine`
+
+All verbs accept `--output json` (for scripting) or `--output table` (default). Add `-p <endpoint>` to any command to override the resolved endpoint.
+
+### Create
+
+A routine needs a **trigger** and an **action**. Build them from flags, or supply a `--file` manifest (`--file` and `--trigger` are mutually exclusive).
+
+```bash
+# One-shot timer -> agent (responses API) by project-scoped agent name
+azd ai routine create nightly-report \
+  --trigger timer --at 2026-08-01T09:00:00Z \
+  --action agent-response --agent-name my-agent
+
+# Recurring cron schedule (min interval 5 minutes) with a time zone
+azd ai routine create daily-digest \
+  --trigger recurring --cron "0 8 * * *" --time-zone America/New_York \
+  --action agent-response --agent-name my-agent \
+  --description "Daily 8am digest"
+
+# GitHub issue event -> agent (invocations API)
+azd ai routine create triage-on-open \
+  --trigger github-issue \
+  --connection-id <workspace-connection-id> --owner Azure --repository azure-dev \
+  --issue-event opened \
+  --action agent-invoke --agent-name triage-agent
+
+# Custom external-provider event
+azd ai routine create on-custom-event \
+  --trigger custom --provider <provider-id> --event-name <event> \
+  --parameters '{"key":"value"}' \
+  --action agent-response --agent-name my-agent
+
+# From a manifest file (name still comes from the positional arg)
+azd ai routine create my-routine --file routine.yaml
+```
+
+Key flags:
+
+| Flag | Applies to | Notes |
+|------|-----------|-------|
+| `--trigger` | all | `timer` \| `recurring` \| `github-issue` \| `custom` (required unless `--file`) |
+| `--at` | timer | ISO 8601 UTC datetime, e.g. `2026-08-01T09:00:00Z` |
+| `--cron` | recurring | 5-field cron, minimum interval 5 minutes |
+| `--time-zone` | recurring | IANA zone, e.g. `America/New_York` (default `UTC`; not valid for timer) |
+| `--connection-id`, `--owner`, `--repository`, `--issue-event` | github-issue | all four required; `--issue-event` is `opened` or `closed` |
+| `--provider`, `--event-name`, `--parameters` | custom | `--provider` + `--parameters` (JSON object) required |
+| `--action` | all | `agent-response` (default, responses API) \| `agent-invoke` (invocations API) |
+| `--agent-name` \| `--agent-endpoint-id` | action | exactly one; identifies the target agent |
+| `--conversation-id` | agent-response | continue an existing conversation (preview) |
+| `--session-id` | agent-invoke | continue an existing hosted-agent session |
+| `--description` | all | free-text description |
+| `--enabled` | all | enabled by default on creation; pass `--enabled=false` to create disabled |
+| `--force` | all | overwrite an existing routine of the same name (upsert) |
+
+Without `--force`, creating a routine whose name already exists fails — use `--force` to upsert or pick a new name.
+
+### Read (list / show)
+
+```bash
+azd ai routine list                      # NAME / ENABLED / TRIGGER / ACTION
+azd ai routine list --output json
+
+azd ai routine show nightly-report       # full detail for one routine
+azd ai routine show nightly-report --output json
+```
+
+### Update
+
+`update` changes only the fields you pass; everything else is preserved. Supply named flags and/or a `--file` manifest (manifest fields win, then explicit flags override).
+
+```bash
+azd ai routine update daily-digest --cron "30 9 * * *"
+azd ai routine update daily-digest --agent-name another-agent --description "New owner"
+azd ai routine update daily-digest --file routine.yaml
+```
+
+> **Trigger and action *types* are immutable.** `--trigger` / `--action` are rejected on `update`. To change the trigger kind (e.g. timer → recurring) or the action kind (agent-response → agent-invoke), `delete` the routine and `create` it again. You can still update the fields *within* the existing trigger/action type (cron, at, time-zone, agent name, etc.).
+
+### Delete
+
+```bash
+azd ai routine delete daily-digest            # interactive confirmation
+azd ai routine delete daily-digest --force    # skip prompt (required with --no-prompt)
+```
+
+## Lifecycle commands
+
+```bash
+azd ai routine enable  daily-digest    # idempotent; enabling an enabled routine is a no-op
+azd ai routine disable daily-digest    # idempotent
+
+# Manually fire a routine once (runs asynchronously server-side)
+azd ai routine dispatch daily-digest
+azd ai routine dispatch daily-digest --input '{"foo":"bar"}'   # override action input (JSON or plain string)
+azd ai routine dispatch daily-digest --async                    # print only the dispatch ID (scripting)
+
+# Inspect execution history for a routine
+azd ai routine run list daily-digest
+azd ai routine run list daily-digest --top 20 --filter "<odata-filter>"
+```
+
+`dispatch` prints a **Dispatch ID** and **Action Correlation ID**; use `azd ai routine run list <name>` to see the resulting run status/phase.
+
+## Declarative form — routines in `azure.yaml`
+
+The extension also registers a **service target** so routines can live in source control and be upserted by `azd up` / `azd deploy`. Declare the routine as a service with `host: azure.ai.routine`; the **service key is the routine name**, and its keys bind directly to the routine model.
+
+```yaml
+# azure.yaml
+services:
+  my-agent:
+    host: azure.ai.agent
+    # ... agent service block ...
+
+  daily-digest:                 # <- routine name = service key
+    host: azure.ai.routine
+    uses:
+      - my-agent                # order the agent ahead of the routine that invokes it
+    description: Daily 8am digest
+    enabled: true
+    triggers:
+      default:
+        type: schedule          # wire type: schedule=recurring, timer, github_issue, custom
+        cron_expression: "0 8 * * *"
+        time_zone: America/New_York
+    action:
+      type: invoke_agent_responses_api   # or invoke_agent_invocations_api
+      agent_name: my-agent
+      input: "Summarize activity for ${AZURE_ENV_NAME}"   # ${VAR} expands from azd env
+```
+
+Then:
+
+```bash
+azd deploy daily-digest --no-prompt    # upsert just this routine
+azd up                                 # provision + deploy everything, including routines
+```
+
+Behavior notes:
+
+- **Upsert on deploy.** `azd deploy` PUTs the routine idempotently (no build artifact — package/publish are no-ops).
+- **`${VAR}` expansion.** String values in `action.input` resolve against the active azd env; Foundry server-side `${{...}}` expressions are left untouched.
+- **Removing the service does not delete the routine.** Deleting the service block from `azure.yaml` only stops azd managing it — the routine still exists in Foundry. Delete it explicitly with `azd ai routine delete <name>`.
+- **Wire vs CLI names.** In `azure.yaml` use wire type values: trigger `type` is `schedule` (recurring) / `timer` / `github_issue` / `custom`; action `type` is `invoke_agent_responses_api` (agent-response) / `invoke_agent_invocations_api` (agent-invoke). The `azd ai routine create --trigger/--action` flags use the friendly aliases.
+
+## Choosing imperative vs declarative
+
+| Situation | Use |
+|-----------|-----|
+| Quick one-off, exploration, scripting, CI ad-hoc | `azd ai routine <verb>` |
+| Routine should be versioned with the agent and reproduced per environment | `azure.yaml` service + `azd deploy` |
+| Enable/disable/dispatch/inspect runs | `azd ai routine enable/disable/dispatch/run list` (no declarative equivalent) |
+| Delete | `azd ai routine delete` (always — declarative removal never deletes) |
+
+## Error handling
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| `unknown command "routine"` / `unknown command "ai"` | Extension not installed or azd too old | `azd extension install azure.ai.routines`; ensure `azd >= 1.27.0` |
+| Missing project endpoint error | No endpoint resolved | Set `AZURE_AI_PROJECT_ENDPOINT` via `azd env set`, run `azd ai project set <url>`, or pass `-p <url>` |
+| `routine "<name>" already exists` on create | Name collision | Re-run with `--force` to upsert, or choose a different name |
+| `--trigger`/`--action cannot be changed on an existing routine` | Trigger/action type is immutable | `delete` then `create` with the new type |
+| `--force is required when --no-prompt is set` on delete | Non-interactive delete without confirmation | Add `--force` |
+| `routine "<name>" not found` | Wrong name or wrong project | `azd ai routine list` to confirm the name and the resolved endpoint |
+| `host "..." is not a recognized Foundry host` | Endpoint host invalid | Use `https://<account>.services.ai.azure.com/api/projects/<project>` (no port) |
+| Network isolation / `PublicNetworkAccessDisabled` / `403` | Project has public access disabled | See [Network Isolation Errors](../../SKILL.md#network-isolation-errors) |
+
+## Additional Resources
+
+- [azd ai CLI Reference](../create/references/azd-ai-cli.md)
+- [Deploy a Foundry Agent](../deploy/deploy.md) — deploy the agent a routine will invoke
+- [Invoke a Foundry Agent](../invoke/invoke.md) — smoke-test the agent before scheduling it
+- [Microsoft Foundry Skill (index)](../../SKILL.md)

--- a/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/routine/routine.md
@@ -11,7 +11,7 @@ Create, read, update, and delete Microsoft Foundry **routines** with the Azure D
 | Primary CLI | `azd ai routine` (from extension `azure.ai.routines`) |
 | Install extension | `azd extension install azure.ai.routines` |
 | CRUD verbs | `create`, `list`, `show`, `update`, `delete` |
-| Lifecycle verbs | `enable`, `disable`, `dispatch`, `run list` |
+| Routine operation verbs | `enable`, `disable`, `dispatch`, `run list` |
 | Declarative form | `azure.yaml` service with `host: azure.ai.routine` (upserted by `azd deploy` / `azd up`) |
 | Project endpoint | Resolved from `-p/--project-endpoint`, then the active azd env (`AZURE_AI_PROJECT_ENDPOINT`), then global config, then `FOUNDRY_PROJECT_ENDPOINT` |
 | Output format | `--output json` or `--output table` (default `table`) on every verb |
@@ -99,7 +99,7 @@ A routine needs a **trigger** and an **action**. Build them from flags, or suppl
 ```bash
 # One-shot timer -> agent (responses API) by project-scoped agent name
 azd ai routine create nightly-report \
-  --trigger timer --at 2026-08-01T09:00:00Z \
+  --trigger timer --at <YYYY-MM-DDTHH:MM:SSZ> \
   --action agent-response --agent-name my-agent
 
 # Recurring cron schedule (min interval 5 minutes) with a time zone
@@ -130,7 +130,7 @@ Key flags:
 | Flag | Applies to | Notes |
 |------|-----------|-------|
 | `--trigger` | all | `timer` \| `recurring` \| `github-issue` \| `custom` (required unless `--file`) |
-| `--at` | timer | ISO 8601 UTC datetime, e.g. `2026-08-01T09:00:00Z` |
+| `--at` | timer | ISO 8601 UTC datetime, e.g. `<YYYY-MM-DDTHH:MM:SSZ>` |
 | `--cron` | recurring | 5-field cron, minimum interval 5 minutes |
 | `--time-zone` | recurring | IANA zone, e.g. `America/New_York` (default `UTC`; not valid for timer) |
 | `--connection-id`, `--owner`, `--repository`, `--issue-event` | github-issue | all four required; `--issue-event` is `opened` or `closed` |
@@ -174,7 +174,7 @@ azd ai routine delete daily-digest            # interactive confirmation
 azd ai routine delete daily-digest --force    # skip prompt (required with --no-prompt)
 ```
 
-## Lifecycle commands
+## Routine operations
 
 ```bash
 azd ai routine enable  daily-digest    # idempotent; enabling an enabled routine is a no-op


### PR DESCRIPTION
## Description

Support foundry routine and add it as a sub-skill.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
