### PR TITLE
chore: update vally stimulus validation script to cover all yaml files

### DIFF
--- a/.github/skills/vally-eval/SKILL.md
+++ b/.github/skills/vally-eval/SKILL.md
@@ -19,7 +19,7 @@ Refer to the official documentation on the schema of the spec and the schema of 
 
 Vally eval suites for azure-skills plugin have the following file layout. The shared eval spec is located at `<repo-root>/.vally.yaml`. The eval suites are categorized by skills. The eval suites for each skill are located at `<repo-root>/evals/<skill-name>/*.yaml`, e.g. `<repo-root>/evals/azure-ai/eval.yaml`. 
 
-Use meaningful file names to categorize tests. If a skill needs fixture files for its eval suites, it should organize such fixture files in a `fixture` directory under its directory, e.g. `<repo-root>/evals/azure-ai/fixture/`. Our test runner and stimulus validation script will load all `*.yaml` files except for those under a `fixture/` directory. Make sure to put all fixture files under the `fixture/` directory.
+Use meaningful file names to categorize tests. If a skill needs fixture files for its eval suites, it should organize such fixture files in a `fixture` directory under its directory, e.g. `<repo-root>/evals/azure-ai/fixture/`. The [vally test runner](/tests/run-vally-test.ts) and [stimulus validation script](/scripts/src/vally/validate-stimulus.ts) will load all `*.yaml` files except for those under a `fixture/` directory. Make sure to put all fixture files under the `fixture/` directory.
 
 ## Migrate integration tests
 

--- a/.github/skills/vally-eval/SKILL.md
+++ b/.github/skills/vally-eval/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: vally-eval
-description: "Author, validate, and run Vally eval.yaml evaluation suites for agent skills. TRIGGERS: create eval, write eval, add eval, run eval, validate eval, vally eval, eval.yaml, add stimulus, map test to eval, migrate test to eval, eval graders, eval scoring, add eval to CI."
+description: "Author, validate, and run Vally evaluation suites for agent skills. TRIGGERS: create eval, write eval, add eval, run eval, validate eval, vally eval, eval.yaml, add stimulus, map test to eval, migrate test to eval, eval graders, eval scoring, add eval to CI."
 license: MIT
 metadata:
   author: Microsoft

--- a/.github/skills/vally-eval/SKILL.md
+++ b/.github/skills/vally-eval/SKILL.md
@@ -17,9 +17,9 @@ Vally eval suites are written as yaml documents. All eval suites share eval spec
 
 Refer to the official documentation on the schema of the spec and the schema of the eval suites [writing-eval-specs](https://microsoft.github.io/vally/guides/writing-eval-specs/).
 
-Vally eval suites for azure-skills plugin have the following file layout. The shared eval spec is located at `<repo-root>/.vally.yaml`. The eval suites are categorized by skills. The eval suites for each skill are located at `<repo-root>/evals/<skill-name>/eval.yaml`, e.g. `<repo-root>/evals/azure-ai/eval.yaml`. If a skill needs fixture files for its eval suites, it should organize such fixture files in a `fixture` directory under its directory, e.g. `<repo-root>/evals/azure-ai/fixture/`.
+Vally eval suites for azure-skills plugin have the following file layout. The shared eval spec is located at `<repo-root>/.vally.yaml`. The eval suites are categorized by skills. The eval suites for each skill are located at `<repo-root>/evals/<skill-name>/*.yaml`, e.g. `<repo-root>/evals/azure-ai/eval.yaml`. 
 
-The eval suites can be organized into separate files under a skill's eval directory. For example, you can have `<repo-root>/evals/<skill-name>/evalA.yaml` and `<repo-root>/evals/<skill-name>/evalB.yaml`. When running the vally suites using `npm run test:vally` command, the test script will run suites from all these .yaml files.
+Use meaningful file names to categorize tests. If a skill needs fixture files for its eval suites, it should organize such fixture files in a `fixture` directory under its directory, e.g. `<repo-root>/evals/azure-ai/fixture/`. Our test runner and stimulus validation script will load all `*.yaml` files except for those under a `fixture/` directory. Make sure to put all fixture files under the `fixture/` directory.
 
 ## Migrate integration tests
 

--- a/scripts/src/vally/validate-stimulus.ts
+++ b/scripts/src/vally/validate-stimulus.ts
@@ -394,7 +394,7 @@ function findEvalYamlFiles(dirPath: string): string[] {
       continue;
     }
 
-    if (entry.isFile() && entry.name === "eval.yaml") {
+    if (entry.isFile() && !entryPath.includes("fixture/") && entry.name.endsWith("yaml")) {
       files.push(entryPath);
     }
   }

--- a/scripts/src/vally/validate-stimulus.ts
+++ b/scripts/src/vally/validate-stimulus.ts
@@ -389,12 +389,12 @@ function findEvalYamlFiles(dirPath: string): string[] {
   for (const entry of entries) {
     const entryPath = join(dirPath, entry.name);
 
-    if (entry.isDirectory()) {
+    if (entry.isDirectory() && entry.name !== "fixture") {
       files.push(...findEvalYamlFiles(entryPath));
       continue;
     }
 
-    if (entry.isFile() && !entryPath.includes("fixture/") && entry.name.endsWith("yaml")) {
+    if (entry.isFile() && entry.name.endsWith(".yaml")) {
       files.push(entryPath);
     }
   }


### PR DESCRIPTION
## Description

Updates the vally stimulus validation script to cover all YAML files (not just a subset), and updates the `vally-eval` SKILL.md documentation to reflect this behavior.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->