### PR TITLE
chore: fix dashboard blob path sanitization

### DIFF
--- a/dashboard/api/src/functions/getTestResults.ts
+++ b/dashboard/api/src/functions/getTestResults.ts
@@ -100,6 +100,8 @@ function collectTestResultPaths(
  * Sanitize a test name the same way agent-runner.ts does when naming directories.
  * Used to match token-summary.jsonl entries (which contain the sanitised name)
  * against skill-invocation test entries (which use the raw Jest name).
+ * 
+ * Note: keep this in sync with the sanitizeTestName function in tests/utils.ts.
  */
 function sanitizeTestName(name: string): string {
     return name

--- a/dashboard/src/integration-tests/App.tsx
+++ b/dashboard/src/integration-tests/App.tsx
@@ -226,7 +226,12 @@ function formatRate(rate: number | null): string {
 }
 
 function formatTestName(name: string): string {
-    return name.replace(/\s+/g, "_");
+    return name
+        .replace(/[<>:"/\\|?*]/g, "-") // Replace invalid chars
+        .replace(/\s+/g, "_")           // Replace spaces with underscores
+        .replace(/-+/g, "-")            // Collapse multiple dashes
+        .replace(/_+/g, "_")            // Collapse multiple underscores
+        .substring(0, 200);             // Limit length
 }
 
 function App() {
@@ -656,8 +661,8 @@ function ToolCallItem({ date, runToken, call }: { date: string; runToken: string
         call.successState === "true"
             ? "it-tool-ok"
             : call.successState === "false"
-              ? "it-tool-fail"
-              : "it-tool-unknown";
+                ? "it-tool-fail"
+                : "it-tool-unknown";
 
     return (
         <li className="it-tool-call">

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -20,6 +20,7 @@ import { type CopilotSession, CopilotClient, type SessionEvent, approveAll, type
 import { redactSecrets } from "./redact.ts";
 import { listSkills } from "./skill-loader.ts";
 import { DEFAULT_SKILL_CHAR_BUDGET, truncateSkills } from "./char-budget.ts";
+import { sanitizeTestName } from "../vally/utils.ts";
 
 // Re-export for backward compatibility (consumers still import from agent-runner)
 export { getAllAssistantMessages } from "./evaluate.ts";
@@ -799,7 +800,7 @@ export function useAgentRunner(agentRunnerConfig: AgentRunnerConfig) {
         const state = expect.getState();
         const testName = state.currentTestName ?? "unknown-test";
         // Sanitize for use as filename
-        return sanitizeFileName(testName);
+        return sanitizeTestName(testName);
       } catch {
         // Fallback if not running in Jest context
         return `test-${Date.now()}`;
@@ -1339,15 +1340,3 @@ export function getIntegrationSkipReason(): string | undefined {
 const DEFAULT_REPORT_DIR = path.join(__dirname, "..", "reports");
 const TIME_STAMP = (process.env.START_TIMESTAMP || new Date().toISOString()).replace(/[:.]/g, "-");
 const testRunDirectoryName = `test-run-${testRunId || TIME_STAMP}`;
-
-/**
- * Sanitize a string for use as a filename
- */
-function sanitizeFileName(name: string): string {
-  return name
-    .replace(/[<>:"/\\|?*]/g, "-") // Replace invalid chars
-    .replace(/\s+/g, "_")           // Replace spaces with underscores
-    .replace(/-+/g, "-")            // Collapse multiple dashes
-    .replace(/_+/g, "_")            // Collapse multiple underscores
-    .substring(0, 200);             // Limit length
-}

--- a/tests/vally/utils.ts
+++ b/tests/vally/utils.ts
@@ -10,7 +10,9 @@ export function normalizeTestName(skillName: string, testName: string) {
 }
 
 /**
- * Sanitize a string for use as the filename from a given test name
+ * Sanitize a string for use as the filename from a given test name.
+ * 
+ * Note: keep this in sync with the sanitizeTestName function in tests/utils.ts.
  */
 export function sanitizeTestName(testName: string): string {
   return testName

--- a/tests/vally/utils.ts
+++ b/tests/vally/utils.ts
@@ -1,9 +1,22 @@
 export function normalizeTestName(skillName: string, testName: string) {
   // Downstream data processing uses the test name as an Azure Storage blob name.
   // Replace unsupported characters with supported ones.
-  testName = testName.replace(/\s+/g, "_").replace(/[:<>|*?]/g, "_");
-  if (!testName.startsWith(`${skillName}_`)) {
-    testName = `${skillName}_${testName}`;
+  const sanitizedTestName = sanitizeTestName(testName);
+  let normalizedTestName = sanitizedTestName;
+  if (!normalizedTestName.startsWith(`${skillName}_`)) {
+    normalizedTestName = `${skillName}_${sanitizedTestName}`;
   }
-  return testName;
+  return normalizedTestName;
+}
+
+/**
+ * Sanitize a string for use as the filename from a given test name
+ */
+export function sanitizeTestName(testName: string): string {
+  return testName
+    .replace(/[<>:"/\\|?*]/g, "-") // Replace invalid chars
+    .replace(/\s+/g, "_")           // Replace spaces with underscores
+    .replace(/-+/g, "-")            // Collapse multiple dashes
+    .replace(/_+/g, "_")            // Collapse multiple underscores
+    .substring(0, 200);             // Limit length
 }


### PR DESCRIPTION
## Description

In current implementation, there are 3 different places we sanitize test names and each of them use a different rule.
1. Dashboard: only replace whitespace with _
2. Test artifacts published by JavaScript runner: replace whitespace with _, replace a selected set of chars with _ (for azure storage and url segment combatibility)
3. Test artifacts published by vally executor: replace a selected set of chars with _, replace whitespace with _, collapse consecutive -, collapse consecutive _, limit length to 200.

Some test artifacts published to the storage cannot be viewed from the dashboard due to the path mismatch. This PR unifies all these sanitizations to use rule number 3.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
