### PR TITLE
fix: clarify canvas-first reminder

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -50,7 +50,7 @@ Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[A
 ```
 
 - **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
-- **`[ACTION]`** — the gate applies. If the user message's `<canvas-context>` already lists **`canvas="agent-builder"`**, the user has already driven the canvas — continue to 1b using their prompt/config (loop guard, independent of prompt wording). Otherwise `open_canvas` (`canvasId: "agent-builder"`), ask the user to **create the agent from the canvas: sign in, select a subscription + Foundry project, then Send**, then **stop — do not run 1b or scaffold**.
+- **`[ACTION]`** — the gate applies. If the user message's `<canvas-context>` already lists **`canvas="agent-builder"`**, the user has already driven the canvas — continue to 1b using their prompt/config (loop guard, independent of prompt wording). Otherwise `open_canvas` (`canvasId: "agent-builder"`), then state this non-question reminder in the normal response: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.** Then **stop — do not run 1b or scaffold**.
 
 **1b — Tooling & auth.** Run the bundled verification script before any other create/deploy command:
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -37,7 +37,7 @@ Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[A
 ```
 
 - **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
-- **`[ACTION]`** — the gate applies. If the user message's `<canvas-context>` already lists **`canvas="agent-builder"`**, the user has already driven the canvas — continue to 1b using their prompt/config (loop guard, independent of prompt wording). Otherwise `open_canvas` (`canvasId: "agent-builder"`), ask the user to **create the agent from the canvas: sign in, select a subscription + Foundry project, then Send**, then **stop — do not run 1b or scaffold**.
+- **`[ACTION]`** — the gate applies. If the user message's `<canvas-context>` already lists **`canvas="agent-builder"`**, the user has already driven the canvas — continue to 1b using their prompt/config (loop guard, independent of prompt wording). Otherwise `open_canvas` (`canvasId: "agent-builder"`), then state this non-question reminder in the normal response: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.** Then **stop — do not run 1b or scaffold**.
 
 **1b — Tooling & auth.** Run the bundled script:
 


### PR DESCRIPTION
## Summary

Present Canvas usage as a non-question reminder in the normal response, avoiding unintended question UI.