### PR TITLE
feat: replace azure-validate Aspire Functions secret-storage scan with a script

### DIFF
--- a/plugin/skills/azure-validate/references/aspire-functions-secrets.md
+++ b/plugin/skills/azure-validate/references/aspire-functions-secrets.md
@@ -14,33 +14,25 @@ This check is required when **all** of these are true:
 
 ## Detection
 
-Search for `AddAzureFunctionsProject` in the AppHost source file(s):
+Run the scan script — it finds `*.cs` files that call `AddAzureFunctionsProject`, checks whether each one already sets `AzureWebJobsSecretStorageType`, and prints a single verdict so you don't have to parse raw grep output.
 
+**Bash** — [`scripts/scan-aspire-functions-secrets.sh`](scripts/scan-aspire-functions-secrets.sh):
 ```bash
-grep -rn "AddAzureFunctionsProject" . --include="*.cs"
+./scripts/scan-aspire-functions-secrets.sh [directory]   # directory defaults to .
 ```
 
-**PowerShell:**
+**PowerShell** — [`scripts/scan-aspire-functions-secrets.ps1`](scripts/scan-aspire-functions-secrets.ps1):
 ```powershell
-Get-ChildItem -Recurse -Filter "*.cs" | Select-String "AddAzureFunctionsProject" -List
+.\scripts\scan-aspire-functions-secrets.ps1 [-Path <directory>]   # -Path defaults to .
 ```
 
-If found, check whether `AzureWebJobsSecretStorageType` is already configured in those same file(s):
+The script prints one of three verdicts:
 
-```bash
-# Check only the AppHost file(s) that contain AddAzureFunctionsProject
-find . -name "*.cs" -path "*AppHost*" -print0 | xargs -0 grep -l "AddAzureFunctionsProject" 2>/dev/null | xargs grep -l "AzureWebJobsSecretStorageType"
-```
-
-**PowerShell:**
-```powershell
-Get-ChildItem -Recurse -Filter "*.cs" |
-  Where-Object { $_.FullName -match "AppHost" } |
-  Select-String "AddAzureFunctionsProject" -List |
-  ForEach-Object { Select-String "AzureWebJobsSecretStorageType" -Path $_.Path }
-```
-
-**If `AddAzureFunctionsProject` is present but `AzureWebJobsSecretStorageType` is NOT configured in the same file → fix is required.**
+| Verdict | Meaning | Action |
+|---------|---------|--------|
+| `NOT APPLICABLE` | No `AddAzureFunctionsProject` call found | Skip this check |
+| `ALREADY CONFIGURED` | Every matching file already sets `AzureWebJobsSecretStorageType` | No change required |
+| `FIX REQUIRED` | Matching file(s) call `AddAzureFunctionsProject` but omit the setting (file/line listed) | Apply the **Fix** below to each listed file |
 
 ## Fix
 

--- a/plugin/skills/azure-validate/references/scripts/scan-aspire-functions-secrets.ps1
+++ b/plugin/skills/azure-validate/references/scripts/scan-aspire-functions-secrets.ps1
@@ -1,0 +1,83 @@
+<#
+.SYNOPSIS
+    Aspire + Azure Functions secret-storage pre-provisioning scan.
+.DESCRIPTION
+    Decides whether the AzureWebJobsSecretStorageType=Files fix is required by
+    scanning C# source for the Aspire Functions builder call and the setting.
+
+    Logic:
+      1. Find *.cs files that call AddAzureFunctionsProject.
+      2. For each, check whether the same file already sets AzureWebJobsSecretStorageType.
+      3. Files with the call but missing the setting -> fix required.
+
+    Prints a single verdict — NOT APPLICABLE, ALREADY CONFIGURED, or FIX REQUIRED
+    (with the matching file(s) and line(s)). Exit code is 0 for every verdict;
+    a non-zero exit only indicates a usage/environment error.
+.PARAMETER Path
+    Directory to scan. Defaults to the current directory.
+.EXAMPLE
+    .\scan-aspire-functions-secrets.ps1
+    # Scan the current directory
+.EXAMPLE
+    .\scan-aspire-functions-secrets.ps1 -Path ./src
+    # Scan a specific directory
+#>
+param(
+    [string]$Path = "."
+)
+
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
+    Write-Error "'$Path' is not a directory."
+    exit 2
+}
+
+$call = "AddAzureFunctionsProject"
+$setting = "AzureWebJobsSecretStorageType"
+
+# Collect *.cs files that reference AddAzureFunctionsProject.
+$matches = Get-ChildItem -Path $Path -Recurse -File -Filter "*.cs" |
+    Where-Object { Select-String -Path $_.FullName -SimpleMatch -Pattern $call -Quiet }
+
+if (-not $matches) {
+    Write-Output "VERDICT: NOT APPLICABLE"
+    Write-Output "No '$call' call found in any *.cs file under '$Path'."
+    Write-Output "The Functions secret-storage check does not apply - skip it."
+    exit 0
+}
+
+# Partition matching files by whether they already configure the setting.
+$needsFix = @()
+$configured = @()
+foreach ($file in $matches) {
+    if (Select-String -Path $file.FullName -SimpleMatch -Pattern $setting -Quiet) {
+        $configured += $file
+    } else {
+        $needsFix += $file
+    }
+}
+
+if ($needsFix.Count -eq 0) {
+    Write-Output "VERDICT: ALREADY CONFIGURED"
+    Write-Output "Every file that calls '$call' already sets '$setting':"
+    foreach ($file in $configured) {
+        $line = (Select-String -Path $file.FullName -SimpleMatch -Pattern $setting |
+            Select-Object -First 1).LineNumber
+        Write-Output "  - $($file.FullName) (line $line)"
+    }
+    Write-Output "No change required."
+    exit 0
+}
+
+Write-Output "VERDICT: FIX REQUIRED"
+Write-Output "The following file(s) call '$call' but do NOT set '$setting':"
+foreach ($file in $needsFix) {
+    $line = (Select-String -Path $file.FullName -SimpleMatch -Pattern $call |
+        Select-Object -First 1).LineNumber
+    Write-Output "  - $($file.FullName) (line $line)"
+}
+Write-Output ""
+Write-Output "Add .WithEnvironment(`"$setting`", `"Files`") to the AddAzureFunctionsProject"
+Write-Output "builder chain in each file above BEFORE running 'azd provision'."
+exit 0

--- a/plugin/skills/azure-validate/references/scripts/scan-aspire-functions-secrets.ps1
+++ b/plugin/skills/azure-validate/references/scripts/scan-aspire-functions-secrets.ps1
@@ -26,7 +26,8 @@ param(
     [string]$Path = "."
 )
 
-$ErrorActionPreference = "Stop"
+# Leave $ErrorActionPreference at its default ("Continue") so that Write-Error
+# below is non-terminating and the explicit `exit` codes are honored.
 
 if (-not (Test-Path -LiteralPath $Path -PathType Container)) {
     Write-Error "'$Path' is not a directory."

--- a/plugin/skills/azure-validate/references/scripts/scan-aspire-functions-secrets.sh
+++ b/plugin/skills/azure-validate/references/scripts/scan-aspire-functions-secrets.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# scan-aspire-functions-secrets.sh
+# Aspire + Azure Functions secret-storage pre-provisioning scan.
+#
+# Decides whether the AzureWebJobsSecretStorageType=Files fix is required by
+# scanning C# source for the Aspire Functions builder call and the setting.
+#
+# Logic:
+#   1. Find *.cs files that call AddAzureFunctionsProject.
+#   2. For each, check whether the same file already sets AzureWebJobsSecretStorageType.
+#   3. Files with the call but missing the setting -> fix required.
+#
+# Usage:
+#   ./scan-aspire-functions-secrets.sh [directory]
+#
+# Examples:
+#   ./scan-aspire-functions-secrets.sh              # Scan current directory
+#   ./scan-aspire-functions-secrets.sh ./src        # Scan a specific directory
+#
+# Output: a single verdict — NOT APPLICABLE, ALREADY CONFIGURED, or FIX REQUIRED
+# (with the matching file(s) and line(s)). Exit code is 0 for every verdict;
+# a non-zero exit only indicates a usage/environment error.
+
+set -euo pipefail
+
+ROOT="${1:-.}"
+
+if [ ! -d "$ROOT" ]; then
+  echo "ERROR: '$ROOT' is not a directory." >&2
+  exit 2
+fi
+
+CALL="AddAzureFunctionsProject"
+SETTING="AzureWebJobsSecretStorageType"
+
+# Collect *.cs files that reference AddAzureFunctionsProject (NUL-delimited for safe paths).
+matches=""
+while IFS= read -r -d '' file; do
+  if grep -q "$CALL" "$file"; then
+    matches+="$file"$'\n'
+  fi
+done < <(find "$ROOT" -type f -name "*.cs" -print0)
+
+# Strip trailing newline.
+matches="${matches%$'\n'}"
+
+if [ -z "$matches" ]; then
+  echo "VERDICT: NOT APPLICABLE"
+  echo "No '$CALL' call found in any *.cs file under '$ROOT'."
+  echo "The Functions secret-storage check does not apply — skip it."
+  exit 0
+fi
+
+# Partition matching files by whether they already configure the setting.
+needs_fix=""
+configured=""
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  if grep -q "$SETTING" "$file"; then
+    configured+="$file"$'\n'
+  else
+    needs_fix+="$file"$'\n'
+  fi
+done <<< "$matches"
+
+needs_fix="${needs_fix%$'\n'}"
+configured="${configured%$'\n'}"
+
+if [ -z "$needs_fix" ]; then
+  echo "VERDICT: ALREADY CONFIGURED"
+  echo "Every file that calls '$CALL' already sets '$SETTING':"
+  while IFS= read -r file; do
+    [ -n "$file" ] || continue
+    line=$(grep -n "$SETTING" "$file" | head -n1 | cut -d: -f1)
+    echo "  - $file (line $line)"
+  done <<< "$configured"
+  echo "No change required."
+  exit 0
+fi
+
+echo "VERDICT: FIX REQUIRED"
+echo "The following file(s) call '$CALL' but do NOT set '$SETTING':"
+while IFS= read -r file; do
+  [ -n "$file" ] || continue
+  line=$(grep -n "$CALL" "$file" | head -n1 | cut -d: -f1)
+  echo "  - $file (line $line)"
+done <<< "$needs_fix"
+echo ""
+echo "Add .WithEnvironment(\"$SETTING\", \"Files\") to the AddAzureFunctionsProject"
+echo "builder chain in each file above BEFORE running 'azd provision'."
+exit 0

--- a/plugin/skills/azure-validate/references/scripts/scan-aspire-functions-secrets.sh
+++ b/plugin/skills/azure-validate/references/scripts/scan-aspire-functions-secrets.sh
@@ -33,18 +33,40 @@ fi
 CALL="AddAzureFunctionsProject"
 SETTING="AzureWebJobsSecretStorageType"
 
-# Collect *.cs files that reference AddAzureFunctionsProject (NUL-delimited for safe paths).
-matches=""
+# file_contains <fixed-string> <file>
+# Returns 0 if the file contains the literal string, 1 if not.
+# A grep read error (exit code 2) is fatal: this is a critical pre-provision
+# scan, so a file we cannot read must not be silently reported as "no match".
+file_contains() {
+  local pattern="$1" file="$2" rc
+  if grep -Fq -- "$pattern" "$file"; then
+    return 0
+  fi
+  rc=$?
+  if [ "$rc" -eq 2 ]; then
+    echo "ERROR: failed to read '$file' while scanning for '$pattern'." >&2
+    exit 3
+  fi
+  return 1
+}
+
+# first_line <fixed-string> <file>
+# Prints the 1-based line number of the first literal match (or nothing).
+first_line() {
+  grep -Fn -- "$1" "$2" | head -n1 | cut -d: -f1
+}
+
+# Collect *.cs files that reference AddAzureFunctionsProject into an array.
+# find ... -print0 + read -d '' keeps paths intact even if they contain
+# newlines or spaces (genuinely NUL-safe, unlike a newline-joined string).
+matches=()
 while IFS= read -r -d '' file; do
-  if grep -q "$CALL" "$file"; then
-    matches+="$file"$'\n'
+  if file_contains "$CALL" "$file"; then
+    matches+=("$file")
   fi
 done < <(find "$ROOT" -type f -name "*.cs" -print0)
 
-# Strip trailing newline.
-matches="${matches%$'\n'}"
-
-if [ -z "$matches" ]; then
+if [ "${#matches[@]}" -eq 0 ]; then
   echo "VERDICT: NOT APPLICABLE"
   echo "No '$CALL' call found in any *.cs file under '$ROOT'."
   echo "The Functions secret-storage check does not apply — skip it."
@@ -52,39 +74,31 @@ if [ -z "$matches" ]; then
 fi
 
 # Partition matching files by whether they already configure the setting.
-needs_fix=""
-configured=""
-while IFS= read -r file; do
-  [ -n "$file" ] || continue
-  if grep -q "$SETTING" "$file"; then
-    configured+="$file"$'\n'
+needs_fix=()
+configured=()
+for file in "${matches[@]}"; do
+  if file_contains "$SETTING" "$file"; then
+    configured+=("$file")
   else
-    needs_fix+="$file"$'\n'
+    needs_fix+=("$file")
   fi
-done <<< "$matches"
+done
 
-needs_fix="${needs_fix%$'\n'}"
-configured="${configured%$'\n'}"
-
-if [ -z "$needs_fix" ]; then
+if [ "${#needs_fix[@]}" -eq 0 ]; then
   echo "VERDICT: ALREADY CONFIGURED"
   echo "Every file that calls '$CALL' already sets '$SETTING':"
-  while IFS= read -r file; do
-    [ -n "$file" ] || continue
-    line=$(grep -n "$SETTING" "$file" | head -n1 | cut -d: -f1)
-    echo "  - $file (line $line)"
-  done <<< "$configured"
+  for file in "${configured[@]}"; do
+    echo "  - $file (line $(first_line "$SETTING" "$file"))"
+  done
   echo "No change required."
   exit 0
 fi
 
 echo "VERDICT: FIX REQUIRED"
 echo "The following file(s) call '$CALL' but do NOT set '$SETTING':"
-while IFS= read -r file; do
-  [ -n "$file" ] || continue
-  line=$(grep -n "$CALL" "$file" | head -n1 | cut -d: -f1)
-  echo "  - $file (line $line)"
-done <<< "$needs_fix"
+for file in "${needs_fix[@]}"; do
+  echo "  - $file (line $(first_line "$CALL" "$file"))"
+done
 echo ""
 echo "Add .WithEnvironment(\"$SETTING\", \"Files\") to the AddAzureFunctionsProject"
 echo "builder chain in each file above BEFORE running 'azd provision'."


### PR DESCRIPTION
## Summary

Fixes #2505.

Replaces the `azure-validate` skill's Aspire + Azure Functions secret-storage scan (previously inline parallel bash/PowerShell one-liners, including an error-prone `find | xargs | grep` pipeline) with a tested cross-platform script pair.

The scan is a deterministic, CRITICAL pre-provisioning check: before `azd provision`, decide whether the `AzureWebJobsSecretStorageType=Files` fix is required for an Aspire app that uses Azure Functions.

## Changes

- **New scripts** in `plugin/skills/azure-validate/references/scripts/`:
  - `scan-aspire-functions-secrets.sh` (bash)
  - `scan-aspire-functions-secrets.ps1` (PowerShell)

  Each scans `*.cs` files for `AddAzureFunctionsProject`, checks whether each match already sets `AzureWebJobsSecretStorageType`, and prints one self-explanatory verdict:
  - `NOT APPLICABLE` — no `AddAzureFunctionsProject` found → skip the check
  - `ALREADY CONFIGURED` — every matching file already sets the value → no change
  - `FIX REQUIRED` — matching file(s) listed with file/line → apply the fix

  Exit code is `0` for every verdict; non-zero only on usage/environment errors.

- **`references/aspire-functions-secrets.md`**: replaced the inline detection one-liners with a markdown-linked script invocation, a one-line description, per-platform sample calls, and a verdict table. The **Fix** (editing the builder chain) and all rationale prose are unchanged — only the scan + verdict is scripted.

## Scope note

Only the scan/verdict is scripted; applying the fix (adding `.WithEnvironment("AzureWebJobsSecretStorageType", "Files")`) still requires source-editing judgment and stays in prose. The shared AppHost `*.cs` scan-helper refactor mentioned in the issue (overlap with #2499 / #2494) is intentionally out of scope.

## Validation

- **Manual fixture tests** of both scripts (no call / call-only / call+setting) — identical, correct verdicts on bash (Git Bash) and PowerShell.
- `npm run build` — version stamping succeeds; scripts are copied into `output/`.
- `cd scripts && npm run references` — ✅ (markdown links stay within the skill directory).
- `npm run tokens check` — the edited reference is within limits (net −8 lines).
- `cd tests && npm test -- --testPathPatterns=azure-validate` — 32 trigger tests pass.
- `.sh` normalized to LF line endings.

## Related tests / evals

No test invokes the script by name; graders assert the resulting `AppHost.cs` edit. The scan-and-verdict flow this script backs is exercised by the `dotnet/aspire-samples` `samples/aspire-with-azure-functions` scenarios:

- **azure-validate (primary):** `evals/azure-validate/e2e-eval.yaml` → "Brownfield - AzureWebJobsSecretStorageType for Aspire Functions" — requires the `azure-validate` skill, early-terminates before `azd provision`, and grades that `**/AppHost.cs` gains `AzureWebJobsSecretStorageType` while deploy never runs.
- **azure-prepare:** `evals/azure-prepare/e2e-eval.yaml` → "Aspire With Azure Functions - Services Section" — same sample; loads `aspire.md` (which links this scan) but grades the `azure.yaml` services section.
- **azure-deploy:** `tests/azure-deploy/integration.test.ts` → `test("deploys aspire azure functions")` — full end-to-end deploy of the same sample; hits the pre-provision scan along the way.
