### PR TITLE
chore: resolve vally 0.7.x lint errors/warnings

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -50,7 +50,7 @@ jobs:
           npm run vally validate-stimulus
 
       - name: Lint skill and eval specs
-        run: npx --yes @microsoft/vally-cli@^0.5.0 lint plugin/skills/ --eval-spec evals/ --strict --grader-plugin ./tests/vally/vally-graders.ts
+        run: npx --yes @microsoft/vally-cli@^0.7.0 lint plugin/skills/ --eval-spec evals/ --strict --grader-plugin ./tests/vally/vally-graders.ts
 
       - name: Determine suite
         if: github.event_name != 'pull_request'

--- a/evals/airunway-aks-setup/eval.yaml
+++ b/evals/airunway-aks-setup/eval.yaml
@@ -21,7 +21,7 @@ tags:
   type: integration
   skill: airunway-aks-setup
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/appinsights-instrumentation/eval.yaml
+++ b/evals/appinsights-instrumentation/eval.yaml
@@ -17,7 +17,7 @@ tags:
   type: integration
   skill: appinsights-instrumentation
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-ai/eval.yaml
+++ b/evals/azure-ai/eval.yaml
@@ -15,7 +15,7 @@ tags:
   type: integration
   skill: azure-ai
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-aigateway/eval.yaml
+++ b/evals/azure-aigateway/eval.yaml
@@ -16,7 +16,7 @@ tags:
   type: integration
   skill: azure-aigateway
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-compliance/eval.yaml
+++ b/evals/azure-compliance/eval.yaml
@@ -16,7 +16,7 @@ tags:
   type: integration
   skill: azure-compliance
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-compute/eval.yaml
+++ b/evals/azure-compute/eval.yaml
@@ -49,7 +49,7 @@ tags:
   type: integration
   skill: azure-compute
 
-config:
+defaults:
   runs: 3
   timeout: "10m"
   executor: copilot-sdk
@@ -58,13 +58,13 @@ config:
 scoring:
   threshold: 0.8
   weights:
-    output-contains: 0.5
-    output-matches: 0.5
-    output-not-matches: 2.0
-    completed: 1.0
+    output-contains: 0.1
+    output-matches: 0.1
+    output-not-matches: 0.3
+    completed: 0.2
     # Routing validation (router smoke stimuli only) — heavy weight because
     # a routing miss is a categorical failure: the wrong skill ran.
-    skill-invocation: 1.5
+    skill-invocation: 0.3
 
 stimuli:
   # ════════════════════════════════════════════════════════════════════

--- a/evals/azure-cost/eval.yaml
+++ b/evals/azure-cost/eval.yaml
@@ -22,7 +22,7 @@ tags:
   type: integration
   skill: azure-cost
 
-config:
+defaults:
   runs: 3
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-deploy/eval.yaml
+++ b/evals/azure-deploy/eval.yaml
@@ -17,7 +17,7 @@ tags:
   type: integration
   skill: azure-deploy
 
-config:
+defaults:
   runs: 3
   timeout: "7m"
   executor: integration-test-agent-runner
@@ -26,10 +26,10 @@ config:
 scoring:
   threshold: 0.8
   weights:
-    output-contains: 0.5
-    output-matches: 0.5
-    output-not-matches: 2.0
-    completed: 1.0
+    output-contains: 0.125
+    output-matches: 0.125
+    output-not-matches: 0.5
+    completed: 0.25
 
 stimuli:
   # ── avm-order-bicep-001 ──

--- a/evals/azure-diagnostics/eval.yaml
+++ b/evals/azure-diagnostics/eval.yaml
@@ -16,7 +16,7 @@ tags:
   type: integration
   skill: azure-diagnostics
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-enterprise-infra-planner/eval.yaml
+++ b/evals/azure-enterprise-infra-planner/eval.yaml
@@ -22,7 +22,7 @@ tags:
   type: integration
   skill: azure-enterprise-infra-planner
 
-config:
+defaults:
   runs: 1
   timeout: "10m"
   executor: integration-test-agent-runner
@@ -31,13 +31,15 @@ config:
 scoring:
   threshold: 0.8
   weights:
-    completed: 1.0
-    file-exists: 1.5
-    file-matches: 1.0
-    output-contains: 0.5
-    output-matches: 1.0
-    output-not-matches: 1.0
-    skill-invocation: 1.5
+    completed: 0.1
+    file-exists: 0.1
+    file-matches: 0.1
+    file-not-exists: 0.1
+    output-contains: 0.1
+    output-matches: 0.1
+    output-not-matches: 0.1
+    json-object-rules: 0.1
+    skill-invocation: 0.2
 
 stimuli:
   # ── invoke-simple-plan ──

--- a/evals/azure-kubernetes/eval.yaml
+++ b/evals/azure-kubernetes/eval.yaml
@@ -12,7 +12,7 @@ tags:
   type: integration
   skill: azure-kubernetes
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-kusto/eval.yaml
+++ b/evals/azure-kusto/eval.yaml
@@ -15,7 +15,7 @@ tags:
   type: integration
   skill: azure-kusto
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-messaging/eval.yaml
+++ b/evals/azure-messaging/eval.yaml
@@ -15,7 +15,7 @@ tags:
   type: integration
   skill: azure-messaging
 
-config:
+defaults:
   runs: 3
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-prepare/e2e-eval.yaml
+++ b/evals/azure-prepare/e2e-eval.yaml
@@ -27,7 +27,7 @@ tags:
   type: integration
   skill: azure-prepare
 
-config:
+defaults:
   runs: 1
   timeout: "30m"
   executor: integration-test-agent-runner

--- a/evals/azure-prepare/routing-eval.yaml
+++ b/evals/azure-prepare/routing-eval.yaml
@@ -26,7 +26,7 @@ tags:
   type: integration
   skill: azure-prepare
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-quotas/eval.yaml
+++ b/evals/azure-quotas/eval.yaml
@@ -22,7 +22,7 @@ tags:
   type: integration
   skill: azure-quotas
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-rbac/eval.yaml
+++ b/evals/azure-rbac/eval.yaml
@@ -15,7 +15,7 @@ tags:
   type: integration
   skill: azure-rbac
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-reliability/eval.yaml
+++ b/evals/azure-reliability/eval.yaml
@@ -27,7 +27,7 @@ tags:
   type: integration
   skill: azure-reliability
 
-config:
+defaults:
   runs: 1
   timeout: "60m"
   executor: integration-test-agent-runner

--- a/evals/azure-resource-lookup/eval.yaml
+++ b/evals/azure-resource-lookup/eval.yaml
@@ -24,7 +24,7 @@ tags:
   type: integration
   skill: azure-resource-lookup
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-resource-visualizer/eval.yaml
+++ b/evals/azure-resource-visualizer/eval.yaml
@@ -16,7 +16,7 @@ tags:
   type: integration
   skill: azure-resource-visualizer
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-storage/eval.yaml
+++ b/evals/azure-storage/eval.yaml
@@ -15,7 +15,7 @@ tags:
   type: integration
   skill: azure-storage
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/azure-upgrade/eval.yaml
+++ b/evals/azure-upgrade/eval.yaml
@@ -24,7 +24,7 @@ tags:
   type: integration
   skill: azure-upgrade
 
-config:
+defaults:
   runs: 1
   timeout: "20m"
   executor: integration-test-agent-runner

--- a/evals/entra-agent-id/eval.yaml
+++ b/evals/entra-agent-id/eval.yaml
@@ -27,7 +27,7 @@ tags:
   type: integration
   skill: entra-agent-id
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/entra-app-registration/eval.yaml
+++ b/evals/entra-app-registration/eval.yaml
@@ -15,7 +15,7 @@ tags:
   type: integration
   skill: entra-app-registration
 
-config:
+defaults:
   runs: 5
   timeout: "10m"
   executor: integration-test-agent-runner

--- a/evals/microsoft-foundry/eval.yaml
+++ b/evals/microsoft-foundry/eval.yaml
@@ -9,7 +9,7 @@ description: |
 tags:
   skill: microsoft-foundry
 
-config:
+defaults:
   runs: 5
   timeout: "30m"
   executor: integration-test-agent-runner

--- a/evals/python-appservice-deploy/eval.yaml
+++ b/evals/python-appservice-deploy/eval.yaml
@@ -28,7 +28,7 @@ tags:
   type: integration
   skill: python-appservice-deploy
 
-config:
+defaults:
   runs: 3
   # 35m global timeout accommodates the Flask e2e stimulus, which runs a
   # real Azure deployment. All other stimuli terminate early via the


### PR DESCRIPTION
## Description

Updates CI and all eval YAML files to be compatible with vally-cli 0.7.0:

1. **Use vally-cli 0.7.0 in CI** — bumps the vally-cli version in `.github/workflows/eval.yml` to `0.7.0`.
2. **Replace `config` with `defaults`** — renames the `config` key to `defaults` across all eval YAML files (no behavior change).
3. **Normalize score weights** — adjusts grader score weights in several eval files so they sum to `1.0`.
4. **Add missing score weights** — added missing score weights for graders that are in use to resolve vally lint warnings.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->