### PR TITLE
Use npm ci in eval workflow dependencies

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -35,7 +35,10 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: npm install
+        run: |
+          npm ci --ignore-scripts
+          cd scripts
+          npm ci
 
       - name: Install test dependencies
         working-directory: tests

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -35,10 +35,11 @@ jobs:
           node-version: "22"
 
       - name: Install dependencies
-        run: |
-          npm ci --ignore-scripts
-          cd scripts
-          npm ci
+        run: npm ci --ignore-scripts
+
+      - name: Install stimuli validation dependencies
+        working-directory: scripts
+        run: npm ci --ignore-scripts
 
       - name: Install test dependencies
         working-directory: tests


### PR DESCRIPTION
## Summary
- Replace `npm install` with deterministic lockfile installs in the eval workflow.
- Use `npm ci --ignore-scripts` at repo root.
- Install `scripts` dependencies explicitly via `npm ci` so `npm run vally` still works.

## Safety rationale
- `npm ci` uses `package-lock.json` exactly and avoids lockfile drift in CI.
- Scripts are now installed in an explicit step, avoiding hidden `postinstall` behavior from root only.
