### PR TITLE
feat: add y-axis labels and connect sparkline points on Skills page

### DIFF
--- a/dashboard/src/skills/App.tsx
+++ b/dashboard/src/skills/App.tsx
@@ -87,7 +87,7 @@ function Sparkline({
     }
     return (
         <ResponsiveContainer width="100%" height={80}>
-            <LineChart data={data} margin={{ top: 6, right: 6, bottom: 0, left: 0 }}>
+            <LineChart data={data} margin={{ top: 6, right: 6, bottom: 0, left: 4 }}>
                 <XAxis
                     dataKey="date"
                     tickFormatter={shortDate}
@@ -95,7 +95,12 @@ function Sparkline({
                     interval="preserveStartEnd"
                     minTickGap={16}
                 />
-                <YAxis hide domain={["auto", "auto"]} />
+                <YAxis
+                    domain={["auto", "auto"]}
+                    tickFormatter={format}
+                    tick={{ fontSize: 10 }}
+                    width={40}
+                />
                 <Tooltip
                     formatter={(value) => {
                         // Missing-data days carry null; show a placeholder
@@ -114,7 +119,7 @@ function Sparkline({
                     stroke="var(--color-focus, #3b82f6)"
                     strokeWidth={2}
                     dot={{ r: 2 }}
-                    connectNulls={false}
+                    connectNulls={true}
                     isAnimationActive={false}
                 />
             </LineChart>


### PR DESCRIPTION
Improves the sparklines on the dashboard Skills page:

- **Y-axis labels**: the y-axis is now visible with formatted tick labels (e.g. `1.2s`, `3.4k`) per metric, instead of being hidden.
- **Connected points**: sparkline points are now connected across days with no data (`connectNulls`), so gaps no longer split the line into disconnected segments. Tooltips still show `No data` for those days.

Related to #2770.