### PR TITLE
feat: add canvas-first entry gate for Foundry agent creation

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -42,7 +42,7 @@ For prompt agents (LLM + instructions, no container), use [create-prompt.md](cre
 
 Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[ACTION]` summary prefixes.
 
-**1a — Canvas-first entry (GitHub Copilot app).** Run the canvas-entry check first (it can short-circuit the rest). **Skip 1a** if the user opts out, e.g. "skip the canvas" / "use the CLI".
+**1a — Canvas-first entry (GitHub Copilot app).** Detects whether the runtime is the GitHub Copilot app (`AI_AGENT=github_copilot_app_agent`) and the Foundry Agent Canvas extension is installed. If both are true, the canvas must be opened first so the user can authenticate and select a Foundry project before scaffolding. Run this check first (it can short-circuit the rest). **Skip 1a** if the user opts out, e.g. "skip the canvas" / "use the CLI".
 
 ```bash
 ./scripts/check-canvas-entry.sh     # macOS / Linux

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -40,7 +40,19 @@ For prompt agents (LLM + instructions, no container), use [create-prompt.md](cre
 
 ### Step 1 -- Verify the environment
 
-Run the bundled verification script before any other create/deploy command:
+Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[ACTION]` summary prefixes.
+
+**1a — Canvas-first entry (GitHub Copilot app).** Run the canvas-entry check first (it can short-circuit the rest). **Skip 1a** if the user opts out, e.g. "skip the canvas" / "use the CLI".
+
+```bash
+./scripts/check-canvas-entry.sh     # macOS / Linux
+./scripts/check-canvas-entry.ps1    # Windows (pwsh)
+```
+
+- **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
+- **`[ACTION]`** — the gate applies. If the user message's `<canvas-context>` already lists **`canvas="agent-builder"`**, the user has already driven the canvas — continue to 1b using their prompt/config (loop guard, independent of prompt wording). Otherwise `open_canvas` (`canvasId: "agent-builder"`), ask the user to **create the agent from the canvas: sign in, select a subscription + Foundry project, then Send**, then **stop — do not run 1b or scaffold**.
+
+**1b — Tooling & auth.** Run the bundled verification script before any other create/deploy command:
 
 ```bash
 ./scripts/verify-environment.sh     # macOS / Linux

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -29,7 +29,7 @@ Walk through every step in order. **Before Step 2**, scan the user's original pr
 
 Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[ACTION]` summary prefixes.
 
-**1a — Canvas-first entry (GitHub Copilot app).** Run the canvas-entry check first (it can short-circuit the rest). **Skip 1a** if the user opts out, e.g. "skip the canvas" / "use the CLI".
+**1a — Canvas-first entry (GitHub Copilot app).** Detects whether the runtime is the GitHub Copilot app (`AI_AGENT=github_copilot_app_agent`) and the Foundry Agent Canvas extension is installed. If both are true, the canvas must be opened first so the user can authenticate and select a Foundry project before scaffolding. Run this check first (it can short-circuit the rest). **Skip 1a** if the user opts out, e.g. "skip the canvas" / "use the CLI".
 
 ```bash
 ./scripts/check-canvas-entry.sh     # macOS / Linux

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -27,7 +27,19 @@ Walk through every step in order. **Before Step 2**, scan the user's original pr
 
 ### Step 1 — Verify the environment
 
-Run the bundled script:
+Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[ACTION]` summary prefixes.
+
+**1a — Canvas-first entry (GitHub Copilot app).** Run the canvas-entry check first (it can short-circuit the rest). **Skip 1a** if the user opts out, e.g. "skip the canvas" / "use the CLI".
+
+```bash
+./scripts/check-canvas-entry.sh     # macOS / Linux
+./scripts/check-canvas-entry.ps1    # Windows (pwsh)
+```
+
+- **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
+- **`[ACTION]`** — the gate applies. If the user message's `<canvas-context>` already lists **`canvas="agent-builder"`**, the user has already driven the canvas — continue to 1b using their prompt/config (loop guard, independent of prompt wording). Otherwise `open_canvas` (`canvasId: "agent-builder"`), ask the user to **create the agent from the canvas: sign in, select a subscription + Foundry project, then Send**, then **stop — do not run 1b or scaffold**.
+
+**1b — Tooling & auth.** Run the bundled script:
 
 ```bash
 ./scripts/verify-environment.sh     # macOS / Linux

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
@@ -1,0 +1,55 @@
+<#
+.SYNOPSIS
+    Canvas-First Entry check for the Foundry "create a new agent" flow.
+.DESCRIPTION
+    Reports -- using the same [OK]/[WARN]/[ACTION] convention as verify-environment --
+    whether the canvas-first gate applies before scaffolding a new hosted agent in the
+    GitHub Copilot app, from two deterministic facts:
+      * copilot_app      - is AI_AGENT=github_copilot_app_agent?
+      * canvas_installed - is the Foundry Agent Canvas (foundry-agent-canvas)
+                           installed in the project, user, or session location?
+
+    Output lines are prefixed with [OK], [WARN], or [ACTION].
+    Exit code is 0 when the gate does not apply (not in the app, or the canvas is
+    not installed), 1 when the canvas is installed and an [ACTION] is required.
+
+    NOTE: whether the canvas is *open* is runtime UI state the agent reads from the
+    message <canvas-context> (look for canvas="agent-builder"); a script cannot see it.
+.EXAMPLE
+    ./check-canvas-entry.ps1
+#>
+
+$ErrorActionPreference = "Stop"
+$ext = "foundry-agent-canvas"
+
+if ($env:AI_AGENT -ne "github_copilot_app_agent") {
+    Write-Output "[OK] Not running in the GitHub Copilot app (AI_AGENT is not github_copilot_app_agent)."
+    Write-Output "[OK] Canvas-first gate does not apply -- continue with the normal create workflow."
+    exit 0
+}
+
+Write-Output "[OK] GitHub Copilot app detected (AI_AGENT=github_copilot_app_agent)."
+
+# Candidate install locations: project (repo), user, session.
+$dirs = @()
+try { $root = (& git rev-parse --show-toplevel 2>$null); if ($root) { $dirs += (Join-Path $root ".github/extensions/$ext") } } catch {}
+$dirs += (Join-Path (Get-Location) ".github/extensions/$ext")
+$homeDir = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
+if ($homeDir) { $dirs += (Join-Path $homeDir ".copilot/extensions/$ext") }
+if ($homeDir -and $env:COPILOT_AGENT_SESSION_ID) {
+    $dirs += (Join-Path $homeDir ".copilot/session-state/$($env:COPILOT_AGENT_SESSION_ID)/extensions/$ext")
+}
+
+$installedAt = $null
+foreach ($d in $dirs) {
+    if (Test-Path (Join-Path $d "extension.mjs")) { $installedAt = $d; break }
+}
+
+if (-not $installedAt) {
+    Write-Output "[WARN] Foundry Agent Canvas is not installed -- canvas-first gate does not apply; continue with the normal create workflow."
+    exit 0
+}
+
+Write-Output "[OK] Foundry Agent Canvas is installed ($installedAt)."
+Write-Output '[ACTION] Canvas-first gate applies. If the message <canvas-context> already lists canvas="agent-builder", the user has already driven the canvas -- proceed with the create workflow. Otherwise open_canvas (canvasId "agent-builder"), have the user sign in / pick a project / configure / Send, then stop -- do not scaffold.'
+exit 1

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
@@ -50,6 +50,6 @@ if (-not $installedAt) {
     exit 0
 }
 
-Write-Output "[OK] Foundry Agent Canvas is installed ($installedAt)."
-Write-Output '[ACTION] Canvas-first gate applies. If the message <canvas-context> already lists canvas="agent-builder", the user has already driven the canvas -- proceed with the create workflow. Otherwise open_canvas (canvasId "agent-builder"), have the user sign in / pick a project / configure / Send, then stop -- do not scaffold.'
+Write-Output "[OK] Foundry Agent Canvas is installed."
+Write-Output '[ACTION] Canvas-first gate applies. If the message <canvas-context> already lists canvas="agent-builder", the user has already driven the canvas -- proceed with the create workflow. Otherwise open_canvas (canvasId: "agent-builder"), have the user sign in / pick a project / configure / Send, then stop -- do not scaffold.'
 exit 1

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
@@ -51,5 +51,5 @@ if (-not $installedAt) {
 }
 
 Write-Output "[OK] Foundry Agent Canvas is installed."
-Write-Output '[ACTION] Canvas-first gate applies. If the message <canvas-context> already lists canvas="agent-builder", the user has already driven the canvas -- proceed with the create workflow. Otherwise open_canvas (canvasId: "agent-builder"), have the user sign in / pick a project / configure / Send, then stop -- do not scaffold.'
+Write-Output '[ACTION] Canvas-first gate applies.'
 exit 1

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# check-canvas-entry.sh
+# Canvas-First Entry check for the Foundry "create a new agent" flow.
+#
+# Reports -- using the same [OK]/[WARN]/[ACTION] convention as verify-environment --
+# whether the canvas-first gate applies before scaffolding a new hosted agent in the
+# GitHub Copilot app, from two deterministic facts:
+#   * copilot_app      - is AI_AGENT=github_copilot_app_agent?
+#   * canvas_installed - is the Foundry Agent Canvas (foundry-agent-canvas)
+#                        installed in the project, user, or session location?
+#
+# Output: summary lines, each prefixed with [OK], [WARN], or [ACTION].
+# Exit code: 0 when the gate does not apply (not in the app, or the canvas is not
+# installed), 1 when the canvas is installed and an [ACTION] is required.
+#
+# NOTE: whether the canvas is *open* is runtime UI state the agent reads from the
+# message <canvas-context> (look for canvas="agent-builder"); a script cannot see it.
+
+set -uo pipefail
+ext="foundry-agent-canvas"
+
+if [ "${AI_AGENT:-}" != "github_copilot_app_agent" ]; then
+  echo "[OK] Not running in the GitHub Copilot app (AI_AGENT is not github_copilot_app_agent)."
+  echo "[OK] Canvas-first gate does not apply -- continue with the normal create workflow."
+  exit 0
+fi
+
+echo "[OK] GitHub Copilot app detected (AI_AGENT=github_copilot_app_agent)."
+
+# Candidate install locations: project (repo), user, session.
+dirs=()
+root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+[ -n "$root" ] && dirs+=("$root/.github/extensions/$ext")
+dirs+=("$PWD/.github/extensions/$ext")
+home_dir="${HOME:-${USERPROFILE:-}}"
+[ -n "$home_dir" ] && dirs+=("$home_dir/.copilot/extensions/$ext")
+[ -n "$home_dir" ] && [ -n "${COPILOT_AGENT_SESSION_ID:-}" ] && \
+  dirs+=("$home_dir/.copilot/session-state/$COPILOT_AGENT_SESSION_ID/extensions/$ext")
+
+installed_at=""
+for d in "${dirs[@]}"; do
+  if [ -f "$d/extension.mjs" ]; then installed_at="$d"; break; fi
+done
+
+if [ -z "$installed_at" ]; then
+  echo "[WARN] Foundry Agent Canvas is not installed -- canvas-first gate does not apply; continue with the normal create workflow."
+  exit 0
+fi
+
+echo "[OK] Foundry Agent Canvas is installed ($installed_at)."
+echo '[ACTION] Canvas-first gate applies. If the message <canvas-context> already lists canvas="agent-builder", the user has already driven the canvas -- proceed with the create workflow. Otherwise open_canvas (canvasId "agent-builder"), have the user sign in / pick a project / configure / Send, then stop -- do not scaffold.'
+exit 1

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
@@ -48,5 +48,5 @@ if [ -z "$installed_at" ]; then
 fi
 
 echo "[OK] Foundry Agent Canvas is installed."
-echo '[ACTION] Canvas-first gate applies. If the message <canvas-context> already lists canvas="agent-builder", the user has already driven the canvas -- proceed with the create workflow. Otherwise open_canvas (canvasId: "agent-builder"), have the user sign in / pick a project / configure / Send, then stop -- do not scaffold.'
+echo '[ACTION] Canvas-first gate applies.'
 exit 1

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
@@ -47,6 +47,6 @@ if [ -z "$installed_at" ]; then
   exit 0
 fi
 
-echo "[OK] Foundry Agent Canvas is installed ($installed_at)."
-echo '[ACTION] Canvas-first gate applies. If the message <canvas-context> already lists canvas="agent-builder", the user has already driven the canvas -- proceed with the create workflow. Otherwise open_canvas (canvasId "agent-builder"), have the user sign in / pick a project / configure / Send, then stop -- do not scaffold.'
+echo "[OK] Foundry Agent Canvas is installed."
+echo '[ACTION] Canvas-first gate applies. If the message <canvas-context> already lists canvas="agent-builder", the user has already driven the canvas -- proceed with the create workflow. Otherwise open_canvas (canvasId: "agent-builder"), have the user sign in / pick a project / configure / Send, then stop -- do not scaffold.'
 exit 1


### PR DESCRIPTION
## Summary
- Adds a canvas-first entry gate (Step 1a) to the Foundry agent create workflow when running inside the GitHub Copilot app with the `foundry-agent-canvas` extension installed.
- New `check-canvas-entry.sh` / `.ps1` scripts detect the runtime environment (`AI_AGENT=github_copilot_app_agent`) and whether the canvas extension is installed, then emit `[ACTION]` to direct the agent to open the canvas UI.
- Updates `create-hosted.md` and `quick-start-hosted.md` to run the canvas-entry check before the existing environment verification, with a loop guard (`<canvas-context>` check) and user opt-out support.

## Motivation
Currently the agent ignores the canvas extension and proceeds with the CLI-based create flow. With this change, users in the Copilot app are redirected to the canvas first (sign in, select subscription/project, configure, then Send), which then invokes the skill for remaining steps.