### PR TITLE
feat: replace azure-validate Aspire ACA env-var setup with a script

### DIFF
--- a/plugin/skills/azure-validate/references/recipes/azd/aspire.md
+++ b/plugin/skills/azure-validate/references/recipes/azd/aspire.md
@@ -34,33 +34,30 @@ See [Aspire Functions Secrets Reference](../../aspire-functions-secrets.md) for 
 
 When using Aspire with Container Apps in "limited mode" (in-memory infrastructure generation), `azd provision` creates Azure resources but doesn't automatically populate environment variables that `azd deploy` needs.
 
-**Check if environment variables are set:**
+**Run the helper script to set the three required variables.** It reads the azd
+environment, derives the resource group, and sets `AZURE_CONTAINER_REGISTRY_ENDPOINT`,
+`AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID`, and `MANAGED_IDENTITY_CLIENT_ID` **only if
+they are missing**, then prints what it set (or "already present") so you don't have to
+re-parse `azd env get-values`.
 
+**bash:**
 ```bash
-azd env get-values | grep -E "AZURE_CONTAINER_REGISTRY_ENDPOINT|AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID|MANAGED_IDENTITY_CLIENT_ID"
-```
-
-**If any are missing, set them now BEFORE running `azd deploy`:**
-
-```bash
-# Get resource group name
-RG_NAME=$(azd env get-values | grep AZURE_RESOURCE_GROUP | cut -d'=' -f2 | tr -d '"')
-
-# Set required variables
-azd env set AZURE_CONTAINER_REGISTRY_ENDPOINT $(az acr list --resource-group "$RG_NAME" --query "[0].loginServer" -o tsv)
-azd env set AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID $(az identity list --resource-group "$RG_NAME" --query "[0].id" -o tsv)
-azd env set MANAGED_IDENTITY_CLIENT_ID $(az identity list --resource-group "$RG_NAME" --query "[0].clientId" -o tsv)
+./scripts/set-aspire-aca-env.sh          # or: -e <azd-env-name>
 ```
 
 **PowerShell:**
 ```powershell
-# Get resource group name
-$rgName = (azd env get-values | Select-String 'AZURE_RESOURCE_GROUP').Line.Split('=')[1].Trim('"')
-
-# Set required variables
-azd env set AZURE_CONTAINER_REGISTRY_ENDPOINT (az acr list --resource-group $rgName --query "[0].loginServer" -o tsv)
-azd env set AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID (az identity list --resource-group $rgName --query "[0].id" -o tsv)
-azd env set MANAGED_IDENTITY_CLIENT_ID (az identity list --resource-group $rgName --query "[0].clientId" -o tsv)
+./scripts/set-aspire-aca-env.ps1         # or: -Environment <azd-env-name>
 ```
+
+The scripts — [scripts/set-aspire-aca-env.sh](scripts/set-aspire-aca-env.sh) and
+[scripts/set-aspire-aca-env.ps1](scripts/set-aspire-aca-env.ps1) — are cross-platform
+equivalents that:
+
+- Load `azd env get-values` safely (no `eval`) and read `AZURE_RESOURCE_GROUP`.
+- Skip any variable already present; set missing ones from live Azure
+  (`az acr list` / `az identity list`).
+- Print a compact summary of each variable and fail with a clear message if the resource
+  group or a resource can't be resolved.
 
 **Why this is needed:** Aspire's "limited mode" generates infrastructure in-memory. While `azd provision` creates all necessary Azure resources (Container Registry, Managed Identity, Container Apps Environment), it doesn't populate the environment variables that reference those resources. The `azd deploy` phase requires these variables to authenticate with the container registry and configure managed identity bindings.

--- a/plugin/skills/azure-validate/references/recipes/azd/aspire.md
+++ b/plugin/skills/azure-validate/references/recipes/azd/aspire.md
@@ -34,11 +34,7 @@ See [Aspire Functions Secrets Reference](../../aspire-functions-secrets.md) for 
 
 When using Aspire with Container Apps in "limited mode" (in-memory infrastructure generation), `azd provision` creates Azure resources but doesn't automatically populate environment variables that `azd deploy` needs.
 
-**Run the helper script to set the three required variables.** It reads the azd
-environment, derives the resource group, and sets `AZURE_CONTAINER_REGISTRY_ENDPOINT`,
-`AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID`, and `MANAGED_IDENTITY_CLIENT_ID` **only if
-they are missing**, then prints what it set (or "already present") so you don't have to
-re-parse `azd env get-values`.
+**Run the helper script** ([scripts/set-aspire-aca-env.sh](scripts/set-aspire-aca-env.sh) or [scripts/set-aspire-aca-env.ps1](scripts/set-aspire-aca-env.ps1)). It sets `AZURE_CONTAINER_REGISTRY_ENDPOINT`, `AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID`, and `MANAGED_IDENTITY_CLIENT_ID` (only the ones that are missing).
 
 **bash:**
 ```bash
@@ -49,15 +45,3 @@ re-parse `azd env get-values`.
 ```powershell
 ./scripts/set-aspire-aca-env.ps1         # or: -Environment <azd-env-name>
 ```
-
-The scripts — [scripts/set-aspire-aca-env.sh](scripts/set-aspire-aca-env.sh) and
-[scripts/set-aspire-aca-env.ps1](scripts/set-aspire-aca-env.ps1) — are cross-platform
-equivalents that:
-
-- Load `azd env get-values` safely (no `eval`) and read `AZURE_RESOURCE_GROUP`.
-- Skip any variable already present; set missing ones from live Azure
-  (`az acr list` / `az identity list`).
-- Print a compact summary of each variable and fail with a clear message if the resource
-  group or a resource can't be resolved.
-
-**Why this is needed:** Aspire's "limited mode" generates infrastructure in-memory. While `azd provision` creates all necessary Azure resources (Container Registry, Managed Identity, Container Apps Environment), it doesn't populate the environment variables that reference those resources. The `azd deploy` phase requires these variables to authenticate with the container registry and configure managed identity bindings.

--- a/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
+++ b/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
@@ -41,8 +41,7 @@ if ($Environment) {
 # rather than relying on $ErrorActionPreference.
 $azdOutput = azd env get-values @azdEnvArgs
 if ($LASTEXITCODE -ne 0) {
-    Write-Host "ERROR: 'azd env get-values' failed with exit code $LASTEXITCODE."
-    Write-Host "Run 'azd provision' before this script so the azd environment is available."
+    Write-Error "'azd env get-values' failed with exit code $LASTEXITCODE. Run 'azd provision' before this script so the azd environment is available."
     exit 1
 }
 
@@ -56,8 +55,7 @@ foreach ($line in $azdOutput) {
 
 $rgName = $azdValues['AZURE_RESOURCE_GROUP']
 if (-not $rgName) {
-    Write-Host "ERROR: AZURE_RESOURCE_GROUP is not set in the azd environment."
-    Write-Host "Run 'azd provision' before this script so the resource group is available."
+    Write-Error "AZURE_RESOURCE_GROUP is not set in the azd environment. Run 'azd provision' before this script so the resource group is available."
     exit 1
 }
 
@@ -76,8 +74,7 @@ function Set-IfMissing {
 
     $value = (& $ValueCommand)
     if (-not $value) {
-        Write-Host "ERROR: Could not resolve $VarName ($Description) in resource group '$rgName'."
-        Write-Host "Confirm 'azd provision' completed and the resource exists."
+        Write-Error "Could not resolve $VarName ($Description) in resource group '$rgName'. Confirm 'azd provision' completed and the resource exists."
         exit 1
     }
 

--- a/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
+++ b/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
@@ -48,8 +48,8 @@ foreach ($line in (azd env get-values @azdEnvArgs)) {
 
 $rgName = $azdValues['AZURE_RESOURCE_GROUP']
 if (-not $rgName) {
-    [Console]::Error.WriteLine("ERROR: AZURE_RESOURCE_GROUP is not set in the azd environment.")
-    [Console]::Error.WriteLine("Run 'azd provision' before this script so the resource group is available.")
+    Write-Host "ERROR: AZURE_RESOURCE_GROUP is not set in the azd environment."
+    Write-Host "Run 'azd provision' before this script so the resource group is available."
     exit 1
 }
 
@@ -68,8 +68,8 @@ function Set-IfMissing {
 
     $value = (& $ValueCommand)
     if (-not $value) {
-        [Console]::Error.WriteLine("ERROR: Could not resolve $VarName ($Description) in resource group '$rgName'.")
-        [Console]::Error.WriteLine("Confirm 'azd provision' completed and the resource exists.")
+        Write-Host "ERROR: Could not resolve $VarName ($Description) in resource group '$rgName'."
+        Write-Host "Confirm 'azd provision' completed and the resource exists."
         exit 1
     }
 

--- a/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
+++ b/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
@@ -1,22 +1,30 @@
-# Set the Container Apps environment variables that Aspire "limited mode" leaves unpopulated.
-#
-# When Aspire runs in "limited mode", `azd provision` creates the Azure resources
-# (Container Registry, Managed Identity, Container Apps Environment) but does NOT populate the
-# env vars that `azd deploy` needs to reference them. This script fills that gap.
-#
-# Run it AFTER `azd provision` but BEFORE `azd deploy`.
-#
-# USAGE:
-#   ./set-aspire-aca-env.ps1 [-Environment <azd-env-name>]
-#
-#   -Environment   Optional azd environment name (forwarded to `azd env` calls).
-#                  Defaults to the current/default azd environment.
-#
-# The script only sets a variable if it is currently missing, and prints what it did so the
-# result can be understood without re-inspecting `azd env get-values`:
-#   AZURE_CONTAINER_REGISTRY_ENDPOINT              <- az acr list ... [0].loginServer
-#   AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID   <- az identity list ... [0].id
-#   MANAGED_IDENTITY_CLIENT_ID                     <- az identity list ... [0].clientId
+<#
+.SYNOPSIS
+    Set the Container Apps environment variables that Aspire "limited mode" leaves unpopulated.
+
+.DESCRIPTION
+    When Aspire runs in "limited mode", `azd provision` creates the Azure resources
+    (Container Registry, Managed Identity, Container Apps Environment) but does NOT populate the
+    env vars that `azd deploy` needs to reference them. This script fills that gap.
+
+    Run it AFTER `azd provision` but BEFORE `azd deploy`.
+
+    The script only sets a variable if it is currently missing, and prints what it did so the
+    result can be understood without re-inspecting `azd env get-values`:
+      AZURE_CONTAINER_REGISTRY_ENDPOINT              <- az acr list ... [0].loginServer
+      AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID   <- az identity list ... [0].id
+      MANAGED_IDENTITY_CLIENT_ID                     <- az identity list ... [0].clientId
+
+.PARAMETER Environment
+    Optional azd environment name (forwarded to `azd env` calls).
+    Defaults to the current/default azd environment.
+
+.EXAMPLE
+    ./set-aspire-aca-env.ps1
+
+.EXAMPLE
+    ./set-aspire-aca-env.ps1 -Environment my-azd-env
+#>
 
 param(
     [string]$Environment

--- a/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
+++ b/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
@@ -48,7 +48,9 @@ foreach ($line in (azd env get-values @azdEnvArgs)) {
 
 $rgName = $azdValues['AZURE_RESOURCE_GROUP']
 if (-not $rgName) {
-    throw "AZURE_RESOURCE_GROUP is not set in the azd environment. Run 'azd provision' before this script so the resource group is available."
+    [Console]::Error.WriteLine("ERROR: AZURE_RESOURCE_GROUP is not set in the azd environment.")
+    [Console]::Error.WriteLine("Run 'azd provision' before this script so the resource group is available.")
+    exit 1
 }
 
 function Set-IfMissing {
@@ -66,7 +68,9 @@ function Set-IfMissing {
 
     $value = (& $ValueCommand)
     if (-not $value) {
-        throw "Could not resolve $VarName ($Description) in resource group '$rgName'. Confirm 'azd provision' completed and the resource exists."
+        [Console]::Error.WriteLine("ERROR: Could not resolve $VarName ($Description) in resource group '$rgName'.")
+        [Console]::Error.WriteLine("Confirm 'azd provision' completed and the resource exists.")
+        exit 1
     }
 
     azd env set @azdEnvArgs $VarName $value

--- a/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
+++ b/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
@@ -1,0 +1,85 @@
+# Set the Container Apps environment variables that Aspire "limited mode" leaves unpopulated.
+#
+# When Aspire runs in "limited mode", `azd provision` creates the Azure resources
+# (Container Registry, Managed Identity, Container Apps Environment) but does NOT populate the
+# env vars that `azd deploy` needs to reference them. This script fills that gap.
+#
+# Run it AFTER `azd provision` but BEFORE `azd deploy`.
+#
+# USAGE:
+#   ./set-aspire-aca-env.ps1 [-Environment <azd-env-name>]
+#
+#   -Environment   Optional azd environment name (forwarded to `azd env` calls).
+#                  Defaults to the current/default azd environment.
+#
+# The script only sets a variable if it is currently missing, and prints what it did so the
+# result can be understood without re-inspecting `azd env get-values`:
+#   AZURE_CONTAINER_REGISTRY_ENDPOINT              <- az acr list ... [0].loginServer
+#   AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID   <- az identity list ... [0].id
+#   MANAGED_IDENTITY_CLIENT_ID                     <- az identity list ... [0].clientId
+
+param(
+    [string]$Environment
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Shared `-e <name>` argument list for azd calls (empty when no env name given).
+$azdEnvArgs = @()
+if ($Environment) {
+    $azdEnvArgs = @('-e', $Environment)
+}
+
+# Load azd environment values into a hashtable.
+$azdValues = @{}
+foreach ($line in (azd env get-values @azdEnvArgs)) {
+    if (-not $line) { continue }
+    $name, $value = $line.Split('=', 2)
+    $azdValues[$name] = $value.Trim('"')
+}
+
+$rgName = $azdValues['AZURE_RESOURCE_GROUP']
+if (-not $rgName) {
+    throw "AZURE_RESOURCE_GROUP is not set in the azd environment. Run 'azd provision' before this script so the resource group is available."
+}
+
+function Set-IfMissing {
+    param(
+        [string]$VarName,
+        [string]$Description,
+        [scriptblock]$ValueCommand
+    )
+
+    $existing = $azdValues[$VarName]
+    if ($existing) {
+        Write-Host "${VarName}: already present ($existing)"
+        return
+    }
+
+    $value = (& $ValueCommand)
+    if (-not $value) {
+        throw "Could not resolve $VarName ($Description) in resource group '$rgName'. Confirm 'azd provision' completed and the resource exists."
+    }
+
+    azd env set @azdEnvArgs $VarName $value
+    Write-Host "${VarName}: set to $value"
+}
+
+Write-Host "Resource group: $rgName"
+
+Set-IfMissing `
+    -VarName 'AZURE_CONTAINER_REGISTRY_ENDPOINT' `
+    -Description 'container registry login server' `
+    -ValueCommand { az acr list --resource-group $rgName --query "[0].loginServer" -o tsv }
+
+Set-IfMissing `
+    -VarName 'AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID' `
+    -Description 'managed identity resource id' `
+    -ValueCommand { az identity list --resource-group $rgName --query "[0].id" -o tsv }
+
+Set-IfMissing `
+    -VarName 'MANAGED_IDENTITY_CLIENT_ID' `
+    -Description 'managed identity client id' `
+    -ValueCommand { az identity list --resource-group $rgName --query "[0].clientId" -o tsv }
+
+Write-Host "Aspire Container Apps environment variables are ready for 'azd deploy'."

--- a/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
+++ b/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.ps1
@@ -30,17 +30,25 @@ param(
     [string]$Environment
 )
 
-$ErrorActionPreference = 'Stop'
-
 # Shared `-e <name>` argument list for azd calls (empty when no env name given).
 $azdEnvArgs = @()
 if ($Environment) {
     $azdEnvArgs = @('-e', $Environment)
 }
 
+# Capture azd environment values and verify the call succeeded. PowerShell does not treat a
+# native command's non-zero exit code as a terminating error, so check $LASTEXITCODE explicitly
+# rather than relying on $ErrorActionPreference.
+$azdOutput = azd env get-values @azdEnvArgs
+if ($LASTEXITCODE -ne 0) {
+    Write-Host "ERROR: 'azd env get-values' failed with exit code $LASTEXITCODE."
+    Write-Host "Run 'azd provision' before this script so the azd environment is available."
+    exit 1
+}
+
 # Load azd environment values into a hashtable.
 $azdValues = @{}
-foreach ($line in (azd env get-values @azdEnvArgs)) {
+foreach ($line in $azdOutput) {
     if (-not $line) { continue }
     $name, $value = $line.Split('=', 2)
     $azdValues[$name] = $value.Trim('"')

--- a/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.sh
+++ b/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Set the Container Apps environment variables that Aspire "limited mode" leaves unpopulated.
 #
 # When Aspire runs in "limited mode", `azd provision` creates the Azure resources
@@ -42,39 +42,40 @@ if [ -n "$AZD_ENV_NAME" ]; then
   AZD_ENV_ARGS="-e $AZD_ENV_NAME"
 fi
 
-# Safely load azd environment values into an associative array (no eval).
-declare -A AZD_VALUES
-while IFS= read -r line; do
-  [ -n "$line" ] || continue
-  key=${line%%=*}
-  value=${line#*=}
-  case "$value" in
-    \"*\") value=${value#\"}; value=${value%\"} ;;
-    \'*\') value=${value#\'}; value=${value%\'} ;;
-  esac
-  AZD_VALUES["$key"]="$value"
-done < <(azd env get-values $AZD_ENV_ARGS)
+# Capture azd environment values via command substitution so `set -e` aborts if the
+# `azd env get-values` call itself fails (rather than silently continuing with no values).
+AZD_VALUES=$(azd env get-values $AZD_ENV_ARGS)
 
-RG_NAME="${AZD_VALUES[AZURE_RESOURCE_GROUP]}"
+# get_env_value <KEY> — print the (unquoted) value of KEY from AZD_VALUES, empty if absent.
+# Uses only POSIX-friendly tools so it works on the widely-available Bash 3.2 (e.g. macOS).
+get_env_value() {
+  printf '%s\n' "$AZD_VALUES" \
+    | grep "^$1=" \
+    | head -n 1 \
+    | sed -e "s/^$1=//" -e 's/^"\(.*\)"$/\1/' -e "s/^'\(.*\)'$/\1/"
+}
+
+RG_NAME=$(get_env_value AZURE_RESOURCE_GROUP)
 if [ -z "$RG_NAME" ]; then
   echo "ERROR: AZURE_RESOURCE_GROUP is not set in the azd environment." >&2
   echo "Run 'azd provision' before this script so the resource group is available." >&2
   exit 1
 fi
 
-# set_if_missing <ENV_VAR_NAME> <description> <command that prints the value>
+# set_if_missing <ENV_VAR_NAME> <description> <resolver command...>
+# The resolver command is passed as arguments and run via "$@" — no eval.
 set_if_missing() {
   var_name="$1"
   description="$2"
-  value_cmd="$3"
+  shift 2
 
-  existing="${AZD_VALUES[$var_name]}"
+  existing=$(get_env_value "$var_name")
   if [ -n "$existing" ]; then
     echo "$var_name: already present ($existing)"
     return 0
   fi
 
-  value=$(eval "$value_cmd")
+  value=$("$@")
   if [ -z "$value" ]; then
     echo "ERROR: Could not resolve $var_name ($description) in resource group '$RG_NAME'." >&2
     echo "Confirm 'azd provision' completed and the resource exists." >&2
@@ -90,16 +91,16 @@ echo "Resource group: $RG_NAME"
 set_if_missing \
   "AZURE_CONTAINER_REGISTRY_ENDPOINT" \
   "container registry login server" \
-  "az acr list --resource-group \"$RG_NAME\" --query \"[0].loginServer\" -o tsv"
+  az acr list --resource-group "$RG_NAME" --query "[0].loginServer" -o tsv
 
 set_if_missing \
   "AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID" \
   "managed identity resource id" \
-  "az identity list --resource-group \"$RG_NAME\" --query \"[0].id\" -o tsv"
+  az identity list --resource-group "$RG_NAME" --query "[0].id" -o tsv
 
 set_if_missing \
   "MANAGED_IDENTITY_CLIENT_ID" \
   "managed identity client id" \
-  "az identity list --resource-group \"$RG_NAME\" --query \"[0].clientId\" -o tsv"
+  az identity list --resource-group "$RG_NAME" --query "[0].clientId" -o tsv
 
 echo "Aspire Container Apps environment variables are ready for 'azd deploy'."

--- a/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.sh
+++ b/plugin/skills/azure-validate/references/recipes/azd/scripts/set-aspire-aca-env.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# Set the Container Apps environment variables that Aspire "limited mode" leaves unpopulated.
+#
+# When Aspire runs in "limited mode", `azd provision` creates the Azure resources
+# (Container Registry, Managed Identity, Container Apps Environment) but does NOT populate the
+# env vars that `azd deploy` needs to reference them. This script fills that gap.
+#
+# Run it AFTER `azd provision` but BEFORE `azd deploy`.
+#
+# USAGE:
+#   ./set-aspire-aca-env.sh [-e <azd-env-name>]
+#
+#   -e, --environment   Optional azd environment name (forwarded to `azd env` calls).
+#                       Defaults to the current/default azd environment.
+#
+# The script only sets a variable if it is currently missing, and prints what it did so the
+# result can be understood without re-inspecting `azd env get-values`:
+#   AZURE_CONTAINER_REGISTRY_ENDPOINT              <- az acr list ... [0].loginServer
+#   AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID   <- az identity list ... [0].id
+#   MANAGED_IDENTITY_CLIENT_ID                     <- az identity list ... [0].clientId
+
+set -e
+
+AZD_ENV_NAME=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -e|--environment)
+      AZD_ENV_NAME="$2"
+      shift 2
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $1" >&2
+      echo "USAGE: ./set-aspire-aca-env.sh [-e <azd-env-name>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Build the shared `-e <name>` argument list for azd calls (empty when no env name given).
+AZD_ENV_ARGS=""
+if [ -n "$AZD_ENV_NAME" ]; then
+  AZD_ENV_ARGS="-e $AZD_ENV_NAME"
+fi
+
+# Safely load azd environment values into an associative array (no eval).
+declare -A AZD_VALUES
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  key=${line%%=*}
+  value=${line#*=}
+  case "$value" in
+    \"*\") value=${value#\"}; value=${value%\"} ;;
+    \'*\') value=${value#\'}; value=${value%\'} ;;
+  esac
+  AZD_VALUES["$key"]="$value"
+done < <(azd env get-values $AZD_ENV_ARGS)
+
+RG_NAME="${AZD_VALUES[AZURE_RESOURCE_GROUP]}"
+if [ -z "$RG_NAME" ]; then
+  echo "ERROR: AZURE_RESOURCE_GROUP is not set in the azd environment." >&2
+  echo "Run 'azd provision' before this script so the resource group is available." >&2
+  exit 1
+fi
+
+# set_if_missing <ENV_VAR_NAME> <description> <command that prints the value>
+set_if_missing() {
+  var_name="$1"
+  description="$2"
+  value_cmd="$3"
+
+  existing="${AZD_VALUES[$var_name]}"
+  if [ -n "$existing" ]; then
+    echo "$var_name: already present ($existing)"
+    return 0
+  fi
+
+  value=$(eval "$value_cmd")
+  if [ -z "$value" ]; then
+    echo "ERROR: Could not resolve $var_name ($description) in resource group '$RG_NAME'." >&2
+    echo "Confirm 'azd provision' completed and the resource exists." >&2
+    exit 1
+  fi
+
+  azd env set $AZD_ENV_ARGS "$var_name" "$value"
+  echo "$var_name: set to $value"
+}
+
+echo "Resource group: $RG_NAME"
+
+set_if_missing \
+  "AZURE_CONTAINER_REGISTRY_ENDPOINT" \
+  "container registry login server" \
+  "az acr list --resource-group \"$RG_NAME\" --query \"[0].loginServer\" -o tsv"
+
+set_if_missing \
+  "AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID" \
+  "managed identity resource id" \
+  "az identity list --resource-group \"$RG_NAME\" --query \"[0].id\" -o tsv"
+
+set_if_missing \
+  "MANAGED_IDENTITY_CLIENT_ID" \
+  "managed identity client id" \
+  "az identity list --resource-group \"$RG_NAME\" --query \"[0].clientId\" -o tsv"
+
+echo "Aspire Container Apps environment variables are ready for 'azd deploy'."

--- a/tests/azure-deploy/utils.ts
+++ b/tests/azure-deploy/utils.ts
@@ -13,8 +13,14 @@ const CONTAINER_DEPLOY_ENV_PATTERNS: readonly RegExp[] = [
  * script (set-aspire-aca-env.sh/.ps1). When the agent runs the script, the env-var names
  * appear inside the script file rather than on the command line, so treat invoking it as
  * satisfying the env-var expectations below.
+ *
+ * Anchored to the start of a command (line start or after a shell separator), optionally via
+ * an interpreter (bash/sh/pwsh/powershell) and a relative path, so that non-execution
+ * references such as `cat ./scripts/set-aspire-aca-env.sh` or `chmod +x .../set-aspire-aca-env.sh`
+ * do not count as running it.
  */
-const ASPIRE_ACA_ENV_SCRIPT_PATTERN = /set-aspire-aca-env(\.sh|\.ps1)?/i;
+const ASPIRE_ACA_ENV_SCRIPT_PATTERN =
+  /(?:^|[;&|]\s*)(?:(?:bash|sh|pwsh|powershell)\s+)?[.\w/\\-]*set-aspire-aca-env\.(?:sh|ps1)\b/im;
 
 /**
  * Soft-check that the agent set the expected container deploy env vars.

--- a/tests/azure-deploy/utils.ts
+++ b/tests/azure-deploy/utils.ts
@@ -9,10 +9,23 @@ const CONTAINER_DEPLOY_ENV_PATTERNS: readonly RegExp[] = [
 ];
 
 /**
+ * The azure-validate Aspire recipe replaces the inline `azd env set` commands with a helper
+ * script (set-aspire-aca-env.sh/.ps1). When the agent runs the script, the env-var names
+ * appear inside the script file rather than on the command line, so treat invoking it as
+ * satisfying the env-var expectations below.
+ */
+const ASPIRE_ACA_ENV_SCRIPT_PATTERN = /set-aspire-aca-env(\.sh|\.ps1)?/i;
+
+/**
  * Soft-check that the agent set the expected container deploy env vars.
  * Emits warnings (testComments) instead of failing the test.
  */
 export function softCheckContainerDeployEnvVars(agentMetadata: AgentMetadata): void {
+  // Running the helper script sets all of the expected env vars, so the check is satisfied.
+  if (matchesCommand(agentMetadata, ASPIRE_ACA_ENV_SCRIPT_PATTERN)) {
+    return;
+  }
+
   for (const pattern of CONTAINER_DEPLOY_ENV_PATTERNS) {
     if (!matchesCommand(agentMetadata, pattern)) {
       agentMetadata.testComments.push(


### PR DESCRIPTION
## Description

The `azure-validate` Aspire recipe (`plugin/skills/azure-validate/references/recipes/azd/aspire.md`) hand-wrote a deterministic get-and-set sequence — duplicated across bash and PowerShell — to populate the Container Apps environment variables that Aspire "limited mode" leaves unset after `azd provision` (needed before `azd deploy`). The bash path parsed `azd env get-values` with `grep | cut | tr` and the PowerShell path duplicated the logic with `Select-String`/`.Split()`, which is fragile and drifts.

This PR replaces that inline sequence with a pair of cross-platform helper scripts:

- **`set-aspire-aca-env.sh`** and **`set-aspire-aca-env.ps1`** (behavior parity) under `plugin/skills/azure-validate/references/recipes/azd/scripts/`.
- They load `azd env get-values` safely (no `eval`), derive the resource group, and set `AZURE_CONTAINER_REGISTRY_ENDPOINT`, `AZURE_CONTAINER_REGISTRY_MANAGED_IDENTITY_ID`, and `MANAGED_IDENTITY_CLIENT_ID` **only if missing**, printing a compact summary (or "already present"). They fail with a clear message if the resource group or a resource can't be resolved.
- The PowerShell script prints errors and exits with a non-zero code (no `throw`) and uses a `<# ... #>` comment-based help header.
- `aspire.md` now links to both scripts with sample invocations and lists the env vars they set, instead of embedding the shell logic.

## Relevant tests / evals

- **`tests/azure-deploy/integration.test.ts` (`brownfield-dotnet` Aspire deploy tests)** are the tests that actually exercise the script: they run the full `azd provision → azd deploy` flow for Aspire Container Apps, passing through the post-provision env-var window. `deploys aspire orleans-voting` explicitly soft-asserts the three env vars via `softCheckContainerDeployEnvVars`.
- **`tests/azure-deploy/utils.ts`** — updated `softCheckContainerDeployEnvVars` so that invoking `set-aspire-aca-env.{sh,ps1}` satisfies the check. Previously it scanned the agent's shell commands for the literal env-var names; now that those `azd env set` calls live inside the script, the names no longer appear on the command line, so the check now also accepts the script invocation.
- **`azure-validate` unit/trigger tests** pass (`SKIP_INTEGRATION_TESTS=true npm test -- --testPathPatterns=azure-validate`).
- No `azure-validate` eval currently drives the post-provision step end-to-end (all `evals/azure-validate` stimuli `earlyTerminate` at/before `azd provision`); coverage comes from the azure-deploy Aspire integration tests above.

Validation run locally: bash/PowerShell parser checks, `npm run build`, `scripts` frontmatter + references validators (`references` passes, no orphaned/escaped links), token check (`aspire.md` within budget), and `tests` typecheck + ESLint.

## Related Issues

Fixes #2504
