### PR TITLE
fix: use proper tool to execute query in Azure SQL Server

### DIFF
--- a/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.ps1
+++ b/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.ps1
@@ -88,7 +88,7 @@ sqlcmd `
   -Q $SqlQuery
 
 if ($LASTEXITCODE -ne 0) {
-  throw "sqlcmd failed with exit code $LASTEXITCODE. SQL access was not granted."
+    throw "sqlcmd failed with exit code $LASTEXITCODE. SQL access was not granted."
 }
 
 Write-Host "SQL access granted successfully."

--- a/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.ps1
+++ b/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.ps1
@@ -74,21 +74,17 @@ IF NOT EXISTS (
 "@
 }
 
-# Ensure the rdbms-connect extension is installed (provides 'az sql db query')
-az extension show --name rdbms-connect *> $null
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "Azure CLI extension 'rdbms-connect' is not installed. Installing..."
-    az extension add --name rdbms-connect --yes
-    if ($LASTEXITCODE -ne 0) {
-        throw "ERROR: Failed to install Azure CLI extension 'rdbms-connect'. Cannot continue because 'az sql db query' requires it."
-    }
+# Ensure sqlcmd is available to execute the query
+if (-not (Get-Command sqlcmd -ErrorAction SilentlyContinue)) {
+    Write-Error "'sqlcmd' is not installed or not on PATH."
+    Write-Error "Install the modern go-sqlcmd from https://github.com/microsoft/go-sqlcmd and retry."
+    exit 1
 }
 
-az sql db query `
-  --server $env:SQL_SERVER `
-  --database $env:SQL_DATABASE `
-  --resource-group $env:AZURE_RESOURCE_GROUP `
-  --auth-mode ActiveDirectoryDefault `
-  --queries $SqlQuery
+sqlcmd `
+  -S "$($env:SQL_SERVER).database.windows.net" `
+  -d $env:SQL_DATABASE `
+  --authentication-method ActiveDirectoryDefault `
+  -Q $SqlQuery
 
 Write-Host "SQL access granted successfully."

--- a/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.ps1
+++ b/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.ps1
@@ -87,4 +87,8 @@ sqlcmd `
   --authentication-method ActiveDirectoryDefault `
   -Q $SqlQuery
 
+if ($LASTEXITCODE -ne 0) {
+  throw "sqlcmd failed with exit code $LASTEXITCODE. SQL access was not granted."
+}
+
 Write-Host "SQL access granted successfully."

--- a/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.sh
+++ b/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.sh
@@ -88,6 +88,7 @@ if ! command -v sqlcmd >/dev/null 2>&1; then
   exit 1
 fi
 
+# script will exit on error due to "set -e"
 sqlcmd \
   -S "${SQL_SERVER}.database.windows.net" \
   -d "$SQL_DATABASE" \

--- a/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.sh
+++ b/plugin/skills/azure-prepare/references/services/sql-database/scripts/grant-sql-access.sh
@@ -81,20 +81,17 @@ if [ "$SQL_GRANT_DDLADMIN" = "true" ]; then
 "
 fi
 
-# Ensure the rdbms-connect extension is installed (provides 'az sql db query')
-if ! az extension show --name rdbms-connect >/dev/null 2>&1; then
-  echo "Azure CLI extension 'rdbms-connect' is not installed. Installing..."
-  if ! az extension add --name rdbms-connect --yes; then
-    echo "ERROR: Failed to install Azure CLI extension 'rdbms-connect'. Ensure Azure CLI has network access and retry." >&2
-    exit 1
-  fi
+# Ensure sqlcmd is available to execute the query
+if ! command -v sqlcmd >/dev/null 2>&1; then
+  echo "ERROR: 'sqlcmd' is not installed or not on PATH." >&2
+  echo "Install the modern go-sqlcmd from https://github.com/microsoft/go-sqlcmd and retry." >&2
+  exit 1
 fi
 
-az sql db query \
-  --server "$SQL_SERVER" \
-  --database "$SQL_DATABASE" \
-  --resource-group "$AZURE_RESOURCE_GROUP" \
-  --auth-mode ActiveDirectoryDefault \
-  --queries "$SQL_QUERIES"
+sqlcmd \
+  -S "${SQL_SERVER}.database.windows.net" \
+  -d "$SQL_DATABASE" \
+  --authentication-method ActiveDirectoryDefault \
+  -Q "$SQL_QUERIES"
 
 echo "SQL access granted successfully."


### PR DESCRIPTION
## Description

The `azure-prepare` skill referenced a non-existent `az sql db query` command. This PR replaces it with the correct tool to execute queries against Azure SQL Server.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

Fixes #2699