### PR TITLE
fix(microsoft-foundry): vnet

### DIFF
--- a/plugin/skills/microsoft-foundry/resource/private-network/private-network.md
+++ b/plugin/skills/microsoft-foundry/resource/private-network/private-network.md
@@ -20,9 +20,11 @@ allowed-tools: Read, Write, Bash, AskUserQuestion, microsoft_docs_search, micros
 
 | Topic | URL |
 |-------|-----|
-| Network isolation | https://learn.microsoft.com/azure/ai-foundry/how-to/configure-private-link |
-| Agent Service VNet | https://learn.microsoft.com/azure/ai-services/agents/how-to/virtual-networks |
-| Managed VNet | https://learn.microsoft.com/azure/ai-foundry/how-to/configure-managed-network |
+| Networking options (decision) | https://learn.microsoft.com/azure/foundry/agents/concepts/networking-options |
+| Network isolation | https://learn.microsoft.com/azure/foundry/how-to/configure-private-link |
+| Agent Service VNet | https://learn.microsoft.com/azure/foundry/agents/how-to/virtual-networks |
+| Networking deep dive (subnet/IP) | https://learn.microsoft.com/azure/foundry/agents/concepts/agents-networking-deep-dive |
+| Managed VNet | https://learn.microsoft.com/azure/foundry/how-to/managed-virtual-network |
 | Feature limitations | https://learn.microsoft.com/azure/foundry/how-to/configure-private-link#foundry-feature-limitations |
 
 ## When to Use
@@ -95,9 +97,7 @@ Catch blockers **before** deploying. These checks apply to all paths.
 az cognitiveservices account list-skus --location <region> --kind AIServices -o table
 ```
 
-**Provider Registrations:** `Microsoft.CognitiveServices`, `Microsoft.DocumentDB`, `Microsoft.Search`, `Microsoft.Network`.
-
-**Feature Flags:** For Managed VNet — verify `AI.ManagedVnetPreview` is registered.
+**Provider Registrations:** `Microsoft.CognitiveServices`, `Microsoft.DocumentDB`, `Microsoft.Search`, `Microsoft.Network`, and `Microsoft.App` (required for agent subnet delegation). The template README lists the authoritative set.
 
 > Do NOT deploy until all pre-flight checks pass.
 
@@ -121,6 +121,6 @@ If any test fails, run `microsoft_docs_search` for the error before attempting r
 
 ## Error Handling
 
-> ⚠️ **Critical retry rule:** If a deployment fails after the capability host step starts, the agent subnet gets a `legionservicelink` that cannot be removed. On retry, always use a **new VNet name** — never reuse the same agent subnet. See [references/deploy.md](references/deploy.md).
+> ⚠️ **Critical retry rule:** If a deployment fails after the capability host step starts, a service association (`legionservicelink`) stays on the agent subnet. Simplest retry: use a **new VNet name**. To reuse the same subnet, first purge the account and delete the capability host, then wait for the link to clear before redeploying. See [references/deploy.md](references/deploy.md).
 
 For all other errors, check `microsoft_docs_search` for current remediation before acting.

--- a/plugin/skills/microsoft-foundry/resource/private-network/references/deploy.md
+++ b/plugin/skills/microsoft-foundry/resource/private-network/references/deploy.md
@@ -14,6 +14,10 @@ az deployment group create \
 
 > ⚠️ Capability host provisioning is **asynchronous** (10–20 min). The CLI produces no output during this phase.
 
+## Managed VNet — Required Post-Deploy Step
+
+After the deployment succeeds, you **must** create the managed network's outbound private endpoint rules — including a **self-referencing private endpoint** back to the Foundry account, plus private endpoints to its dependent data resources. **Without them, hosted agents fail with `500 (403: Public access is disabled)`** — the agent container in Microsoft's managed VNet can't reach the account privately. Prompt agents are unaffected. Ensure the account's managed identity holds `Azure AI Enterprise Network Connection Approver` so the rules auto-approve. See the Managed VNet doc (Key Documentation) for the current steps, or the template README for its specific script.
+
 ## Monitor Progress
 
 Use exponential backoff — do NOT poll every 30 seconds.
@@ -65,7 +69,7 @@ Use `microsoft_docs_search` with the error code or message to find current remed
 
 | Error | Likely cause | Fix |
 |-------|-------------|-----|
-| `legionservicelink` / subnet in use | Orphaned service link from prior attempt | Use a new `vnetName` — do not reuse the prior VNet |
+| `legionservicelink` / subnet in use | Capability host association still linked to the agent subnet | Use a new `vnetName`, or purge the account and delete the capability host, then wait for the link to clear before reusing the subnet |
 | `AuthorizationFailed` on `validate/action` | Missing Contributor role | Assign Contributor + User Access Administrator to deploying identity |
 | `SubnetDelegationAlreadyExists` | Agent subnet already delegated to another resource | Use a new VNet or open a support ticket to remove the delegation |
 | `disableLocalAuth` policy violation | Template defaults to `false` | Set `disableLocalAuth: true` in Bicep params |

--- a/plugin/skills/microsoft-foundry/resource/private-network/references/deploy.md
+++ b/plugin/skills/microsoft-foundry/resource/private-network/references/deploy.md
@@ -16,7 +16,16 @@ az deployment group create \
 
 ## Managed VNet — Required Post-Deploy Step
 
-After the deployment succeeds, you **must** create the managed network's outbound private endpoint rules — including a **self-referencing private endpoint** back to the Foundry account, plus private endpoints to its dependent data resources. **Without them, hosted agents fail with `500 (403: Public access is disabled)`** — the agent container in Microsoft's managed VNet can't reach the account privately. Prompt agents are unaffected. Ensure the account's managed identity holds `Azure AI Enterprise Network Connection Approver` so the rules auto-approve. See the Managed VNet doc (Key Documentation) for the current steps, or the template README for its specific script.
+After the deployment succeeds, you **must** create the managed network's outbound private endpoint rules:
+
+- A **self-referencing private endpoint** back to the Foundry account.
+- Private endpoints to its dependent data resources.
+
+> ⚠️ **Without them, hosted agents fail with `500 (403: Public access is disabled)`** — the agent container in Microsoft's managed VNet can't reach the account privately. Prompt agents are unaffected.
+
+The account's managed identity must hold `Azure AI Enterprise Network Connection Approver` so the rules auto-approve.
+
+See the Managed VNet doc (Key Documentation) for current steps, or the template README for its specific script.
 
 ## Monitor Progress
 

--- a/plugin/skills/microsoft-foundry/resource/private-network/references/intake.md
+++ b/plugin/skills/microsoft-foundry/resource/private-network/references/intake.md
@@ -118,7 +118,7 @@ Confirm the approach with the user before continuing to Tier 2.
 **BYO resources:** Reuse existing Cosmos DB / Storage / AI Search, or create new?
 
 > If reusing, confirm all in same region as VNet.
-> If reusing AI Search, it must accept Entra ID (AAD) data-plane auth — a key-only service makes agents fail with HTTP 403. Enable with `az search service update --name <n> --resource-group <rg> --auth-options aadOrApiKey --aad-auth-failure-mode http401WithBearerChallenge`.
+> If reusing AI Search, it must accept Entra ID (AAD) data-plane auth — a key-only service makes agents fail with HTTP 403. Enable with `az search service update --name <search-name> --resource-group <search-rg> --auth-options aadOrApiKey --aad-auth-failure-mode http401WithBearerChallenge`.
 
 **Key Vault / App Insights:** If user mentions existing ones, collect resource IDs. Optional.
 

--- a/plugin/skills/microsoft-foundry/resource/private-network/references/intake.md
+++ b/plugin/skills/microsoft-foundry/resource/private-network/references/intake.md
@@ -38,7 +38,7 @@ Scan the user's message before asking:
 
 For unanswered items, use `AskUserQuestion`:
 
-**VNet model:** BYO VNet or Managed VNet (preview)?
+**VNet model:** BYO VNet or Managed VNet?
 
 **Agents:** Agent workloads, or just models/projects?
 
@@ -101,8 +101,6 @@ Confirm the approach with the user before continuing to Tier 2.
 
 ### Managed VNet only
 
-**Feature flag:** Run `az feature show` to verify `AI.ManagedVnetPreview` is registered. If not, register and wait 15–30 min.
-
 **Outbound mode:** Internet outbound (default) or approved outbound only?
 
 **MCP:** Public MCP endpoints or private MCP on VNet?
@@ -120,6 +118,7 @@ Confirm the approach with the user before continuing to Tier 2.
 **BYO resources:** Reuse existing Cosmos DB / Storage / AI Search, or create new?
 
 > If reusing, confirm all in same region as VNet.
+> If reusing AI Search, it must accept Entra ID (AAD) data-plane auth — a key-only service makes agents fail with HTTP 403. Enable with `az search service update --name <n> --resource-group <rg> --auth-options aadOrApiKey --aad-auth-failure-mode http401WithBearerChallenge`.
 
 **Key Vault / App Insights:** If user mentions existing ones, collect resource IDs. Optional.
 
@@ -161,12 +160,14 @@ After collecting all requirements, validate the user's configuration against cur
 
 | Topic | URL |
 |-------|-----|
-| Network isolation overview | https://learn.microsoft.com/azure/ai-foundry/how-to/configure-private-link |
-| Agent Service private networking | https://learn.microsoft.com/azure/ai-services/agents/how-to/virtual-networks |
-| Managed VNet configuration | https://learn.microsoft.com/azure/ai-foundry/how-to/configure-managed-network |
+| Networking options (decision) | https://learn.microsoft.com/azure/foundry/agents/concepts/networking-options |
+| Network isolation overview | https://learn.microsoft.com/azure/foundry/how-to/configure-private-link |
+| Agent Service private networking | https://learn.microsoft.com/azure/foundry/agents/how-to/virtual-networks |
+| Networking deep dive (subnet/IP) | https://learn.microsoft.com/azure/foundry/agents/concepts/agents-networking-deep-dive |
+| Managed VNet configuration | https://learn.microsoft.com/azure/foundry/how-to/managed-virtual-network |
 | Agent Service FAQ — VNet | https://learn.microsoft.com/azure/foundry/agents/faq#virtual-networking |
-| Supported regions & availability | https://learn.microsoft.com/azure/ai-foundry/reference/region-support |
-| NSP | https://learn.microsoft.com/en-us/azure/networking/network-security-perimeter |
+| Supported regions & availability | https://learn.microsoft.com/azure/foundry/reference/region-support |
+| NSP | https://learn.microsoft.com/azure/foundry/how-to/add-foundry-to-network-security-perimeter |
 | Feature Limitations | https://learn.microsoft.com/en-us/azure/foundry/how-to/configure-private-link#foundry-feature-limitations |
 
 > These URLs may change. If a fetch returns 404, use `microsoft_docs_search` to find the current page.

--- a/plugin/skills/microsoft-foundry/resource/private-network/references/post-deployment-validation.md
+++ b/plugin/skills/microsoft-foundry/resource/private-network/references/post-deployment-validation.md
@@ -46,6 +46,18 @@ All should return `Disabled`.
 
 > **T10 (Private Basic):** Steps 2-5 below do not apply — T10 has no agents, no capability host, and no BYO resources. Setup is complete after Step 1.
 
+### 1.4 Managed VNet — Outbound Private Endpoint Rules
+
+For Managed VNet, verify the managed network's **outbound** private endpoint rules exist, especially the self-referencing private endpoint back to the account:
+
+```bash
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<account>/managedNetworks/default/outboundRules?api-version=2025-10-01-preview" \
+  --query "value[].{name:name,type:properties.type,status:properties.status}" -o table
+```
+
+Expect a self-referencing private endpoint to the account plus private endpoints to its dependent data resources. A missing self-endpoint causes hosted agents to return `500 (403)`.
+
 ## 2. RBAC Role Assignment (no VNet required)
 
 The template does not assign data-plane roles automatically.

--- a/plugin/skills/microsoft-foundry/resource/private-network/references/post-deployment-validation.md
+++ b/plugin/skills/microsoft-foundry/resource/private-network/references/post-deployment-validation.md
@@ -52,7 +52,7 @@ For Managed VNet, verify the managed network's **outbound** private endpoint rul
 
 ```bash
 az rest --method get \
-  --url "https://management.azure.com/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<account>/managedNetworks/default/outboundRules?api-version=2025-10-01-preview" \
+  --url "https://management.azure.com/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<ai-account>/managedNetworks/default/outboundRules?api-version=2025-10-01-preview" \
   --query "value[].{name:name,type:properties.type,status:properties.status}" -o table
 ```
 

--- a/plugin/skills/microsoft-foundry/resource/private-network/references/template-index.md
+++ b/plugin/skills/microsoft-foundry/resource/private-network/references/template-index.md
@@ -6,11 +6,13 @@ Official templates for deploying Microsoft Foundry. Each template may be availab
 
 **Terraform templates:** https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-terraform/
 
+**Deployment helpers:** https://github.com/microsoft-foundry/foundry-samples/tree/main/infrastructure/infrastructure-setup-bicep/deployment-tools/ — `preflight` (pre-deploy checks) and `cleanup` (correct capability-host/subnet teardown order).
+
 Not all templates exist in both Bicep and Terraform. Some have format-specific variants (e.g., Terraform has `15a`/`15b` for new VNet vs BYO VNet; Bicep has `15a` for evaluation-only).
 
 ## How to Use
 
-1. Fetch the **directory listing** from the relevant repo URL above — the folder names are descriptive (e.g., `15-private-network-standard-agent-setup`, `18-managed-virtual-network-preview`)
+1. Fetch the **directory listing** from the relevant repo URL above — the folder names are descriptive (e.g., `15-private-network-standard-agent-setup`, `18-managed-virtual-network`)
 2. Narrow to 1–2 candidates that match the user's requirements based on folder names
 3. Fetch only those candidates' READMEs for full details (prerequisites, parameters, deployment instructions)
 


### PR DESCRIPTION
## Description

Sync latest foundry private network sub skill. 
- remove the "preview" tag/suffix and feature flag
- update to latest links and templates
- update post-deploy step

## Checklist

- [X] Tests pass locally (`cd tests && npm test`)
- [X] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [X] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

