### PR TITLE
feat: script-ify Terraform validation preflight sequence (azure-validate)

### DIFF
--- a/plugin/skills/azure-validate/references/recipes/terraform/README.md
+++ b/plugin/skills/azure-validate/references/recipes/terraform/README.md
@@ -7,118 +7,89 @@ Validation steps for Terraform deployments.
 - `./infra/main.tf` exists
 - State backend accessible
 
-## Validation Steps
+## Run the preflight script
 
-- [ ] 1. Terraform Installation
-- [ ] 2. Azure CLI Installation
-- [ ] 3. Authentication
-- [ ] 4. Initialize
-- [ ] 5. Format Check
-- [ ] 6. Validate Syntax
-- [ ] 7. Plan Preview
-- [ ] 8. State Backend
-- [ ] 9. Azure Policy Validation
-- [ ] 10. Template Variable Resolution Check (AZD+Terraform)
+Run the pre-built validation script instead of executing each check by hand. It runs
+the full deterministic preflight sequence in one call and prints a compact
+**PASS / FAIL / SKIP** summary plus the captured error text for any failed step, so you
+can jump straight to remediation without re-parsing raw command output.
 
-## Validation Details
+| Script | Purpose |
+|--------|---------|
+| [`scripts/validate-terraform.sh`](scripts/validate-terraform.sh) | Bash preflight runner |
+| [`scripts/validate-terraform.ps1`](scripts/validate-terraform.ps1) | PowerShell preflight runner |
 
-### 1. Terraform Installation
+The script runs, in order: Terraform installed → Azure CLI installed → authenticated
+(`az account show`) → `terraform init` → `terraform fmt -check` → `terraform validate` →
+`terraform plan` → `terraform state list` → Go-style `{{ .Env.* }}` template-variable scan.
+It runs **every** check even if an earlier one fails, and exits non-zero when any step fails.
 
-Verify Terraform is installed:
-
-```bash
-terraform version
-```
-
-**If not installed:** See https://developer.hashicorp.com/terraform/install
-
-### 2. Azure CLI Installation
-
-Verify Azure CLI is installed:
+**Usage:**
 
 ```bash
-az version
+./scripts/validate-terraform.sh [infra-dir] [subscription-id]   # infra-dir defaults to ./infra
+```
+```powershell
+.\scripts\validate-terraform.ps1 [-InfraDir <path>] [-SubscriptionId <id>]
 ```
 
-**If not installed:**
-```
-mcp_azure_mcp_extension_cli_install(cli-type: "az")
-```
-
-### 3. Authentication
+**Examples:**
 
 ```bash
-az account show
+./scripts/validate-terraform.sh                 # validate ./infra
+./scripts/validate-terraform.sh ./infra 00000000-0000-0000-0000-000000000000
+```
+```powershell
+.\scripts\validate-terraform.ps1 -InfraDir ./infra
 ```
 
-**If not logged in:**
+**Reading the output:** the summary table lists every step with `PASS`, `FAIL`, or `SKIP`
+(a step is skipped when a prerequisite such as Terraform or the infra directory is missing).
+For each `FAIL`, a **FAILURE DETAILS** section prints the captured error text. Use the
+remediation guidance below to fix failed steps, then re-run the script.
+
+## Remediation
+
+The script only **runs and reports** — fixing failures is manual. Guidance per step:
+
+### Terraform / Azure CLI not installed
+
+- Terraform: see https://developer.hashicorp.com/terraform/install
+- Azure CLI: `mcp_azure_mcp_extension_cli_install(cli-type: "az")`
+
+### Not authenticated
+
 ```bash
 az login
 az account set --subscription <subscription-id>
 ```
 
-### 4. Initialize
+### Format check failed
 
-```bash
-cd infra
-terraform init
-```
-
-### 5. Format Check
-
-```bash
-terraform fmt -check -recursive
-```
-
-**Fix if needed:**
 ```bash
 terraform fmt -recursive
 ```
 
-### 6. Validate Syntax
+### Validate / plan / state failures
 
-```bash
-terraform validate
-```
+Read the captured error text in the script output, then consult
+[Error handling](./errors.md).
 
-### 7. Plan Preview
+### Azure Policy Validation
 
-```bash
-terraform plan -out=tfplan
-```
+The script does not cover policy checks. See
+[Policy Validation Guide](../../policy-validation.md) for retrieving and validating Azure
+policies for your subscription.
 
-### 8. State Backend
-
-Verify state is accessible:
-
-```bash
-terraform state list
-```
-
-### 9. Azure Policy Validation
-
-See [Policy Validation Guide](../../policy-validation.md) for instructions on retrieving and validating Azure policies for your subscription.
-
-### 10. Template Variable Resolution Check (AZD+Terraform)
+### Template Variable Resolution (AZD+Terraform)
 
 > ⚠️ **CRITICAL for azd+Terraform projects.** azd substitutes `${VAR}` references in
 > `main.tfvars.json` via envsubst, but does NOT interpolate Go-style template variables
 > (`{{ .Env.* }}`). Unresolved Go-style template strings passed to Terraform cause
 > cascading deployment failures, state conflicts, and timeouts.
 
-**Check for Go-style template variables:**
+When the template-variable scan reports `FAIL`:
 
-```bash
-# Check for Go-style template variables in Terraform files
-grep -rn '{{ *\.Env\.' infra/ --include='*.tf' --include='*.tfvars.json' || echo "OK: No Go-style template variables found"
-
-# Check main.tfvars.json uses correct ${VAR} syntax
-if test -f infra/main.tfvars.json; then
-  grep -n '{{ *\.Env\.' infra/main.tfvars.json && echo "WARNING: Use \${VAR} syntax instead of {{ .Env.* }}" || echo "OK: main.tfvars.json syntax is correct"
-fi
-```
-
-**If Go-style template variables are found:**
 1. **Fix the syntax** in `main.tfvars.json` — replace `{{ .Env.VAR }}` with `${VAR}`:
    ```json
    {
@@ -130,12 +101,12 @@ fi
    ```bash
    azd env set TF_VAR_environment_name "$(azd env get-value AZURE_ENV_NAME)"
    ```
-3. **Verify** that `variables.tf` declares all required variables
-4. **Re-run** `terraform validate` and `terraform plan` to confirm
+3. **Verify** that `variables.tf` declares all required variables.
+4. **Re-run** the script to confirm `terraform validate` / `plan` and the scan now pass.
 
-**If `.tfvars.json` uses wrong syntax:**
-- Replace Go-style `{{ .Env.* }}` with `${VAR}` (azd's envsubst format)
-- Prefer putting static defaults in `variables.tf` `default` values. Using `terraform.tfvars` (HCL) for static defaults is acceptable if your team prefers it; this restriction is specifically about avoiding Go-style template expressions in `.tfvars.json` files.
+> Prefer putting static defaults in `variables.tf` `default` values. Using `terraform.tfvars`
+> (HCL) for static defaults is acceptable if your team prefers it; this restriction is
+> specifically about avoiding Go-style template expressions in `.tfvars.json` files.
 
 ## References
 

--- a/plugin/skills/azure-validate/references/recipes/terraform/README.md
+++ b/plugin/skills/azure-validate/references/recipes/terraform/README.md
@@ -9,10 +9,10 @@ Validation steps for Terraform deployments.
 
 ## Run the preflight script
 
-Run the pre-built validation script instead of executing each check by hand. It runs
-the full deterministic preflight sequence in one call and prints a compact
-**PASS / FAIL / SKIP** summary plus the captured error text for any failed step, so you
-can jump straight to remediation without re-parsing raw command output.
+Run the pre-built validation script instead of executing each check by hand. It runs the
+full deterministic preflight sequence in one call and prints a compact **PASS / FAIL / SKIP**
+summary plus captured error text for any failed step — jump straight to remediation without
+re-parsing raw command output.
 
 | Script | Purpose |
 |--------|---------|
@@ -20,9 +20,11 @@ can jump straight to remediation without re-parsing raw command output.
 | [`scripts/validate-terraform.ps1`](scripts/validate-terraform.ps1) | PowerShell preflight runner |
 
 The script runs, in order: Terraform installed → Azure CLI installed → authenticated
-(`az account show`) → `terraform init` → `terraform fmt -check` → `terraform validate` →
-`terraform plan` → `terraform state list` → Go-style `{{ .Env.* }}` template-variable scan.
-It runs **every** check even if an earlier one fails, and exits non-zero when any step fails.
+(`az account show`) → `terraform init` → `fmt -check` → `validate` → `plan` →
+`state list` → Go-style `{{ .Env.* }}` template-variable scan → `main.tfvars.json`
+JSON-syntax check. A subscription-selection step is added when a subscription id is
+supplied. It runs **every** check even if an earlier one fails, and exits non-zero when
+any step fails.
 
 **Usage:**
 
@@ -43,10 +45,10 @@ It runs **every** check even if an earlier one fails, and exits non-zero when an
 .\scripts\validate-terraform.ps1 -InfraDir ./infra
 ```
 
-**Reading the output:** the summary table lists every step with `PASS`, `FAIL`, or `SKIP`
-(a step is skipped when a prerequisite such as Terraform or the infra directory is missing).
-For each `FAIL`, a **FAILURE DETAILS** section prints the captured error text. Use the
-remediation guidance below to fix failed steps, then re-run the script.
+**Reading the output:** the summary table lists every step as `PASS`, `FAIL`, or `SKIP`
+(skipped when a prerequisite such as Terraform or the infra directory is missing). Each
+`FAIL` is expanded in a **FAILURE DETAILS** section with the captured error text. Fix
+failed steps using the guidance below, then re-run the script.
 
 ## Remediation
 
@@ -57,7 +59,7 @@ The script only **runs and reports** — fixing failures is manual. Guidance per
 - Terraform: see https://developer.hashicorp.com/terraform/install
 - Azure CLI: `mcp_azure_mcp_extension_cli_install(cli-type: "az")`
 
-### Not authenticated
+### Not authenticated / wrong subscription
 
 ```bash
 az login
@@ -70,7 +72,7 @@ az account set --subscription <subscription-id>
 terraform fmt -recursive
 ```
 
-### Validate / plan / state failures
+### Init / validate / plan / state failures
 
 Read the captured error text in the script output, then consult
 [Error handling](./errors.md).
@@ -92,10 +94,7 @@ When the template-variable scan reports `FAIL`:
 
 1. **Fix the syntax** in `main.tfvars.json` — replace `{{ .Env.VAR }}` with `${VAR}`:
    ```json
-   {
-       "environment_name": "${AZURE_ENV_NAME}",
-       "location": "${AZURE_LOCATION}"
-   }
+   { "environment_name": "${AZURE_ENV_NAME}", "location": "${AZURE_LOCATION}" }
    ```
 2. For additional variables, use **`TF_VAR_*` environment variables**:
    ```bash

--- a/plugin/skills/azure-validate/references/recipes/terraform/scripts/validate-terraform.ps1
+++ b/plugin/skills/azure-validate/references/recipes/terraform/scripts/validate-terraform.ps1
@@ -33,8 +33,8 @@ $steps = [System.Collections.Generic.List[object]]::new()
 
 function Add-Result {
     param([string]$Name, [string]$Status, [string]$ErrorText = "")
+    # Results are collected here and rendered once in the summary at the end.
     $steps.Add([pscustomobject]@{ Name = $Name; Status = $Status; Error = $ErrorText })
-    "  [{0,-4}] {1}" -f $Status, $Name | Write-Host
 }
 
 function Test-Command {
@@ -57,13 +57,18 @@ $hasAz = Test-Command "az"
 if ($hasAz) {
     Add-Result "Azure CLI installed" "PASS"
 } else {
-    Add-Result "Azure CLI installed" "FAIL" "az not found on PATH. Install the Azure CLI (mcp_azure_mcp_extension_cli_install cli-type: az)."
+    Add-Result "Azure CLI installed" "FAIL" "az not found on PATH. Install the Azure CLI: mcp_azure_mcp_extension_cli_install(cli-type: `"az`")"
 }
 
 # --- 3. Authentication -------------------------------------------------------
 if ($hasAz) {
     if ($SubscriptionId) {
-        az account set --subscription $SubscriptionId 2>&1 | Out-Null
+        $subOut = az account set --subscription $SubscriptionId 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Add-Result "Select subscription" "PASS"
+        } else {
+            Add-Result "Select subscription" "FAIL" ($subOut | Out-String).Trim()
+        }
     }
     $accountOut = az account show -o none 2>&1
     if ($LASTEXITCODE -eq 0) {
@@ -86,12 +91,18 @@ function Invoke-Tf {
     }
     Push-Location $InfraDir
     try {
-        $out = & terraform @Args 2>&1
+        # Stream output to a temp file so large output (e.g. terraform plan) is
+        # not held in memory; only read it back when the command fails.
+        $tmp = New-TemporaryFile
+        & terraform @Args *> $tmp.FullName
         if ($LASTEXITCODE -eq 0) {
             Add-Result $Name "PASS"
         } else {
-            Add-Result $Name "FAIL" ($out | Out-String).Trim()
+            $content = Get-Content -Raw $tmp.FullName
+            if ($null -eq $content) { $content = "" }
+            Add-Result $Name "FAIL" $content.Trim()
         }
+        Remove-Item $tmp.FullName -ErrorAction SilentlyContinue
     } finally {
         Pop-Location
     }
@@ -125,6 +136,19 @@ if (Test-Path -Path $InfraDir -PathType Container) {
     }
 } else {
     Add-Result "Template-variable scan ({{ .Env.* }})" "SKIP" "infra dir '$InfraDir' not found"
+}
+
+# --- 10. main.tfvars.json JSON syntax ----------------------------------------
+$tfvars = Join-Path $InfraDir "main.tfvars.json"
+if (Test-Path -Path $tfvars -PathType Leaf) {
+    try {
+        Get-Content -Raw $tfvars | ConvertFrom-Json -ErrorAction Stop | Out-Null
+        Add-Result "main.tfvars.json is valid JSON" "PASS"
+    } catch {
+        Add-Result "main.tfvars.json is valid JSON" "FAIL" $_.Exception.Message
+    }
+} else {
+    Add-Result "main.tfvars.json is valid JSON" "SKIP" "$tfvars not found"
 }
 
 # --- summary -----------------------------------------------------------------

--- a/plugin/skills/azure-validate/references/recipes/terraform/scripts/validate-terraform.ps1
+++ b/plugin/skills/azure-validate/references/recipes/terraform/scripts/validate-terraform.ps1
@@ -1,0 +1,156 @@
+<#
+.SYNOPSIS
+    Runs the Terraform pre-deployment validation preflight sequence and prints a
+    compact PASS/FAIL/SKIP summary plus captured error text for any failed step.
+.DESCRIPTION
+    Runs every check even if an earlier one fails, so you get a complete verdict in
+    a single call. It never fixes anything - it only runs and reports, so you can
+    jump straight to remediation for any failed step.
+
+    Steps: terraform present, az present, authenticated, init, fmt -check, validate,
+    plan, state list, Go-style {{ .Env.* }} template-variable scan.
+.PARAMETER InfraDir
+    Path to the Terraform infra directory (default: ./infra).
+.PARAMETER SubscriptionId
+    Optional subscription to select before checks.
+.EXAMPLE
+    .\validate-terraform.ps1
+    # Validate ./infra
+.EXAMPLE
+    .\validate-terraform.ps1 -InfraDir ./infra -SubscriptionId 00000000-0000-0000-0000-000000000000
+    # Validate an explicit directory against a specific subscription
+.NOTES
+    Exit code: 0 when every non-skipped step passes, 1 when any step fails.
+#>
+param(
+    [string]$InfraDir = "./infra",
+    [string]$SubscriptionId
+)
+
+$ErrorActionPreference = "Continue"
+
+$steps = [System.Collections.Generic.List[object]]::new()
+
+function Add-Result {
+    param([string]$Name, [string]$Status, [string]$ErrorText = "")
+    $steps.Add([pscustomobject]@{ Name = $Name; Status = $Status; Error = $ErrorText })
+    "  [{0,-4}] {1}" -f $Status, $Name | Write-Host
+}
+
+function Test-Command {
+    param([string]$Name)
+    return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+Write-Host "Terraform validation preflight - infra dir: $InfraDir"
+Write-Host ""
+
+# --- 1. Terraform installed --------------------------------------------------
+if (Test-Command "terraform") {
+    Add-Result "Terraform installed" "PASS"
+} else {
+    Add-Result "Terraform installed" "FAIL" "terraform not found on PATH. Install: https://developer.hashicorp.com/terraform/install"
+}
+
+# --- 2. Azure CLI installed --------------------------------------------------
+$hasAz = Test-Command "az"
+if ($hasAz) {
+    Add-Result "Azure CLI installed" "PASS"
+} else {
+    Add-Result "Azure CLI installed" "FAIL" "az not found on PATH. Install the Azure CLI (mcp_azure_mcp_extension_cli_install cli-type: az)."
+}
+
+# --- 3. Authentication -------------------------------------------------------
+if ($hasAz) {
+    if ($SubscriptionId) {
+        az account set --subscription $SubscriptionId 2>&1 | Out-Null
+    }
+    $accountOut = az account show -o none 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        Add-Result "Authenticated (az account show)" "PASS"
+    } else {
+        Add-Result "Authenticated (az account show)" "FAIL" ($accountOut | Out-String).Trim()
+    }
+} else {
+    Add-Result "Authenticated (az account show)" "SKIP" "Azure CLI not installed"
+}
+
+# --- infra dir presence gate -------------------------------------------------
+$haveTf = (Test-Command "terraform") -and (Test-Path -Path $InfraDir -PathType Container)
+
+function Invoke-Tf {
+    param([string]$Name, [string[]]$Args)
+    if (-not $haveTf) {
+        Add-Result $Name "SKIP" "terraform unavailable or infra dir '$InfraDir' not found"
+        return
+    }
+    Push-Location $InfraDir
+    try {
+        $out = & terraform @Args 2>&1
+        if ($LASTEXITCODE -eq 0) {
+            Add-Result $Name "PASS"
+        } else {
+            Add-Result $Name "FAIL" ($out | Out-String).Trim()
+        }
+    } finally {
+        Pop-Location
+    }
+}
+
+# --- 4. Initialize -----------------------------------------------------------
+Invoke-Tf "terraform init" @("init", "-input=false")
+
+# --- 5. Format check ---------------------------------------------------------
+Invoke-Tf "terraform fmt -check" @("fmt", "-check", "-recursive")
+
+# --- 6. Validate syntax ------------------------------------------------------
+Invoke-Tf "terraform validate" @("validate")
+
+# --- 7. Plan preview ---------------------------------------------------------
+Invoke-Tf "terraform plan" @("plan", "-input=false", "-out=tfplan")
+
+# --- 8. State backend --------------------------------------------------------
+Invoke-Tf "terraform state list" @("state", "list")
+
+# --- 9. Go-style template-variable scan --------------------------------------
+if (Test-Path -Path $InfraDir -PathType Container) {
+    $hits = Get-ChildItem -Path $InfraDir -Recurse -Include "*.tf", "*.tfvars.json" -ErrorAction SilentlyContinue |
+        Select-String -Pattern '{{ *\.Env\.' |
+        ForEach-Object { "{0}:{1}:{2}" -f $_.Path, $_.LineNumber, $_.Line.Trim() }
+    if ($hits) {
+        $detail = "Found unresolved Go-style template variables - replace {{ .Env.VAR }} with `${VAR} (azd envsubst format):`n" + ($hits -join "`n")
+        Add-Result "Template-variable scan ({{ .Env.* }})" "FAIL" $detail
+    } else {
+        Add-Result "Template-variable scan ({{ .Env.* }})" "PASS"
+    }
+} else {
+    Add-Result "Template-variable scan ({{ .Env.* }})" "SKIP" "infra dir '$InfraDir' not found"
+}
+
+# --- summary -----------------------------------------------------------------
+Write-Host ""
+Write-Host "==================== SUMMARY ===================="
+"{0,-40} {1}" -f "STEP", "RESULT" | Write-Host
+"{0,-40} {1}" -f "----", "------" | Write-Host
+foreach ($s in $steps) {
+    "{0,-40} {1}" -f $s.Name, $s.Status | Write-Host
+}
+Write-Host "================================================="
+
+$failed = @($steps | Where-Object { $_.Status -eq "FAIL" })
+if ($failed.Count -gt 0) {
+    Write-Host ""
+    Write-Host "----- FAILURE DETAILS -----"
+    foreach ($s in $failed) {
+        Write-Host ""
+        Write-Host "### $($s.Name)"
+        Write-Host $s.Error
+    }
+    Write-Host ""
+    Write-Host "RESULT: $($failed.Count) step(s) failed. See remediation guidance in README.md."
+    exit 1
+}
+
+Write-Host ""
+Write-Host "RESULT: All checks passed. Ready for azure-deploy."
+exit 0

--- a/plugin/skills/azure-validate/references/recipes/terraform/scripts/validate-terraform.sh
+++ b/plugin/skills/azure-validate/references/recipes/terraform/scripts/validate-terraform.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# validate-terraform.sh
+# Runs the Terraform pre-deployment validation preflight sequence and prints a
+# compact PASS/FAIL/SKIP summary plus the captured error text for any failed step.
+#
+# The script runs every check even if an earlier one fails, so you get a complete
+# verdict in a single call. It never fixes anything - it only runs and reports, so
+# you can jump straight to remediation for any failed step.
+#
+# Steps: terraform present, az present, authenticated, init, fmt -check, validate,
+#        plan, state list, Go-style {{ .Env.* }} template-variable scan.
+#
+# Usage:
+#   ./validate-terraform.sh [infra-dir] [subscription-id]
+#
+# Arguments:
+#   infra-dir         Path to the Terraform infra directory (default: ./infra).
+#   subscription-id   Optional subscription to select before checks.
+#
+# Examples:
+#   ./validate-terraform.sh                       # Validate ./infra
+#   ./validate-terraform.sh ./infra               # Validate an explicit directory
+#   ./validate-terraform.sh ./infra 00000000-0000-0000-0000-000000000000
+#
+# Exit code: 0 when every non-skipped step passes, 1 when any step fails.
+
+set -uo pipefail
+
+INFRA_DIR="${1:-./infra}"
+SUBSCRIPTION_ID="${2:-}"
+
+# --- result tracking ---------------------------------------------------------
+STEP_NAMES=()
+STEP_STATUS=()   # PASS | FAIL | SKIP
+STEP_ERRORS=()   # captured error text (empty unless FAIL)
+
+record() {
+    # record <name> <status> [error-text]
+    STEP_NAMES+=("$1")
+    STEP_STATUS+=("$2")
+    STEP_ERRORS+=("${3:-}")
+    printf '  [%-4s] %s\n' "$2" "$1"
+}
+
+echo "Terraform validation preflight - infra dir: $INFRA_DIR"
+echo ""
+
+# --- 1. Terraform installed --------------------------------------------------
+if command -v terraform >/dev/null 2>&1; then
+    record "Terraform installed" "PASS"
+else
+    record "Terraform installed" "FAIL" "terraform not found on PATH. Install: https://developer.hashicorp.com/terraform/install"
+fi
+
+# --- 2. Azure CLI installed --------------------------------------------------
+if command -v az >/dev/null 2>&1; then
+    record "Azure CLI installed" "PASS"
+else
+    record "Azure CLI installed" "FAIL" "az not found on PATH. Install the Azure CLI (mcp_azure_mcp_extension_cli_install cli-type: az)."
+fi
+
+# --- 3. Authentication -------------------------------------------------------
+if command -v az >/dev/null 2>&1; then
+    if [ -n "$SUBSCRIPTION_ID" ]; then
+        az account set --subscription "$SUBSCRIPTION_ID" >/dev/null 2>&1 || true
+    fi
+    if ACCOUNT_OUT=$(az account show -o none 2>&1); then
+        record "Authenticated (az account show)" "PASS"
+    else
+        record "Authenticated (az account show)" "FAIL" "$ACCOUNT_OUT"
+    fi
+else
+    record "Authenticated (az account show)" "SKIP" "Azure CLI not installed"
+fi
+
+# --- infra dir presence gate -------------------------------------------------
+HAVE_TF=false
+if command -v terraform >/dev/null 2>&1 && [ -d "$INFRA_DIR" ]; then
+    HAVE_TF=true
+fi
+
+run_tf() {
+    # run_tf <name> <terraform args...>
+    local name="$1"; shift
+    if [ "$HAVE_TF" != true ]; then
+        record "$name" "SKIP" "terraform unavailable or infra dir '$INFRA_DIR' not found"
+        return
+    fi
+    local out
+    if out=$(cd "$INFRA_DIR" && terraform "$@" 2>&1); then
+        record "$name" "PASS"
+    else
+        record "$name" "FAIL" "$out"
+    fi
+}
+
+# --- 4. Initialize -----------------------------------------------------------
+run_tf "terraform init" init -input=false
+
+# --- 5. Format check ---------------------------------------------------------
+run_tf "terraform fmt -check" fmt -check -recursive
+
+# --- 6. Validate syntax ------------------------------------------------------
+run_tf "terraform validate" validate
+
+# --- 7. Plan preview ---------------------------------------------------------
+run_tf "terraform plan" plan -input=false -out=tfplan
+
+# --- 8. State backend --------------------------------------------------------
+run_tf "terraform state list" state list
+
+# --- 9. Go-style template-variable scan --------------------------------------
+if [ -d "$INFRA_DIR" ]; then
+    TEMPLATE_HITS=$(grep -rn '{{ *\.Env\.' "$INFRA_DIR" --include='*.tf' --include='*.tfvars.json' 2>/dev/null || true)
+    if [ -n "$TEMPLATE_HITS" ]; then
+        record "Template-variable scan ({{ .Env.* }})" "FAIL" \
+            "Found unresolved Go-style template variables - replace {{ .Env.VAR }} with \${VAR} (azd envsubst format):
+$TEMPLATE_HITS"
+    else
+        record "Template-variable scan ({{ .Env.* }})" "PASS"
+    fi
+else
+    record "Template-variable scan ({{ .Env.* }})" "SKIP" "infra dir '$INFRA_DIR' not found"
+fi
+
+# --- summary -----------------------------------------------------------------
+echo ""
+echo "==================== SUMMARY ===================="
+printf '%-40s %s\n' "STEP" "RESULT"
+printf '%-40s %s\n' "----" "------"
+FAILED=0
+for i in "${!STEP_NAMES[@]}"; do
+    printf '%-40s %s\n' "${STEP_NAMES[$i]}" "${STEP_STATUS[$i]}"
+    [ "${STEP_STATUS[$i]}" = "FAIL" ] && FAILED=$((FAILED + 1))
+done
+echo "================================================="
+
+if [ "$FAILED" -gt 0 ]; then
+    echo ""
+    echo "----- FAILURE DETAILS -----"
+    for i in "${!STEP_NAMES[@]}"; do
+        if [ "${STEP_STATUS[$i]}" = "FAIL" ]; then
+            echo ""
+            echo "### ${STEP_NAMES[$i]}"
+            echo "${STEP_ERRORS[$i]}"
+        fi
+    done
+    echo ""
+    echo "RESULT: $FAILED step(s) failed. See remediation guidance in README.md."
+    exit 1
+fi
+
+echo ""
+echo "RESULT: All checks passed. Ready for azure-deploy."
+exit 0

--- a/plugin/skills/azure-validate/references/recipes/terraform/scripts/validate-terraform.sh
+++ b/plugin/skills/azure-validate/references/recipes/terraform/scripts/validate-terraform.sh
@@ -36,10 +36,10 @@ STEP_ERRORS=()   # captured error text (empty unless FAIL)
 
 record() {
     # record <name> <status> [error-text]
+    # Results are collected here and rendered once in the summary at the end.
     STEP_NAMES+=("$1")
     STEP_STATUS+=("$2")
     STEP_ERRORS+=("${3:-}")
-    printf '  [%-4s] %s\n' "$2" "$1"
 }
 
 echo "Terraform validation preflight - infra dir: $INFRA_DIR"
@@ -56,13 +56,17 @@ fi
 if command -v az >/dev/null 2>&1; then
     record "Azure CLI installed" "PASS"
 else
-    record "Azure CLI installed" "FAIL" "az not found on PATH. Install the Azure CLI (mcp_azure_mcp_extension_cli_install cli-type: az)."
+    record "Azure CLI installed" "FAIL" "az not found on PATH. Install the Azure CLI: mcp_azure_mcp_extension_cli_install(cli-type: \"az\")"
 fi
 
 # --- 3. Authentication -------------------------------------------------------
 if command -v az >/dev/null 2>&1; then
     if [ -n "$SUBSCRIPTION_ID" ]; then
-        az account set --subscription "$SUBSCRIPTION_ID" >/dev/null 2>&1 || true
+        if SUB_OUT=$(az account set --subscription "$SUBSCRIPTION_ID" 2>&1); then
+            record "Select subscription" "PASS"
+        else
+            record "Select subscription" "FAIL" "$SUB_OUT"
+        fi
     fi
     if ACCOUNT_OUT=$(az account show -o none 2>&1); then
         record "Authenticated (az account show)" "PASS"
@@ -86,12 +90,16 @@ run_tf() {
         record "$name" "SKIP" "terraform unavailable or infra dir '$INFRA_DIR' not found"
         return
     fi
-    local out
-    if out=$(cd "$INFRA_DIR" && terraform "$@" 2>&1); then
+    # Stream output to a temp file so large output (e.g. terraform plan) is not
+    # held in memory; only read it back when the command fails.
+    local tmp
+    tmp=$(mktemp)
+    if (cd "$INFRA_DIR" && terraform "$@") >"$tmp" 2>&1; then
         record "$name" "PASS"
     else
-        record "$name" "FAIL" "$out"
+        record "$name" "FAIL" "$(cat "$tmp")"
     fi
+    rm -f "$tmp"
 }
 
 # --- 4. Initialize -----------------------------------------------------------
@@ -121,6 +129,28 @@ $TEMPLATE_HITS"
     fi
 else
     record "Template-variable scan ({{ .Env.* }})" "SKIP" "infra dir '$INFRA_DIR' not found"
+fi
+
+# --- 10. main.tfvars.json JSON syntax ----------------------------------------
+TFVARS="$INFRA_DIR/main.tfvars.json"
+if [ -f "$TFVARS" ]; then
+    if command -v python3 >/dev/null 2>&1; then
+        if JSON_ERR=$(python3 -c "import json,sys; json.load(open(sys.argv[1]))" "$TFVARS" 2>&1); then
+            record "main.tfvars.json is valid JSON" "PASS"
+        else
+            record "main.tfvars.json is valid JSON" "FAIL" "$JSON_ERR"
+        fi
+    elif command -v jq >/dev/null 2>&1; then
+        if JSON_ERR=$(jq empty "$TFVARS" 2>&1); then
+            record "main.tfvars.json is valid JSON" "PASS"
+        else
+            record "main.tfvars.json is valid JSON" "FAIL" "$JSON_ERR"
+        fi
+    else
+        record "main.tfvars.json is valid JSON" "SKIP" "no JSON parser (python3/jq) available"
+    fi
+else
+    record "main.tfvars.json is valid JSON" "SKIP" "$TFVARS not found"
 fi
 
 # --- summary -----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #2501.

Replaces the manual, per-command **Terraform validation preflight sequence** in the `azure-validate` skill with a pair of run-and-report scripts, per the issue's recommendation.

### Changes

- **New scripts** at `plugin/skills/azure-validate/references/recipes/terraform/scripts/`:
  - `validate-terraform.sh` (bash) and `validate-terraform.ps1` (PowerShell), with feature parity.
  - **Input:** infra directory path (default `./infra`), optional subscription id.
  - Runs the full deterministic sequence in one call — terraform installed → az installed → authenticated → `init` → `fmt -check` → `validate` → `plan` → `state list` → Go-style `{{ .Env.* }}` template-variable scan.
  - Runs **every** step even if an earlier one fails, captures per-step **PASS/FAIL/SKIP** plus the error text for failed steps, prints a compact summary + FAILURE DETAILS section, and exits non-zero on any failure.
- **`recipes/terraform/README.md`** now references the scripts via markdown links with Usage/Examples and an output-reading guide. Remediation prose (fmt fix, `{{ .Env.* }}` → `${VAR}`, `TF_VAR_*`, `variables.tf`) and the Azure Policy Validation reference stay in prose — only the *run-and-report* is scripted.

### Why

- **Fewer tokens / round-trips** — one script call replaces 8+ command generations and large-output parsing.
- **Deterministic & reliable** — the logic is written once instead of re-derived each run.
- **Compact, actionable output** — the agent jumps straight to remediation for any failed step.

### Validation

- Both scripts parse & run under Windows PowerShell 5.1 and bash (smoke-tested).
- `npm run build` stamps versions (azure-validate → 1.1.2).
- Frontmatter passes against built output; `npm run references` passes (scripts linked, not orphaned, no escaped links); `npm run tokens check` passes.
- `azure-validate` trigger tests pass. Integration tests run in CI.