### PR TITLE
feat: update invocations_ws skill for GA and path-based routing

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/invocations-ws.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/invocations-ws.md
@@ -148,7 +148,7 @@ The same `agent_session_id` can be used to stream container logs (see the [`trou
 | Error | Cause | Resolution |
 |-------|-------|------------|
 | HTTP 401 / 403 on WS upgrade | Missing or stale Entra token | Re-run `az account get-access-token --resource https://ai.azure.com`; ensure the caller has Foundry data-plane RBAC |
-| HTTP 404 on upgrade | Wrong `agent_name` / `project_name` path segment, missing `api-version`, or unsupported region | Verify with `agent_get`; ensure the project/agent path segments are correct and `api-version=v1` is on the URL; confirm region per [Hosted Agents region availability](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents#region-availability) |
+| HTTP 404 on upgrade | Wrong `{project}` / `{agentName}` path segment, missing `api-version`, or unsupported region | Verify with `agent_get`; ensure the project/agent path segments are correct and `api-version=v1` is on the URL; confirm region per [Hosted Agents region availability](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents#region-availability) |
 | WS closes immediately after accept | Container handler raised inside the request | Check logs via `azd ai agent monitor`; typical causes are missing env vars or unreachable backend services |
 | Browser cannot connect directly | Browser `WebSocket` cannot set `Authorization` | Run a thin server-side proxy that injects the token before forwarding |
 | Frames received but no response | Wire-format mismatch | Confirm both ends use the same framing (binary vs text, codec, sample rate, schema). The platform does **not** validate or transcode frames |

--- a/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/invocations-ws.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/invocations-ws.md
@@ -2,7 +2,9 @@
 
 Build, deploy, and connect to Foundry hosted agents that expose a **duplex WebSocket** endpoint instead of an HTTP request/response surface. Use this for real-time, bidirectional workloads — voice agents, live transcripts, custom streaming protocols, and signaling for out-of-band media transports.
 
-> ℹ️ **Preview.** `invocations_ws` is in public preview. For current region availability see [Foundry Hosted Agents — region availability](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents#region-availability). Every upgrade must carry the preview flag — either the `foundry_features=HostedAgents=V1Preview` query parameter or the `Foundry-Features: HostedAgents=V1Preview` request header.
+> ℹ️ **Generally available.** `invocations_ws` is GA — **no preview feature flag is required**. Every upgrade must carry the required `api-version=v1` query parameter. For current region availability see [Foundry Hosted Agents — region availability](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents#region-availability).
+>
+> **Migrating from preview:** the old `HostedAgents=V1Preview` gate (sent via the `foundry_features` query parameter or the `Foundry-Features` header) has been removed — stop sending it. Project and agent are now **path segments** instead of query parameters.
 
 ## Quick Reference
 
@@ -12,7 +14,7 @@ Build, deploy, and connect to Foundry hosted agents that expose a **duplex WebSo
 | Protocol id (`azure.yaml`) | `invocations_ws` |
 | Recommended version | `1.0.0` |
 | Container route | `WS /invocations_ws` (served by `azure-ai-agentserver-invocations`; the host binds the port and probes for you) |
-| Foundry-side URL | `wss://{account}.services.ai.azure.com/api/projects/agents/endpoint/protocols/invocations_ws?project_name={project}&agent_name={agentName}&agent_session_id={sessionId}&foundry_features=HostedAgents=V1Preview` |
+| Foundry-side URL | `wss://{account}.services.ai.azure.com/api/projects/{project}/agents/{agentName}/endpoint/protocols/invocations_ws?api-version=v1&agent_session_id={sessionId}` |
 | Auth | `Authorization: Bearer <Entra token>` for scope `https://ai.azure.com/.default` |
 | Wire format | Developer-defined (binary frames, JSON text frames, protobuf, raw PCM — anything) |
 | Session affinity | Per-connection, keyed by the `agent_session_id` query parameter (optional — auto-generated if omitted) |
@@ -113,17 +115,13 @@ Connect to the Foundry-side WebSocket directly:
    az account get-access-token --resource https://ai.azure.com --query accessToken -o tsv
    ```
 
-2. **Build the upstream URL.** The `agent_session_id` query parameter is **optional** — if you omit it the platform generates one; supply your own (URL-safe; see [Session Management](../invoke/references/session-management.md) for ID format) only when you need to resume an existing session. The preview flag is required:
+2. **Build the upstream URL.** Project and agent are **path segments** (mirroring the HTTP `/invocations` shape); `api-version=v1` is a **required** query parameter. The `agent_session_id` query parameter is **optional** — if you omit it the platform generates one; supply your own (URL-safe; see [Session Management](../invoke/references/session-management.md) for ID format) only when you need to resume an existing session:
 
    ```
-   wss://{account}.services.ai.azure.com/api/projects/agents/endpoint/protocols/invocations_ws
-     ?project_name={project}
-     &agent_name={agentName}
+   wss://{account}.services.ai.azure.com/api/projects/{project}/agents/{agentName}/endpoint/protocols/invocations_ws
+     ?api-version=v1
      &agent_session_id={your-id}        # optional
-     &foundry_features=HostedAgents=V1Preview
    ```
-
-   You can alternatively pass the preview flag as the `Foundry-Features: HostedAgents=V1Preview` request header on the upgrade.
 
 3. **Open the WebSocket** with header `Authorization: Bearer <token>`. Browser code typically needs a small server-side proxy because the browser `WebSocket` constructor cannot set headers.
 
@@ -150,7 +148,7 @@ The same `agent_session_id` can be used to stream container logs (see the [`trou
 | Error | Cause | Resolution |
 |-------|-------|------------|
 | HTTP 401 / 403 on WS upgrade | Missing or stale Entra token | Re-run `az account get-access-token --resource https://ai.azure.com`; ensure the caller has Foundry data-plane RBAC |
-| HTTP 404 on upgrade | Wrong `agent_name` / `project_name`, missing preview flag, or unsupported region | Verify with `agent_get`; ensure `foundry_features=HostedAgents=V1Preview` is on the URL (or `Foundry-Features` header); confirm region per [Hosted Agents region availability](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents#region-availability) |
+| HTTP 404 on upgrade | Wrong `agent_name` / `project_name` path segment, missing `api-version`, or unsupported region | Verify with `agent_get`; ensure the project/agent path segments are correct and `api-version=v1` is on the URL; confirm region per [Hosted Agents region availability](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents#region-availability) |
 | WS closes immediately after accept | Container handler raised inside the request | Check logs via `azd ai agent monitor`; typical causes are missing env vars or unreachable backend services |
 | Browser cannot connect directly | Browser `WebSocket` cannot set `Authorization` | Run a thin server-side proxy that injects the token before forwarding |
 | Frames received but no response | Wire-format mismatch | Confirm both ends use the same framing (binary vs text, codec, sample rate, schema). The platform does **not** validate or transcode frames |

--- a/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/references/invocations-ws-protocol.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/references/invocations-ws-protocol.md
@@ -18,24 +18,24 @@ The `invocations_ws` protocol is a **duplex WebSocket pass-through**. After the 
 
 ```
 wss://{account}.services.ai.azure.com
-   /api/projects/agents/endpoint/protocols/invocations_ws
-   ?project_name={project}
-   &agent_name={agentName}
+   /api/projects/{project}/agents/{agentName}/endpoint/protocols/invocations_ws
+   ?api-version=v1
    &agent_session_id={sessionId}
-   &foundry_features=HostedAgents=V1Preview
 ```
+
+| Path segment | Required | Notes |
+|--------------|----------|-------|
+| `{project}` | ✅ | Foundry project name (the segment after `/api/projects/` in the project endpoint). Literal `_default` resolves to the resource's default project. |
+| `{agentName}` | ✅ | Hosted agent name as declared in `azure.yaml` |
 
 | Query parameter | Required | Notes |
 |-----------------|----------|-------|
-| `project_name` | ✅ | Foundry project name (the segment after `/api/projects/` in the project endpoint) |
-| `agent_name` | ✅ | Hosted agent name as declared in `azure.yaml` |
+| `api-version` | ✅ | Standard Foundry data-plane API version (`v1`). The upgrade is rejected before `101 Switching Protocols` if it is missing. |
 | `agent_session_id` | ❌ | Per-connection identifier — see [Session Management](../../invoke/references/session-management.md). If omitted, the platform (or the container) generates a random id |
-| `foundry_features` | ✅ (preview) | Must be `HostedAgents=V1Preview` while the protocol is in preview. May alternatively be sent as the `Foundry-Features` request header. |
 
 | Header | Required | Notes |
 |--------|----------|-------|
 | `Authorization: Bearer <token>` | ✅ | Entra token for audience `https://ai.azure.com` (scope `https://ai.azure.com/.default`) — `az account get-access-token --resource https://ai.azure.com`. Validated by APIM and the Agents service; the container does **not** see this header. |
-| `Foundry-Features: HostedAgents=V1Preview` | ✅ (preview) | Required unless the equivalent `foundry_features` query parameter is set. |
 
 The container receives the upgrade on path `/invocations_ws`. Inside the container, read the session id from the `FOUNDRY_AGENT_SESSION_ID` environment variable (set by `azure-ai-agentserver-invocations`), or fall back to the `agent_session_id` query string.
 
@@ -88,10 +88,9 @@ import os, uuid, websockets  # requires websockets >= 12 for the additional_head
 
 token = os.popen("az account get-access-token --resource https://ai.azure.com --query accessToken -o tsv").read().strip()
 url = (
-    "wss://{account}.services.ai.azure.com/api/projects/agents/endpoint/protocols/invocations_ws"
-    "?project_name={project}&agent_name={name}"
+    "wss://{account}.services.ai.azure.com/api/projects/{project}/agents/{name}/endpoint/protocols/invocations_ws"
+    "?api-version=v1"
     f"&agent_session_id={uuid.uuid4().hex}"
-    "&foundry_features=HostedAgents=V1Preview"
 )
 
 # websockets >= 12 uses `additional_headers`; older versions (<12) expect `extra_headers`.
@@ -108,7 +107,7 @@ async with websockets.connect(url, additional_headers={"Authorization": f"Bearer
 | Error | Cause | Resolution |
 |-------|-------|------------|
 | 401 / 403 on upgrade | Missing or expired Entra token | Re-mint with `az account get-access-token --resource https://ai.azure.com` |
-| 404 on upgrade | Wrong `project_name` or `agent_name`, missing preview flag, or unsupported region | Verify with `agent_get`; ensure `foundry_features=HostedAgents=V1Preview` is set; confirm the deployed version uses `protocol: invocations_ws` and that the region is supported per [Hosted Agents region availability](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents#region-availability) |
+| 404 on upgrade | Wrong `project` or `agentName` path segment, missing `api-version`, or unsupported region | Verify with `agent_get`; ensure the path segments are correct and `api-version=v1` is set; confirm the deployed version uses `protocol: invocations_ws` and that the region is supported per [Hosted Agents region availability](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents#region-availability) |
 | WS closes after accept | Container raised in the handler | Tail logs with `azd ai agent monitor --session-id <agent_session_id> --follow` |
 | Frames silently dropped | Wire-format mismatch (binary vs text, wrong schema) | Confirm both ends agree on framing — the platform performs no transcoding |
 | State lost on reconnect | Different `agent_session_id` used | Reuse the same `agent_session_id` to land on the same logical state inside the container |

--- a/plugin/skills/microsoft-foundry/foundry-agent/invoke/invoke.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/invoke/invoke.md
@@ -43,7 +43,7 @@ Hosted agents support three protocols declared at deployment time. They are dist
 |----------|-------------------|-------|----------|
 | `responses` | `1.0.0` | `.../agents/{agentName}/endpoint/protocols/openai/responses` | Conversational agents, OpenAI-compatible |
 | `invocations` | `1.0.0` | `.../agents/{agentName}/endpoint/protocols/invocations` | Custom payloads, protocol bridges, webhook callers |
-| `invocations_ws` | `1.0.0` | `wss://.../agents/endpoint/protocols/invocations_ws` | Duplex WebSocket — voice, WebRTC signaling, custom real-time streams. See the dedicated [invocations-ws skill](../invocations-ws/invocations-ws.md); `agent_invoke` does **not** speak WebSocket. |
+| `invocations_ws` | `1.0.0` | `wss://.../projects/{project}/agents/{agentName}/endpoint/protocols/invocations_ws` | Duplex WebSocket — voice, WebRTC signaling, custom real-time streams. See the dedicated [invocations-ws skill](../invocations-ws/invocations-ws.md); `agent_invoke` does **not** speak WebSocket. |
 
 Key difference: `responses` takes a natural language `inputText` message with platform-managed history. `invocations` is **bytes in, bytes out** — the request body is forwarded as-is to the container and the raw response is returned. The developer defines the schema; the platform is pure pass-through. See [Invocations Protocol Guide](references/invocations-protocol.md) for I/O details, schema discovery, and examples.
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/invoke/invoke.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/invoke/invoke.md
@@ -43,7 +43,7 @@ Hosted agents support three protocols declared at deployment time. They are dist
 |----------|-------------------|-------|----------|
 | `responses` | `1.0.0` | `.../agents/{agentName}/endpoint/protocols/openai/responses` | Conversational agents, OpenAI-compatible |
 | `invocations` | `1.0.0` | `.../agents/{agentName}/endpoint/protocols/invocations` | Custom payloads, protocol bridges, webhook callers |
-| `invocations_ws` | `1.0.0` | `wss://.../projects/{project}/agents/{agentName}/endpoint/protocols/invocations_ws` | Duplex WebSocket — voice, WebRTC signaling, custom real-time streams. See the dedicated [invocations-ws skill](../invocations-ws/invocations-ws.md); `agent_invoke` does **not** speak WebSocket. |
+| `invocations_ws` | `1.0.0` | `wss://.../api/projects/{project}/agents/{agentName}/endpoint/protocols/invocations_ws` | Duplex WebSocket — voice, WebRTC signaling, custom real-time streams. See the dedicated [invocations-ws skill](../invocations-ws/invocations-ws.md); `agent_invoke` does **not** speak WebSocket. |
 
 Key difference: `responses` takes a natural language `inputText` message with platform-managed history. `invocations` is **bytes in, bytes out** — the request body is forwarded as-is to the container and the raw response is returned. The developer defines the schema; the platform is pure pass-through. See [Invocations Protocol Guide](references/invocations-protocol.md) for I/O details, schema discovery, and examples.
 


### PR DESCRIPTION
## Description

The hosted-agent `invocations_ws` WebSocket endpoint is going GA and switching from query-parameter routing to path-based routing (foundrysdk_specs PR #221), now that APIM supports templated `webSocketUrlTemplate` paths. This updates the `microsoft-foundry` skill docs so agents generate the correct GA URL shape instead of the old preview one.

Key contract changes reflected across the skill:

- **Path-based routing.** Project and agent move from query parameters to path segments: `wss://<account>.services.ai.azure.com/api/projects/{project}/agents/{agentName}/endpoint/protocols/invocations_ws`, mirroring the HTTP `/invocations` shape.
- **GA.** Removed the `HostedAgents=V1Preview` gate (the `foundry_features` query parameter / `Foundry-Features` header); the endpoint is generally available. Added a short "migrating from preview" note.
- **`api-version=v1`** is now a required query parameter.

Files touched (all doc body content, no frontmatter or version changes):
- `invocations-ws/invocations-ws.md` - GA callout, Quick Reference URL, client URL step, 404 error guidance.
- `invocations-ws/references/invocations-ws-protocol.md` - URL block, split path-segment vs query-parameter tables, dropped the `Foundry-Features` header row, updated the Python sample and 404 row.
- `invoke/invoke.md` - protocol route table now shows the path-templated WS route.

Note: `troubleshoot.md` still sends `Foundry-Features: HostedAgents=V1Preview` on the hosted-agent `/sessions` and `:logstream` REST endpoints. Those are a separate management API (still `2025-11-15-preview`) that PR #221 does not touch, so they are intentionally left unchanged.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

Skill descriptions (frontmatter) were not modified, only reference/body content. Validated with `npm run references` (all 27 skills pass) and `npm run checkCopilotCliCharBudget` (18392/20000).

## Related Issues

N/A