### PR TITLE
fix: link azure-compute reference guides so vally reachability passes

### DIFF
--- a/plugin/skills/azure-compute/SKILL.md
+++ b/plugin/skills/azure-compute/SKILL.md
@@ -44,3 +44,12 @@ Azure compute intent?
 | **VM Troubleshooter** | [vm-troubleshooter.md](workflows/vm-troubleshooter/vm-troubleshooter.md) | User can't connect, RDP/SSH refused, black screen, needs password reset |
 | **Capacity Reservation** | [capacity-reservation.md](workflows/capacity-reservation/capacity-reservation.md) | User needs to reserve / guarantee VM capacity (CRG create / associate / disassociate) |
 | **Essential Machine Management** | [essential-machine-management.md](workflows/essential-machine-management/essential-machine-management.md) | User asks about EMM / machine enrollment / monitor |
+
+## Reference Guides
+
+Looked up on demand by the workflows above (primarily VM Recommender):
+
+- [vm-families.md](references/vm-families.md) — VM family-to-workload mapping
+- [vmss-guide.md](references/vmss-guide.md) — when to use VMSS, orchestration, autoscale
+- [vm-quotas.md](references/vm-quotas.md) — vCPU quota checks and CLI commands
+- [retail-prices-api.md](references/retail-prices-api.md) — Retail Prices API query patterns


### PR DESCRIPTION
## Problem

The `eval` job (vally-cli `--strict`) fails on **every open PR** with:

```
✗ orphan-files: Found 4 orphan file(s) not reachable from SKILL.md:
  references/retail-prices-api.md, references/vm-families.md,
  references/vm-quotas.md, references/vmss-guide.md
```

These four files *are* used — but only via `../../references/…` links from `workflows/vm-recommender/vm-recommender.md`. vally's reachability walk does not follow those upward relative links, so it treats them as orphans. This is a pre-existing failure on `main`, unrelated to any feature PR, but it shows a red `eval` check on all of them.

## Fix

Add a **Reference Guides** list to `azure-compute/SKILL.md` linking the four files directly (`references/…`), making them reachable in one hop.

## Verification

```
npx @microsoft/vally-cli@^0.5.0 lint plugin/skills/ --eval-spec evals/ --strict …
→ ✅ azure-compute (3/3 checks passed); full run exit 0
```

No behavior change — documentation reachability only.