### PR TITLE
fix: include output/skills paths in Skills dashboard

### DIFF
--- a/dashboard/src/skills/App.tsx
+++ b/dashboard/src/skills/App.tsx
@@ -36,6 +36,11 @@ interface HealthData {
     categories?: Record<string, { items?: HealthCategoryItem[] }>;
 }
 
+function isPluginSkillPath(pathValue: string): boolean {
+    const normalized = pathValue.replace(/\\/g, "/");
+    return normalized.startsWith("output/skills/") || normalized.startsWith("plugin/skills/");
+}
+
 /** Extract plugin skills (with descriptions) from the frontmatter category. */
 function skillsFromHealthData(data: HealthData): Skill[] {
     const items = data.categories?.frontmatter?.items ?? [];
@@ -43,7 +48,7 @@ function skillsFromHealthData(data: HealthData): Skill[] {
     for (const item of items) {
         const path = String(item.metadata?.path ?? "");
         // Only plugin skills; the frontmatter check also covers .github/skills.
-        if (!path.startsWith("plugin/skills/")) continue;
+        if (!isPluginSkillPath(path)) continue;
         const description = String(item.metadata?.description ?? "");
         skills.push({ name: item.name, description, descriptionLength: description.length });
     }


### PR DESCRIPTION
## Summary
- update Skills page path filtering to accept both `output/skills/` and `plugin/skills/`
- normalize path separators before filtering so Windows-style paths are handled
- keep `.github/skills` excluded as before

## Why
The health data used by the Skills page now includes frontmatter item paths from `output/skills/...`; filtering only `plugin/skills/...` caused the page to show "No skills found."
