### PR TITLE
fix(microsoft-foundry): support user-entra-token auth for incoming a2a

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/tool-a2a.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/tool-a2a.md
@@ -18,16 +18,21 @@ azd ai connection create <conn-name> \
 
 `$TARGET_AGENT_A2A_ENDPOINT` is `https://<account>.services.ai.azure.com/api/projects/<project>/agents/<peer>/endpoint/protocols/a2a`.
 
-> 🚦 **Prerequisite: the target Foundry agent must have incoming A2A enabled** and return 200 on `$TARGET_AGENT_A2A_ENDPOINT/agentCard/v1.0`. If that URL 404s, follow [enable-incoming-a2a.md](enable-incoming-a2a.md) on the peer first.
+#### Pick an auth type
 
-Grant the **calling** agent's identity the **Foundry Agent Consumer** role (least privilege) on the peer project.
+| `--auth-type` | Identity passed to the peer | RBAC |
+|---|---|---|
+| `user-entra-token` | End user's Entra token, passed through | Grant the **end user's** identity the **Foundry Agent Consumer** role (least privilege) on the peer project |
+| `agentic-identity` | Calling agent's own identity | Grant the **calling agent's** identity the **Foundry Agent Consumer** role on the peer project |
+
+#### Create the connection
 
 ```bash
 azd ai connection create $CONNECTION_NAME \
   --project-endpoint $PROJECT_ENDPOINT \
   --kind remote-a2a \
   --target $TARGET_AGENT_A2A_ENDPOINT \
-  --auth-type AgenticIdentityToken \
+  --auth-type <user-entra-token | agentic-identity> \
   --audience "https://ai.azure.com" \
   --metadata "ApiType=Azure" \
   --metadata "type=custom_A2A" \

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/tools.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/tools.md
@@ -112,7 +112,7 @@ Call any A2A-compatible agent (Foundry or external) as a tool. The target must a
 
 **Step 1 (Foundry peers only) — Enable incoming A2A on the target agent.** If the peer already returns 200 on `/endpoint/protocols/a2a/agentCard/v1.0`, skip. Otherwise follow [enable-incoming-a2a.md](enable-incoming-a2a.md). For external A2A services, assume the peer owner has already done this — no action here.
 
-**Step 2 — Create the `remote-a2a` connection.** See [tool-a2a.md](tool-a2a.md) for the full connection command, including the Foundry-specific values (`AgenticIdentityToken` auth, audience, agent-card path, RBAC) and non-Foundry variants.
+**Step 2 — Create the `remote-a2a` connection.** See [tool-a2a.md](tool-a2a.md) for the full connection command, including the Foundry-specific values (`user-entra-token` or `agentic-identity` auth, audience, agent-card path, RBAC) and non-Foundry variants.
 
 **Step 3 — Attach to the toolbox.**
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/references/tools.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/references/tools.md
@@ -112,7 +112,7 @@ Call any A2A-compatible agent (Foundry or external) as a tool. The target must a
 
 **Step 1 (Foundry peers only) — Enable incoming A2A on the target agent.** If the peer already returns 200 on `/endpoint/protocols/a2a/agentCard/v1.0`, skip. Otherwise follow [enable-incoming-a2a.md](enable-incoming-a2a.md). For external A2A services, assume the peer owner has already done this — no action here.
 
-**Step 2 — Create the `remote-a2a` connection.** See [tool-a2a.md](tool-a2a.md) for the full connection command, including the Foundry-specific values (`user-entra-token` or `agentic-identity` auth, audience, agent-card path, RBAC) and non-Foundry variants.
+**Step 2 — Create the `remote-a2a` connection.** See [tool-a2a.md](tool-a2a.md) for the full connection command, including the Foundry-specific values (auth type, audience, agent-card path, RBAC) and non-Foundry variants.
 
 **Step 3 — Attach to the toolbox.**
 


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
