### PR TITLE
fix: enforce 7-day minimum age for test dependencies

### DIFF
--- a/tests/.npmrc
+++ b/tests/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -4829,9 +4829,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.28",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
-      "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+      "version": "4.12.27",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+      "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

- Add `min-release-age=7` to `tests/.npmrc`.
- Update the test lockfile to use `hono@4.12.27` instead of `4.12.28`.

## Context

Microsoft’s internal Azure Artifacts npm feed does not make packages available until they have been published for at least seven days. The lockfile selected the newly released `hono@4.12.28`, causing `npm ci` to fail with a 404.

This prevents future lockfile generation from selecting packages that have not passed the seven-day availability window.

## Validation

- `npm ci` with npm 11.13.0
- `npm ci` with npm 10.9.8
- `npm run typecheck`