### PR TITLE
feat: capture and report skill version in telemetry hooks

### DIFF
--- a/plugin/hooks/scripts/track-telemetry.ps1
+++ b/plugin/hooks/scripts/track-telemetry.ps1
@@ -38,7 +38,7 @@
 # 1. skill_invocation
 #    - Triggered when: the "skill"/"Skill" tool is called with a skill name,
 #      OR a SKILL.md file is read from a recognized azure-skills path
-#    - Tracked field: --skill-name <name>
+#    - Tracked fields: --skill-name <name>, --skill-version <version>
 #
 # 2. tool_invocation
 #    - Triggered when: a tool matching an Azure MCP prefix is called
@@ -50,7 +50,18 @@
 #      inside a recognized azure-skills path that is NOT a SKILL.md
 #    - These are the reference/instruction files that skills bundle alongside
 #      SKILL.md (e.g., recipes, templates, requirement docs)
-#    - Tracked field: --file-reference <relative-path-after-skills/>
+#    - Tracked fields: --file-reference <relative-path-after-skills/>,
+#      --skill-version <version>
+#
+# === Skill Version ===
+#
+# The skill version is read from the SKILL.md frontmatter (metadata.version),
+# which the build stamps at package time. It is resolved as follows:
+#   - skill/Skill tool call: locate SKILL.md relative to this script's plugin
+#     root ("<plugin-root>/skills/<name>/SKILL.md")
+#   - SKILL.md read:          read the version from the SKILL.md being read
+#   - reference_file_read:    read the version from the sibling SKILL.md at the
+#                             root of the skill folder the reference lives in
 #    - Example: azure-validate/references/recipes/azd/README.md
 #
 # === Reference File Detection ===
@@ -86,6 +97,36 @@ if ($env:AZURE_MCP_COLLECT_TELEMETRY -eq "false") {
 function Write-Success {
     Write-Output '{"continue":true}'
     exit 0
+}
+
+# Resolve this script's directory so we can locate bundled skills. In the
+# installed plugin, hooks/ and skills/ are siblings under the plugin root, so
+# <plugin-root>/skills/<name>/SKILL.md is the skill definition.
+$scriptDir = $PSScriptRoot
+if (-not $scriptDir) { $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path }
+$skillsDir = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) 'skills'
+
+# Extract the skill version from a SKILL.md frontmatter (metadata.version).
+# Returns $null if the file or version cannot be read.
+function Get-SkillVersion {
+    param([string]$SkillMdPath)
+    if (-not $SkillMdPath) { return $null }
+    $SkillMdPath = $SkillMdPath -replace '\\', '/'
+    if (-not (Test-Path -LiteralPath $SkillMdPath)) { return $null }
+    try {
+        $lines = Get-Content -LiteralPath $SkillMdPath -ErrorAction SilentlyContinue
+    } catch { return $null }
+    $inFrontmatter = $false
+    foreach ($line in $lines) {
+        if ($line -match '^---\s*$') {
+            if (-not $inFrontmatter) { $inFrontmatter = $true; continue }
+            else { break }
+        }
+        if ($inFrontmatter -and $line -match '^\s*version:\s*(.+?)\s*$') {
+            return $Matches[1].Trim().Trim('"').Trim("'")
+        }
+    }
+    return $null
 }
 
 # === Main Processing ===
@@ -190,6 +231,7 @@ $pathPatternAgentsSkills = '\.agents/skills/'
 $shouldTrack = $false
 $eventType = $null
 $skillName = $null
+$skillVersion = $null
 $azureToolName = $null
 $filePath = $null
 
@@ -204,6 +246,7 @@ if ($toolName -eq "skill" -or $toolName -eq "Skill") {
     if ($skillName) {
         $eventType = "skill_invocation"
         $shouldTrack = $true
+        $skillVersion = Get-SkillVersion (Join-Path $skillsDir (Join-Path $skillName 'SKILL.md'))
     }
 }
 
@@ -233,6 +276,7 @@ if ($toolName -eq "view" -or $toolName -eq "Read" -or $toolName -eq "read_file")
                 $skillName = $Matches[1]
                 $eventType = "skill_invocation"
                 $shouldTrack = $true
+                $skillVersion = Get-SkillVersion $pathToCheck
             }
         }
     }
@@ -272,6 +316,11 @@ if (-not $filePath -and -not $skillName) {
                 if (-not $shouldTrack) {
                     $shouldTrack = $true
                     $eventType = "reference_file_read"
+                    # Resolve the version from the sibling SKILL.md at the root
+                    # of the skill folder this reference lives in.
+                    $skillNameSeg = ($filePath -split '/')[0]
+                    $skillRootAbs = $pathNormalized.Substring(0, $pathNormalized.Length - $filePath.Length)
+                    $skillVersion = Get-SkillVersion ("$skillRootAbs$skillNameSeg/SKILL.md")
                 }
             }
         }
@@ -291,6 +340,7 @@ if ($shouldTrack) {
     if ($eventType) { $mcpArgs += "--event-type"; $mcpArgs += $eventType }
     if ($sessionId) { $mcpArgs += "--session-id"; $mcpArgs += $sessionId }
     if ($skillName) { $mcpArgs += "--skill-name"; $mcpArgs += $skillName }
+    if ($skillVersion) { $mcpArgs += "--skill-version"; $mcpArgs += $skillVersion }
     if ($azureToolName) { $mcpArgs += "--tool-name"; $mcpArgs += $azureToolName }
     # Convert forward slashes to backslashes for azmcp allowlist compatibility
     if ($filePath) { $mcpArgs += "--file-reference"; $mcpArgs += ($filePath -replace '/', '\') }

--- a/plugin/hooks/scripts/track-telemetry.sh
+++ b/plugin/hooks/scripts/track-telemetry.sh
@@ -326,9 +326,11 @@ if [ -z "$filePath" ] && [ -z "$skillName" ]; then
                     shouldTrack=true
                     eventType="reference_file_read"
                     # Resolve the version from the sibling SKILL.md at the root
-                    # of the skill folder this reference lives in.
+                    # of the skill folder this reference lives in. Strip the
+                    # relative suffix by length (literal removal) so glob
+                    # metacharacters in the path can't corrupt the result.
                     skillNameSeg="${filePath%%/*}"
-                    skillRootAbs="${pathNormalized%"$filePath"}"
+                    skillRootAbs="${pathNormalized:0:${#pathNormalized}-${#filePath}}"
                     skillVersion=$(get_skill_version "${skillRootAbs}${skillNameSeg}/SKILL.md")
                 fi
             fi

--- a/plugin/hooks/scripts/track-telemetry.sh
+++ b/plugin/hooks/scripts/track-telemetry.sh
@@ -40,7 +40,7 @@
 # 1. skill_invocation
 #    - Triggered when: the "skill"/"Skill" tool is called with a skill name,
 #      OR a SKILL.md file is read from a recognized azure-skills path
-#    - Tracked field: --skill-name <name>
+#    - Tracked fields: --skill-name <name>, --skill-version <version>
 #
 # 2. tool_invocation
 #    - Triggered when: a tool matching an Azure MCP prefix is called
@@ -52,7 +52,18 @@
 #      inside a recognized azure-skills path that is NOT a SKILL.md
 #    - These are the reference/instruction files that skills bundle alongside
 #      SKILL.md (e.g., recipes, templates, requirement docs)
-#    - Tracked field: --file-reference <relative-path-after-skills/>
+#    - Tracked fields: --file-reference <relative-path-after-skills/>,
+#      --skill-version <version>
+#
+# === Skill Version ===
+#
+# The skill version is read from the SKILL.md frontmatter (metadata.version),
+# which the build stamps at package time. It is resolved as follows:
+#   - skill/Skill tool call: locate SKILL.md relative to this script's plugin
+#     root ("<plugin-root>/skills/<name>/SKILL.md")
+#   - SKILL.md read:          read the version from the SKILL.md being read
+#   - reference_file_read:    read the version from the sibling SKILL.md at the
+#                             root of the skill folder the reference lives in
 #    - Example: azure-validate/references/recipes/azd/README.md
 #
 # === Reference File Detection ===
@@ -88,6 +99,28 @@ fi
 return_success() {
     echo '{"continue":true}'
     exit 0
+}
+
+# Resolve this script's directory so we can locate bundled skills. In the
+# installed plugin, hooks/ and skills/ are siblings under the plugin root, so
+# <script-dir>/../../skills/<name>/SKILL.md is the skill definition.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
+SKILLS_DIR="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)/skills"
+
+# Extract the skill version from a SKILL.md frontmatter (metadata.version).
+# Prints nothing if the file or version cannot be read.
+get_skill_version() {
+    local skillMdPath="$1"
+    [ -n "$skillMdPath" ] || return 0
+    # Normalize backslashes so Windows-style paths are readable
+    skillMdPath="$(echo "$skillMdPath" | tr '\\' '/')"
+    [ -f "$skillMdPath" ] || return 0
+    # Read the frontmatter block (between the first two --- lines) and pull the
+    # version value, stripping surrounding quotes and whitespace.
+    sed -n '/^---[[:space:]]*$/,/^---[[:space:]]*$/p' "$skillMdPath" 2>/dev/null \
+        | grep -E '^[[:space:]]*version:[[:space:]]*' \
+        | head -1 \
+        | sed -E 's/^[[:space:]]*version:[[:space:]]*//; s/^["'"'"']//; s/["'"'"'][[:space:]]*$//; s/[[:space:]]*$//'
 }
 
 # === JSON Parsing Functions (using sed - portable across platforms) ===
@@ -223,6 +256,7 @@ is_azure_skills_path() {
 shouldTrack=false
 eventType=""
 skillName=""
+skillVersion=""
 azureToolName=""
 filePath=""
 
@@ -235,6 +269,7 @@ if [ "$toolName" = "skill" ] || [ "$toolName" = "Skill" ]; then
     if [ -n "$skillName" ]; then
         eventType="skill_invocation"
         shouldTrack=true
+        skillVersion=$(get_skill_version "$SKILLS_DIR/$skillName/SKILL.md")
     fi
 fi
 
@@ -253,6 +288,7 @@ if [ "$toolName" = "view" ] || [ "$toolName" = "Read" ] || [ "$toolName" = "read
                 skillName="${BASH_REMATCH[1]}"
                 eventType="skill_invocation"
                 shouldTrack=true
+                skillVersion=$(get_skill_version "$pathToCheck")
             fi
         fi
     fi
@@ -289,6 +325,11 @@ if [ -z "$filePath" ] && [ -z "$skillName" ]; then
                 if [ "$shouldTrack" = false ]; then
                     shouldTrack=true
                     eventType="reference_file_read"
+                    # Resolve the version from the sibling SKILL.md at the root
+                    # of the skill folder this reference lives in.
+                    skillNameSeg="${filePath%%/*}"
+                    skillRootAbs="${pathNormalized%"$filePath"}"
+                    skillVersion=$(get_skill_version "${skillRootAbs}${skillNameSeg}/SKILL.md")
                 fi
             fi
         fi
@@ -308,6 +349,7 @@ if [ "$shouldTrack" = true ]; then
     [ -n "$eventType" ] && mcpArgs+=("--event-type" "$eventType")
     [ -n "$sessionId" ] && mcpArgs+=("--session-id" "$sessionId")
     [ -n "$skillName" ] && mcpArgs+=("--skill-name" "$skillName")
+    [ -n "$skillVersion" ] && mcpArgs+=("--skill-version" "$skillVersion")
     [ -n "$azureToolName" ] && mcpArgs+=("--tool-name" "$azureToolName")
     # Convert forward slashes to backslashes for azmcp allowlist compatibility
     [ -n "$filePath" ] && mcpArgs+=("--file-reference" "$(echo "$filePath" | tr '/' '\\')")


### PR DESCRIPTION
## Summary
Updates the plugin telemetry hooks to capture and report the version of each skill used.

Both `track-telemetry.sh` and `track-telemetry.ps1` now resolve the skill version from the `SKILL.md` frontmatter (`metadata.version`, stamped by the build) and pass it to the telemetry MCP call as a new `--skill-version` argument.

Version is resolved for all three ways a skill is used:

| Event | Source of version |
|-------|-------------------|
| `skill_invocation` (skill/Skill tool) | `<plugin-root>/skills/<name>/SKILL.md`, plugin root derived from the script's own location |
| `skill_invocation` (SKILL.md read) | the `SKILL.md` file being read |
| `reference_file_read` | the sibling `SKILL.md` at the root of the skill folder the reference lives in |

## Details
- Added a `get_skill_version` / `Get-SkillVersion` helper that parses the frontmatter block, handles quoted/unquoted values, and normalizes Windows backslash paths.
- Fails silently (no version emitted) if the file or field is missing, so telemetry never breaks.
- Updated header doc comments to document the new field and resolution logic.

## Testing
Verified both scripts (PowerShell via `pwsh`, bash via Git Bash) across four cases:
- skill tool → emits `--skill-version`
- SKILL.md read → emits `--skill-version`
- reference read → emits `--skill-version` + `--file-reference`
- MCP tool invocation → no version emitted (correct)

## Note
The azmcp `plugin-telemetry` server (synced separately via `sync-to-azure-mcp.yml`) must accept `--skill-version` to persist it. Unknown flags fail silently on the plugin side, so this is safe to ship independently.