### PR TITLE
chore: remove copilot pat

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -8,6 +8,7 @@ name: Integration Tests - all
 permissions:
   id-token: write
   contents: read
+  copilot-requests: write
 
 on:
   schedule:
@@ -167,8 +168,6 @@ jobs:
       model-override: ${{ inputs.model-override }}
       test-pattern: ${{ needs.resolve-inputs.outputs.deploy-test-pattern }}
       debug: ${{ needs.resolve-inputs.outputs.debug == 'true' }}
-    secrets:
-      COPILOT_CLI_TOKEN: ${{ secrets.COPILOT_CLI_TOKEN }}
 
   test:
     name: Integration – ${{ matrix.skill }}
@@ -262,17 +261,12 @@ jobs:
           npm ci --ignore-scripts
           npm run build
 
-      # COPILOT_CLI_TOKEN must be a fine-grained access token with the Account level Copilot Request permission
-      # saved to the secrets of the microsoft/GitHub-Copilot-for-Azure repo.
-      # As a known issue, when the permission of the token doesn't grant sufficient access,
-      # the agent will hang instead of giving an error.
-      # If you see the agent hang indefinitely, try refreshing the access token.
-      # See https://github.com/github/copilot-sdk/issues/343 for more details.
+      # github.token(aka. GITHUB_TOKEN) is granted permission to make CAPI requests by having the copilot-requests permission
       - name: Setup Copilot CLI
         id: setup-copilot-cli
         uses: mvkaran/setup-copilot-cli@d05a47209e6b3185c9c55702bef49f28e6eebef7 # v1
         with:
-          token: ${{ secrets.COPILOT_CLI_TOKEN }}
+          token: ${{ github.token }}
 
       # Integration tests are broken down per skill for easy tracking of partially complete runs.
       # Test failures now fail the job (continue-on-error: false), while report steps still run via if: always().

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -8,6 +8,7 @@ name: Integration Tests - azure-deploy
 permissions:
   id-token: write
   contents: read
+  copilot-requests: write
 
 on:
   workflow_dispatch:
@@ -45,9 +46,6 @@ on:
         required: false
         type: boolean
         default: false
-    secrets:
-      COPILOT_CLI_TOKEN:
-        required: true
 
 jobs:
   setup:
@@ -167,17 +165,12 @@ jobs:
           npm ci --ignore-scripts
           npm run build
       
-      # COPILOT_CLI_TOKEN must be a fine-grained access token with the Account level Copilot Request permission
-      # saved to the secrets of the microsoft/GitHub-Copilot-for-Azure repo.
-      # As a known issue, when the permission of the token doesn't grant sufficient access,
-      # the agent will hang instead of giving an error.
-      # If you see the agent hang indefinitely, try refreshing the access token.
-      # See https://github.com/github/copilot-sdk/issues/343 for more details.
+      # github.token(aka. GITHUB_TOKEN) is granted permission to make CAPI requests by having the copilot-requests permission
       - name: Setup Copilot CLI
         id: setup-copilot-cli
         uses: mvkaran/setup-copilot-cli@d05a47209e6b3185c9c55702bef49f28e6eebef7 # v1
         with:
-          token: ${{ secrets.COPILOT_CLI_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Run tests – ${{ matrix.test-group }}
         env:


### PR DESCRIPTION
## Description

Remove the explicitly maintained COPILOT_CLI_TOKEN and use the built-in GITHUB_TOKEN for Copilot CLI tasks.

Learn more at: https://docs.github.com/en/copilot/how-tos/copilot-cli/use-copilot-cli-in-actions#using-copilot-cli-directly-in-a-workflow

Test run that indicate it works: https://github.com/microsoft/GitHub-Copilot-for-Azure/actions/runs/29114457000

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
