### PR TITLE
fix: correct toolbox reference docs from live testing

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/azd-ai-cli.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/azd-ai-cli.md
@@ -22,9 +22,9 @@ azd deploy                           # core azd; packages + registers new agent 
 azd ai agent endpoint update         # patch agentEndpoint / agentCard in place
 
 azd ai connection list / show / create / update / delete
-azd ai toolbox list / show / create / update / delete
+azd ai toolbox list / show / create / publish / delete
 azd ai toolbox connection add / remove / list
-azd ai toolbox version list
+azd ai toolbox versions list
 
 azd ai agent files list / show / upload / download / delete / stat / mkdir
 azd ai agent sessions list / show / create / update / delete

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/foundry-tool-catalog.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/foundry-tool-catalog.md
@@ -638,7 +638,6 @@ $connId = "/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Cognitiv
 $tok  = az account get-access-token --resource "https://ai.azure.com" --query accessToken -o tsv
 $hdr  = @{ Authorization      = "Bearer $tok"
            "Content-Type"     = "application/json"
-           "Foundry-Features" = "Toolboxes=V1Preview"   # REQUIRED
            Accept             = "application/json, text/event-stream" }
 
 # 1. Create a toolbox version with the connection attached.
@@ -669,7 +668,7 @@ Invoke-WebRequest -Method POST -Headers $hdr -UseBasicParsing -Body $call `
    -Uri "$dp/toolboxes/$tb/mcp?api-version=v1"
 ```
 
-The `Foundry-Features: Toolboxes=V1Preview` header is mandatory — without it the dataplane returns 404. The response body for `/mcp` is plain JSON (no SSE `data:` framing) despite the `text/event-stream` Accept.
+The response body for `/mcp` is plain JSON (no SSE `data:` framing) despite the `text/event-stream` Accept.
 
 ## Required RBAC summary
 
@@ -693,7 +692,7 @@ The `Foundry-Features: Toolboxes=V1Preview` header is mandatory — without it t
 - **`metadata.audience` is required for `ProjectManagedIdentity`.** Without it the MCP server returns 401.
 - **Header names for `CustomKeys` come from the catalog**, not from a default `Authorization: Bearer` template.
 - **`ApiKey` is rejected** for `category=RemoteTool`. Use `CustomKeys` for static secrets.
-- **OAuth consent is per-user, per-connection, per-project.** Each new caller hits `CONSENT_REQUIRED` (code `-32007`) once and must open the URL the toolbox returns.
+- **OAuth consent is per-user, per-connection, per-project.** Each new caller hits `CONSENT_REQUIRED` once (returned as a nested string code inside an outer `-32006` error) and must open the URL the toolbox returns.
 - **`api.githubcopilot.com/mcp` rejects user OAuth-App tokens.** Use a self-hosted MCP or fall back to OpenAPI.
 - **PMI forwarder drops `target` query strings and mints a fixed audience.** Setting `properties.audience` is accepted but does not change what is sent.
 - **Network-secured Foundry** projects cannot use private-endpoint-only MCP servers — only public endpoints reachable from the Foundry data plane and the Connector Namespace.

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/skills/skill-toolbox-attach.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/skills/skill-toolbox-attach.md
@@ -109,21 +109,18 @@ URL="$PE/toolboxes/<toolbox>/mcp?api-version=v1"
 curl -s -X POST "$URL" \
   -H "Authorization: Bearer $TOK" \
   -H "Content-Type: application/json" \
-  -H "Foundry-Features: Toolboxes=V1Preview" \
   -d '{"jsonrpc":"2.0","id":1,"method":"resources/list","params":{}}'
 
 # Read skill index
 curl -s -X POST "$URL" \
   -H "Authorization: Bearer $TOK" \
   -H "Content-Type: application/json" \
-  -H "Foundry-Features: Toolboxes=V1Preview" \
   -d '{"jsonrpc":"2.0","id":2,"method":"resources/read","params":{"uri":"skill://index.json"}}'
 
 # Read a specific skill's content
 curl -s -X POST "$URL" \
   -H "Authorization: Bearer $TOK" \
   -H "Content-Type: application/json" \
-  -H "Foundry-Features: Toolboxes=V1Preview" \
   -d '{"jsonrpc":"2.0","id":3,"method":"resources/read","params":{"uri":"skill://my-skill/SKILL.md"}}'
 ```
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/toolbox-reference.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/toolbox-reference.md
@@ -14,7 +14,6 @@ The toolbox MCP endpoint is constructed from the **project endpoint** + **toolbo
 - **Project endpoint** format: `https://<account>.services.ai.azure.com/api/projects/<project>`
 - The latest-version endpoint always serves the toolbox's `default_version`.
 - Use the specific-version endpoint to test a version before promoting it.
-- **Required header** on every request: `Foundry-Features: Toolboxes=V1Preview`
 - `?api-version=v1` query parameter is **required** — requests without it return HTTP 400.
 
 ### Agent env contract
@@ -35,7 +34,7 @@ TOOLBOX_ENDPOINT=https://{host}/api/projects/{project}/toolboxes/{toolbox_name}/
 
 Toolboxes use **Model Context Protocol (MCP)** — JSON-RPC 2.0 over HTTP POST:
 
-- **`initialize`** — Handshake to establish an MCP session. Returns a `mcp-session-id` header to include in subsequent requests.
+- **`initialize`** — Optional MCP handshake. The toolbox endpoint is effectively **stateless**: it does **not** return an `mcp-session-id` header, and `tools/list` / `tools/call` work without first calling `initialize` or passing any session header.
 - **`tools/list`** — Returns all available tools with names, descriptions, and input schemas.
 - **`tools/call`** — Invokes a tool with arguments and returns structured results.
 
@@ -43,10 +42,9 @@ Toolboxes use **Model Context Protocol (MCP)** — JSON-RPC 2.0 over HTTP POST:
 
 ### Tool naming
 
-- **MCP-sourced tools** (`type: mcp`) are exposed as `{server_label}.{tool_name}` (e.g. `myserver.get_info`). Call them with the prefixed name in `tools/call`.
+- **MCP-sourced tools** (`type: mcp`) are exposed as `{server_label}___{tool_name}` — joined by **three underscores** (e.g. `myserver___get_info`). Call them with the prefixed name in `tools/call`.
 - **All other tool types** (`web_search`, `file_search`, `azure_ai_search`, `code_interpreter`, `openapi`, `a2a_preview`, `work_iq_preview`, `fabric_iq_preview`, …) use the value of the entry's `name` field, or the default tool name if `name` is unset.
 - **Tool Search** injects two platform meta-tools whose names are always `tool_search` and `call_tool`.
-- Some clients (e.g. GitHub Copilot SDK) reject dots in tool names — the Copilot bridge replaces `.` with `_` (so `myserver.get_info` becomes `myserver_get_info`) and reverses it before calling MCP.
 
 Each tool returned by `tools/list` includes a `_meta.tool_configuration` block with at least the `type`, plus type-specific fields (e.g. `server_label`, `server_url`, `require_approval` for MCP).
 
@@ -61,22 +59,24 @@ Each tool returned by `tools/list` includes a `_meta.tool_configuration` block w
 
 ## OAuth Consent Handling
 
-When a toolbox includes an OAuth-based MCP connection (e.g., GitHub OAuth), the **first** call from a new user triggers a `CONSENT_REQUIRED` error (MCP error code **`-32007`**). The error message contains the consent URL. This error can surface on either `initialize` or `tools/call` depending on when the server discovers the missing grant.
+When a toolbox includes an OAuth-based MCP connection (e.g., GitHub OAuth), the **first** call from a new user surfaces a consent requirement. The toolbox wraps per-source failures in a JSON-RPC error with outer **code `-32006`** (`tools/list failed for N tool source(s)…`); the failing source's nested error carries the **string** code `"CONSENT_REQUIRED"`, and its `message` is the consent URL. This can surface on `tools/list`, `initialize`, or `tools/call` depending on when the server discovers the missing grant.
 
 **Agent code must handle this:**
 
-1. Catch MCP error code **`-32007`** from `tools/call` **or** during MCP session initialization.
-2. Extract the consent URL from the error message.
+1. On a `-32006` error, parse the outer `message` — it embeds a JSON `{"errors":[{"name":...,"error":{"code":"CONSENT_REQUIRED","message":"<consent-url>"}}]}` payload.
+2. Detect the nested `"code":"CONSENT_REQUIRED"` and read the consent URL from that nested `message`.
 3. Log the URL and surface it to the user (e.g., print to stdout or return in the agent response).
 4. After the user completes the OAuth flow in a browser, retry the call — subsequent calls succeed without re-prompting.
 
-Example error shape:
+Example error shape (as actually returned):
 
 ```json
 {
+  "jsonrpc": "2.0",
+  "id": 1,
   "error": {
-    "code": -32007,
-    "message": "User consent is required. Please visit: https://..."
+    "code": -32006,
+    "message": "tools/list failed for 1 tool source(s), succeeded for 0 tool source(s) {\"errors\":[{\"name\":\"GitHub\",\"type\":\"mcp\",\"error\":{\"code\":\"CONSENT_REQUIRED\",\"message\":\"https://logic-apis-<region>.consent.azure-apim.net/login?data=...\"}}]}"
   }
 }
 ```
@@ -132,18 +132,19 @@ TOKEN=$(az account get-access-token --resource https://ai.azure.com --query acce
 TOOLBOX_URL="https://<account>.services.ai.azure.com/api/projects/<project>/toolboxes/<name>/mcp?api-version=v1"
 ```
 
-**2. Initialize MCP session:**
+**2. (Optional) Initialize MCP session:**
+
+The toolbox endpoint is stateless, so this step is not required — `tools/list` and `tools/call` work without it. Run it only to confirm the handshake:
 
 ```bash
 curl -sS -X POST "$TOOLBOX_URL" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -H "Foundry-Features: Toolboxes=V1Preview" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"debug","version":"1.0.0"}}}' \
   -D - | head -20
 ```
 
-Save the `mcp-session-id` header from the response for subsequent calls.
+No `mcp-session-id` header is returned, and none is needed on later calls.
 
 **3. List tools:**
 
@@ -151,8 +152,6 @@ Save the `mcp-session-id` header from the response for subsequent calls.
 curl -sS -X POST "$TOOLBOX_URL" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -H "Foundry-Features: Toolboxes=V1Preview" \
-  -H "mcp-session-id: <session-id-from-step-2>" \
   -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}' | jq .
 ```
 
@@ -160,7 +159,7 @@ Checklist:
 
 - Response contains `result.tools[]` with `len > 0`
 - Each tool has `name`, `description`, and `inputSchema` with a `properties` field
-- MCP tool names for remote servers are prefixed with `server_label` (e.g., `myserver.get_info`)
+- MCP tool names for remote servers are prefixed with `server_label` joined by three underscores (e.g., `myserver___get_info`)
 - All other tool types use the entry's `name` field value (or the default tool name)
 
 **4. Call a tool (optional):**
@@ -169,8 +168,6 @@ Checklist:
 curl -sS -X POST "$TOOLBOX_URL" \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
-  -H "Foundry-Features: Toolboxes=V1Preview" \
-  -H "mcp-session-id: <session-id-from-step-2>" \
   -d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"<tool_name>","arguments":{"query":"test"}}}' | jq .
 ```
 
@@ -178,14 +175,14 @@ curl -sS -X POST "$TOOLBOX_URL" \
 
 | Error | Cause | Resolution |
 |-------|-------|------------|
-| `CONSENT_REQUIRED` (code `-32007`) | OAuth MCP connection needs user consent | Open consent URL in browser, complete OAuth flow, retry |
+| `CONSENT_REQUIRED` (nested string code inside an outer `-32006` error) | OAuth MCP connection needs user consent | Parse the consent URL from the nested error `message`, open it in a browser, complete OAuth, retry |
 | 401 on MCP calls | Expired token or wrong scope | Use scope `https://ai.azure.com/.default` (not `cognitiveservices`) and refresh token on every request |
 | OAuth/ARA errors when calling MCP directly from agent | Direct MCP wiring without toolbox token passthrough | Wire the MCP server into a toolbox and call the toolbox endpoint instead — Foundry handles consent + refresh |
 | 400 `invalid_payload: Multiple tools without identifiers found` | Two unnamed tools of the same type (or duplicate `server_label`) in one toolbox | Keep at most one unnamed tool per type; give each MCP tool a unique `server_label` |
 | `tools/list` returns 0 tools | Toolbox version still provisioning, or tool type not yet available in the region | Wait ~10s and retry; try a different region |
 | `tools/list` returns 0 tools for MCP/A2A only | Invalid or missing connection credentials | Verify `project_connection_id` exists and credentials are correct; for MI auth, check RBAC on the target service |
 | `tools/list` returns 0 tools for OpenAPI only | Invalid OpenAPI spec (malformed paths, missing operationIds) | Validate the spec against OpenAPI 3.0/3.1; for MI auth, also verify RBAC |
-| Tool not found on `tools/call` | Missing `server_label.` prefix for MCP-sourced tools | Call as `{server_label}.{tool_name}` |
+| Tool not found on `tools/call` | Missing `server_label___` prefix for MCP-sourced tools | Call as `{server_label}___{tool_name}` (three underscores) |
 | 500 on `prompts/list` | Not supported by toolbox endpoint | Pass `load_prompts=False` to MCP client constructor |
 | 500 on `send_ping()` (MAF `MCPStreamableHTTPTool._ensure_connected`) | Toolbox MCP server doesn't implement `ping` | Disable the ping check or override with a no-op |
 | 500 with non-streaming `tools/call` | Non-streaming not supported | Always use `stream=True` for toolbox MCP tools |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/toolbox-reference.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/toolbox-reference.md
@@ -63,12 +63,18 @@ When a toolbox includes an OAuth-based MCP connection (e.g., GitHub OAuth), the 
 
 **Agent code must handle this:**
 
-1. On a `-32006` error, parse the outer `message` — it embeds a JSON `{"errors":[{"name":...,"error":{"code":"CONSENT_REQUIRED","message":"<consent-url>"}}]}` payload.
-2. Detect the nested `"code":"CONSENT_REQUIRED"` and read the consent URL from that nested `message`.
+1. On a `-32006` error, extract the embedded JSON from the outer `message`. **The message is not directly JSON-parseable** — it begins with a human-readable prefix (`tools/list failed for N tool source(s), succeeded for M tool source(s) `) followed by a `{"errors":[...]}` payload. Locate the first `{` and parse from there (do **not** call `JSON.parse` on the whole `message`):
+
+   ```python
+   msg = err["message"]
+   payload = json.loads(msg[msg.index("{"):])   # slice off the prefix first
+   ```
+
+2. Detect the nested `"code":"CONSENT_REQUIRED"` in `payload["errors"][i]["error"]` and read the consent URL from that nested `message`.
 3. Log the URL and surface it to the user (e.g., print to stdout or return in the agent response).
 4. After the user completes the OAuth flow in a browser, retry the call — subsequent calls succeed without re-prompting.
 
-Example error shape (as actually returned):
+Example error shape (as actually returned — note the prefix text before the JSON):
 
 ```json
 {

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/tools.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/tools.md
@@ -15,11 +15,12 @@ azd extension install azure.ai.toolboxes
 ## The flow (every recipe)
 
 1. Create the **connection** (`azd ai connection create ...`).
-2. Create or update the **toolbox** (`azd ai toolbox create` / `connection add`).
-3. Read the endpoint (`azd ai toolbox show <name> --output json`).
-4. `azd env set TOOLBOX_<NAME>_MCP_ENDPOINT "<endpoint>"`.
-5. Reference it in the agent service's `environmentVariables` in `azure.yaml`.
-6. `azd deploy`.
+2. Create the **toolbox** (`azd ai toolbox create`) or add tools to an existing one (`azd ai toolbox connection add`).
+3. If you added to an existing toolbox, **promote the new version** (`azd ai toolbox publish <name> <version>`) — `create` publishes its first version automatically, but later mutations do not.
+4. Read the endpoint (`azd ai toolbox show <name> --output json`).
+5. `azd env set TOOLBOX_<NAME>_MCP_ENDPOINT "<endpoint>"`.
+6. Reference it in the agent service's `environmentVariables` in `azure.yaml`.
+7. `azd deploy`.
 
 ## Env var naming convention
 
@@ -36,17 +37,17 @@ To auto-pick up new default versions without redeploying, drop the `/versions/<v
 
 | Command | What it does |
 |---------|--------------|
-| `azd ai toolbox create <name> --from-file <path>` | Create toolbox + publish v1. File must list at least one connection. |
-| `azd ai toolbox connection add <toolbox> <connection> [--index ...] [--instance-name ...]` | Attach one; new default version. |
-| `azd ai toolbox connection add <toolbox> --from-file <path>` | Attach many in one call; ONE new version. |
-| `azd ai toolbox connection remove <toolbox> <connection>` | Detach; new default version. Refuses to leave zero tools. |
+| `azd ai toolbox create <name> --from-file <path>` | Create toolbox + its first version. File must list at least one connection, skill, or tool. |
+| `azd ai toolbox connection add <toolbox> <connection> [--index ...] [--instance-name ...]` | Attach one; creates a new version (default unchanged). |
+| `azd ai toolbox connection add <toolbox> --from-file <path>` | Attach many in one call; ONE new version (default unchanged). |
+| `azd ai toolbox connection remove <toolbox> <connection>` | Detach; creates a new version (default unchanged). Refuses to leave zero tools. |
 | `azd ai toolbox show <name> [--version <ver>]` | Show toolbox + MCP endpoint URL. |
 | `azd ai toolbox list` | List toolboxes. |
-| `azd ai toolbox version list <toolbox>` | List versions. |
-| `azd ai toolbox update <name> --default-version <ver>` | Re-point default (rollback). |
+| `azd ai toolbox versions list <toolbox>` | List versions. |
+| `azd ai toolbox publish <name> <version>` | Promote a version to default (also used to roll back). |
 | `azd ai toolbox delete <name> [--version <ver>] [--force]` | Delete toolbox or one version. |
 
-Every mutation publishes a new immutable version and promotes it to default.
+Every mutation publishes a new immutable version but does **not** change the default; run `azd ai toolbox publish <name> <version>` to promote one.
 
 ## `--from-file` shape
 
@@ -133,9 +134,10 @@ connections:
 ```bash
 azd ai toolbox create agent-tools --from-file tools.yaml
 # OR (existing toolbox): azd ai toolbox connection add agent-tools --from-file tools.yaml
+#   then promote it: azd ai toolbox publish agent-tools <version>
 ```
 
-One new default version regardless of how many connections you attach in one call.
+One new version regardless of how many connections you attach in one call. `create` publishes it as the first (default) version; `connection add` leaves the default unchanged until you `publish`.
 
 ## Tools the CLI does NOT manage today
 
@@ -143,13 +145,7 @@ One new default version regardless of how many connections you attach in one cal
 
 To include any built-in in a toolbox today, use the Python / .NET / JS SDK or call the REST API directly.
 
-## Required header (agent code)
-
-Every MCP request to the toolbox endpoint must include:
-
-```http
-Foundry-Features: Toolboxes=V1Preview
-```
+## Token and RBAC (agent code)
 
 Token scope: `https://ai.azure.com/.default`. RBAC: the calling identity (developer + agent identity at runtime) needs **Foundry User** on the Foundry project.
 
@@ -166,7 +162,6 @@ def _inject_auth(request: httpx.Request) -> None:
     # Per-request token refresh -- static tokens expire in ~1 hour.
     token = _credential.get_token("https://ai.azure.com/.default").token
     request.headers["Authorization"] = f"Bearer {token}"
-    request.headers["Foundry-Features"] = "Toolboxes=V1Preview"
 
 tool = MCPStreamableHTTPTool(
     name="github",                    # becomes server_label prefix
@@ -184,7 +179,7 @@ Install: `pip install httpx azure-identity agent-framework`.
 - **Always stream.** Non-streaming is not supported.
 - **Don't call `prompts/list`.** Returns `500`. Pass `load_prompts=False`.
 - **Don't `send_ping()`** with generic clients (returns `500`). Agent Framework handles this.
-- **Tool names are prefixed with `server_label`.** `name="myserver"` -> tools appear as `myserver.<tool>`.
+- **Tool names are prefixed with `server_label`.** `name="myserver"` -> tools appear as `myserver___<tool>` (joined by three underscores).
 - **`require_approval`** is the client's responsibility -- the toolbox proxy does NOT enforce it. Pass `approval_mode="never_require"` or wire an approval handler.
 
 ## Verify the wire end-to-end
@@ -202,10 +197,9 @@ azd ai agent invoke "list the tools you have access to"
 |---------|--------------|
 | `TOOLBOX_<NAME>_MCP_ENDPOINT` not set | Run `azd ai toolbox show` + `azd env set`. |
 | Env var missing in deployed agent | Add to the agent service's `environmentVariables` in `azure.yaml`, `azd deploy`. |
-| `400` mentioning `Toolboxes` | Missing `Foundry-Features: Toolboxes=V1Preview` header. |
 | `401` on MCP calls | Expired / wrong-scope token. Use `https://ai.azure.com/.default`; refresh per request. |
 | `403 Forbidden` | Caller missing `Foundry User` role. |
 | `500` on `prompts/list` / ping | Disable in MCP client (`load_prompts=False`). |
 | Empty response, tool never called | `require_approval: always` with no handler. Pass `approval_mode="never_require"`. |
 | `tools/list` returns zero | Bad credentials, or toolbox version still provisioning. |
-| Tool names don't match | Use `{server_label}.{tool_name}`. |
+| Tool names don't match | Use `{server_label}___{tool_name}` (three underscores). |

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-toolbox-in-hosted-agent.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/use-toolbox-in-hosted-agent.md
@@ -193,22 +193,22 @@ See [azd `params` reference](https://learn.microsoft.com/azure/developer/azure-d
 > $PE = "https://<account>.services.ai.azure.com/api/projects/<project>"
 > ```
 
-### Retarget the default version — `azd ai toolbox update`
+### Retarget the default version — `azd ai toolbox publish`
 
-Each toolbox version is **immutable**. The version an agent actually hits is the one marked `*` in `version list` — i.e. the **default version**. Use `update` to point that pointer at any existing version (e.g. rollback to a known-good version after a bad publish).
+Each toolbox version is **immutable**. The version an agent actually hits is the one marked `*` in `versions list` — i.e. the **default version**. Use `publish` to point that pointer at any existing version (e.g. rollback to a known-good version after a bad publish).
 
 ```pwsh
 # Inspect first — current default is marked with '*'
-azd ai toolbox version list my-toolbox --project-endpoint $PE
+azd ai toolbox versions list my-toolbox --project-endpoint $PE
 
 # Retarget the default
-azd ai toolbox update my-toolbox --default-version 20 --project-endpoint $PE --no-prompt
+azd ai toolbox publish my-toolbox 20 --project-endpoint $PE --no-prompt
 
 # Verify (Default version / Shown version / Endpoint all reflect the new value)
 azd ai toolbox show my-toolbox --project-endpoint $PE
 ```
 
-- `--default-version` is the only field `update` accepts today.
+- `publish <name> <version>` promotes an existing version to default (also used to roll back).
 - Validated: switched `default-tb` from version 21 → 20 → 21; both `show` and the computed MCP endpoint (`.../toolboxes/<name>/versions/<n>/mcp?api-version=v1`) tracked the change immediately.
 
 ### End-to-end smoke test
@@ -220,14 +220,13 @@ $TOK = az account get-access-token --resource "https://ai.azure.com" --query acc
 $H   = @{
   Authorization      = "Bearer $TOK"
   "Content-Type"     = "application/json"
-  "Foundry-Features" = "Toolboxes=V1Preview"
 }
 $URL = "$PE/toolboxes/my-toolbox/mcp?api-version=v1"
 $body = @{ jsonrpc = "2.0"; id = 1; method = "tools/list"; params = @{} } | ConvertTo-Json
 (Invoke-RestMethod -Method POST -Uri $URL -Headers $H -Body $body).result.tools | Select-Object name
 ```
 
-`?api-version=v1` and the `Foundry-Features: Toolboxes=V1Preview` header are both required.
+`?api-version=v1` is required.
 
 ## Code Integration Patterns
 
@@ -251,11 +250,10 @@ The sample repo provides integration patterns for both Python and C#. Read the s
 **Notes** (apply to all patterns, both Python and C#):
 
 - Auth: Inject a bearer token with scope `https://ai.azure.com/.default` on every request (Python: `httpx.Auth` subclass; C#: `DefaultAzureCredential` + `BearerTokenAuthenticationPolicy`).
-- Header: Always include `Foundry-Features: Toolboxes=V1Preview`.
 - MCP client: Pass `load_prompts=False` — the toolbox endpoint does not support `prompts/list`.
 - Endpoint: Construct from `{project_endpoint}/toolboxes/{toolbox_name}/mcp?api-version=v1`.
 - Multi-tool toolboxes: at most one tool per unnamed type, and unique `server_label` per MCP tool (see [toolbox-reference.md](toolbox-reference.md#multi-tool-toolbox-constraint)). `toolbox_search_preview` doesn't count toward this limit.
-- Tool naming: MCP-sourced tools are prefixed `{server_label}.{tool_name}`; **all other tool types** use the entry's `name` field value (or the default tool name).
+- Tool naming: MCP-sourced tools are prefixed `{server_label}___{tool_name}` (three underscores); **all other tool types** use the entry's `name` field value (or the default tool name).
 
 > 💡 **Tip:** If MCP tools have `require_approval: "always"` in `_meta.tool_configuration`, the agent runtime must ask the user for confirmation before invoking. The toolbox endpoint does not enforce this — your agent code is responsible.
 


### PR DESCRIPTION
## Summary

Corrects the microsoft-foundry skill's toolbox reference docs based on **live testing** against a real Foundry project (azd extensions `azure.ai.toolboxes` 1.0.0-beta.1, `azure.ai.connections` 1.0.0-beta.1). Three themes:

- **Remove obsolete `Foundry-Features: Toolboxes=V1Preview` header** from every curl / PowerShell / httpx example and its "required header" prose. The toolbox MCP endpoint no longer needs the preview flag.
- **Fix MCP tool-name separator** `{server_label}.{tool_name}` → `{server_label}___{tool_name}` (three underscores), and drop the stale Copilot dot-swap note. Verified live (e.g. `azdverify-pub___ask_question`).
- **Fix OAuth consent error shape** to outer JSON-RPC `-32006` + nested string code `"CONSENT_REQUIRED"` (was `-32007`). Confirmed live against a managed OAuth GitHub connection returning the Azure APIM consent URL.
- **Document `initialize` as optional/stateless** — the endpoint returns no `mcp-session-id`; `tools/list` / `tools/call` work without it.
- **Fix azd CLI surface**: `versions list` (not `version list`), `publish <name> <version>` (not `update --default-version`); mutations create a new immutable version but do **not** auto-promote the default.

## Files changed

- `references/toolbox-reference.md` — consent `-32006`, stateless `initialize`, `___` separator
- `references/tools.md` — CLI surface (`versions list`, `publish`), V1Preview removal, `___` separator
- `references/use-toolbox-in-hosted-agent.md` — `publish` retarget section, `___` separator, V1Preview removal
- `references/foundry-tool-catalog.md` — consent `-32006`, V1Preview removal
- `references/azd-ai-cli.md` — CLI surface (`versions list`, `publish`)
- `references/skills/skill-toolbox-attach.md` — V1Preview removal

## Test plan

- [x] `azd ai toolbox versions list` / `publish <name> <version>` verified live (old commands rejected as unknown)
- [x] MCP tool-name `___` separator verified via live `tools/list`
- [x] `initialize` returns no `mcp-session-id`; `tools/list` works without it
- [x] OAuth consent returns outer `-32006` + nested `"CONSENT_REQUIRED"` + APIM consent URL (live, managed OAuth GitHub connection)
- [x] No stale `V1Preview` / `{server_label}.` / `-32007` / `toolbox update` / singular `version list` references remain in the skill

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Note
We will create another PR to refactor the toolbox reference files later.