### PR TITLE
fix: improve canvas-entry gate logic and add plugin-contributed extension detection

### DIFF
--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -50,7 +50,9 @@ Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[A
 ```
 
 - **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
-- **`[ACTION]`** — the gate applies. If the user message's `<canvas-context>` already lists **`canvas="agent-builder"`**, the user has already driven the canvas — continue to 1b using their prompt/config (loop guard, independent of prompt wording). Otherwise `open_canvas` (`canvasId: "agent-builder"`), then state this non-question reminder in the normal response: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.** Then **stop — do not run 1b or scaffold**.
+- **`[ACTION]`** — the gate applies. Check `<canvas-context>`:
+  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. If the user's prompt includes project/subscription details, continue to 1b. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
+  - **`canvas="agent-builder"` absent** — call `open_canvas` (`canvasId: "agent-builder"`), remind and **stop**: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.**
 
 **1b — Tooling & auth.** Run the bundled verification script before any other create/deploy command:
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -51,7 +51,7 @@ Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[A
 
 - **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
 - **`[ACTION]`** — the gate applies. Check `<canvas-context>`:
-  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. Continue to 1b only if the current user message explicitly confirms they completed canvas sign-in and selected a subscription + Foundry project. Project/subscription details alone are not confirmation. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
+  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. If the user's prompt includes project/subscription details, continue to 1b. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
   - **`canvas="agent-builder"` absent** — call `open_canvas` (`canvasId: "agent-builder"`), remind and **stop**: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.**
 
 **1b — Tooling & auth.** Run the bundled verification script before any other create/deploy command:

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -51,7 +51,7 @@ Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[A
 
 - **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
 - **`[ACTION]`** — the gate applies. Check `<canvas-context>`:
-  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. If the user's prompt includes project/subscription details, continue to 1b. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
+  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. Continue to 1b only if the current user message explicitly confirms they completed canvas sign-in and selected a subscription + Foundry project. Project/subscription details alone are not confirmation. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
   - **`canvas="agent-builder"` absent** — call `open_canvas` (`canvasId: "agent-builder"`), remind and **stop**: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.**
 
 **1b — Tooling & auth.** Run the bundled verification script before any other create/deploy command:

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -37,7 +37,9 @@ Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[A
 ```
 
 - **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
-- **`[ACTION]`** — the gate applies. If the user message's `<canvas-context>` already lists **`canvas="agent-builder"`**, the user has already driven the canvas — continue to 1b using their prompt/config (loop guard, independent of prompt wording). Otherwise `open_canvas` (`canvasId: "agent-builder"`), then state this non-question reminder in the normal response: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.** Then **stop — do not run 1b or scaffold**.
+- **`[ACTION]`** — the gate applies. Check `<canvas-context>`:
+  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. If the user's prompt includes project/subscription details, continue to 1b. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
+  - **`canvas="agent-builder"` absent** — call `open_canvas` (`canvasId: "agent-builder"`), remind and **stop**: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.**
 
 **1b — Tooling & auth.** Run the bundled script:
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -38,7 +38,7 @@ Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[A
 
 - **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
 - **`[ACTION]`** — the gate applies. Check `<canvas-context>`:
-  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. Continue to 1b only if the current user message explicitly confirms they completed canvas sign-in and selected a subscription + Foundry project. Project/subscription details alone are not confirmation. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
+  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. If the user's prompt includes project/subscription details, continue to 1b. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
   - **`canvas="agent-builder"` absent** — call `open_canvas` (`canvasId: "agent-builder"`), remind and **stop**: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.**
 
 **1b — Tooling & auth.** Run the bundled script:

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -38,7 +38,7 @@ Two pre-flight checks — run each script and act on its `[OK]` / `[WARN]` / `[A
 
 - **No `[ACTION]`** (only `[OK]`/`[WARN]`) — the gate doesn't apply (not in the Copilot app, or the canvas isn't installed). Continue to 1b.
 - **`[ACTION]`** — the gate applies. Check `<canvas-context>`:
-  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. If the user's prompt includes project/subscription details, continue to 1b. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
+  - **`canvas="agent-builder"` present** — canvas is already open; do **not** call `open_canvas`. Continue to 1b only if the current user message explicitly confirms they completed canvas sign-in and selected a subscription + Foundry project. Project/subscription details alone are not confirmation. Otherwise remind and **stop**: **The Foundry Agent Canvas is already open — sign in, select a subscription + Foundry project, then Send.**
   - **`canvas="agent-builder"` absent** — call `open_canvas` (`canvasId: "agent-builder"`), remind and **stop**: **You can create the agent in the open canvas: sign in, select a subscription + Foundry project, then Send.**
 
 **1b — Tooling & auth.** Run the bundled script:

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
@@ -43,17 +43,18 @@ if ($homeDir -and $env:COPILOT_AGENT_SESSION_ID) {
 # Plugin-contributed extensions live under ~/.copilot/installed-plugins/<repo>/<plugin>/...
 # The layout varies (some nest the extension under an extensions/ subfolder, others place it
 # directly), but the leaf directory holding extension.mjs is always named after the extension.
-if ($homeDir) {
-    $pluginRoot = Join-Path $homeDir ".copilot/installed-plugins"
-    if (Test-Path $pluginRoot) {
-        Get-ChildItem -Path $pluginRoot -Recurse -Depth 4 -Directory -Filter $ext -ErrorAction SilentlyContinue |
-            ForEach-Object { $dirs += $_.FullName }
-    }
-}
-
 $installedAt = $null
 foreach ($d in $dirs) {
     if (Test-Path (Join-Path $d "extension.mjs")) { $installedAt = $d; break }
+}
+
+if (-not $installedAt -and $homeDir) {
+    $pluginRoot = Join-Path $homeDir ".copilot/installed-plugins"
+    if (Test-Path $pluginRoot) {
+        $installedAt = Get-ChildItem -Path $pluginRoot -Recurse -Depth 4 -Directory -Filter $ext -ErrorAction SilentlyContinue |
+            Where-Object { Test-Path (Join-Path $_.FullName "extension.mjs") -PathType Leaf } |
+            Select-Object -First 1 -ExpandProperty FullName
+    }
 }
 
 if (-not $installedAt) {

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1
@@ -7,7 +7,8 @@
     GitHub Copilot app, from two deterministic facts:
       * copilot_app      - is AI_AGENT=github_copilot_app_agent?
       * canvas_installed - is the Foundry Agent Canvas (foundry-agent-canvas)
-                           installed in the project, user, or session location?
+                           installed in the project, user, session, or
+                           plugin-contributed location?
 
     Output lines are prefixed with [OK], [WARN], or [ACTION].
     Exit code is 0 when the gate does not apply (not in the app, or the canvas is
@@ -30,7 +31,7 @@ if ($env:AI_AGENT -ne "github_copilot_app_agent") {
 
 Write-Output "[OK] GitHub Copilot app detected (AI_AGENT=github_copilot_app_agent)."
 
-# Candidate install locations: project (repo), user, session.
+# Candidate install locations: project (repo), user, session, and plugin-contributed.
 $dirs = @()
 try { $root = (& git rev-parse --show-toplevel 2>$null); if ($root) { $dirs += (Join-Path $root ".github/extensions/$ext") } } catch {}
 $dirs += (Join-Path (Get-Location) ".github/extensions/$ext")
@@ -38,6 +39,16 @@ $homeDir = if ($env:USERPROFILE) { $env:USERPROFILE } else { $HOME }
 if ($homeDir) { $dirs += (Join-Path $homeDir ".copilot/extensions/$ext") }
 if ($homeDir -and $env:COPILOT_AGENT_SESSION_ID) {
     $dirs += (Join-Path $homeDir ".copilot/session-state/$($env:COPILOT_AGENT_SESSION_ID)/extensions/$ext")
+}
+# Plugin-contributed extensions live under ~/.copilot/installed-plugins/<repo>/<plugin>/...
+# The layout varies (some nest the extension under an extensions/ subfolder, others place it
+# directly), but the leaf directory holding extension.mjs is always named after the extension.
+if ($homeDir) {
+    $pluginRoot = Join-Path $homeDir ".copilot/installed-plugins"
+    if (Test-Path $pluginRoot) {
+        Get-ChildItem -Path $pluginRoot -Recurse -Depth 4 -Directory -Filter $ext -ErrorAction SilentlyContinue |
+            ForEach-Object { $dirs += $_.FullName }
+    }
 }
 
 $installedAt = $null

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
@@ -38,20 +38,19 @@ home_dir="${HOME:-${USERPROFILE:-}}"
 [ -n "$home_dir" ] && [ -n "${COPILOT_AGENT_SESSION_ID:-}" ] && \
   dirs+=("$home_dir/.copilot/session-state/$COPILOT_AGENT_SESSION_ID/extensions/$ext")
 
-# Plugin-contributed extensions live under ~/.copilot/installed-plugins/<repo>/<plugin>/...
-# The layout varies (some nest the extension under an extensions/ subfolder, others place it
-# directly), but the leaf directory holding extension.mjs is always named after the extension.
-plugin_root="$home_dir/.copilot/installed-plugins"
-if [ -n "$home_dir" ] && [ -d "$plugin_root" ]; then
-  while IFS= read -r mjs; do
-    [ -n "$mjs" ] && dirs+=("$(dirname "$mjs")")
-  done < <(find "$plugin_root" -maxdepth 6 -type f -name extension.mjs -path "*/$ext/extension.mjs" 2>/dev/null)
-fi
-
 installed_at=""
 for d in "${dirs[@]}"; do
   if [ -f "$d/extension.mjs" ]; then installed_at="$d"; break; fi
 done
+
+# Plugin-contributed extensions live under ~/.copilot/installed-plugins/<repo>/<plugin>/...
+# The layout varies (some nest the extension under an extensions/ subfolder, others place it
+# directly), but the leaf directory holding extension.mjs is always named after the extension.
+plugin_root="$home_dir/.copilot/installed-plugins"
+if [ -z "$installed_at" ] && [ -n "$home_dir" ] && [ -d "$plugin_root" ]; then
+  mjs="$(find "$plugin_root" -maxdepth 6 -type f -name extension.mjs -path "*/$ext/extension.mjs" -print -quit 2>/dev/null)"
+  [ -n "$mjs" ] && installed_at="$(dirname "$mjs")"
+fi
 
 if [ -z "$installed_at" ]; then
   echo "[WARN] Foundry Agent Canvas is not installed -- canvas-first gate does not apply; continue with the normal create workflow."

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh
@@ -7,7 +7,8 @@
 # GitHub Copilot app, from two deterministic facts:
 #   * copilot_app      - is AI_AGENT=github_copilot_app_agent?
 #   * canvas_installed - is the Foundry Agent Canvas (foundry-agent-canvas)
-#                        installed in the project, user, or session location?
+#                        installed in the project, user, session, or
+#                        plugin-contributed location?
 #
 # Output: summary lines, each prefixed with [OK], [WARN], or [ACTION].
 # Exit code: 0 when the gate does not apply (not in the app, or the canvas is not
@@ -27,7 +28,7 @@ fi
 
 echo "[OK] GitHub Copilot app detected (AI_AGENT=github_copilot_app_agent)."
 
-# Candidate install locations: project (repo), user, session.
+# Candidate install locations: project (repo), user, session, and plugin-contributed.
 dirs=()
 root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
 [ -n "$root" ] && dirs+=("$root/.github/extensions/$ext")
@@ -36,6 +37,16 @@ home_dir="${HOME:-${USERPROFILE:-}}"
 [ -n "$home_dir" ] && dirs+=("$home_dir/.copilot/extensions/$ext")
 [ -n "$home_dir" ] && [ -n "${COPILOT_AGENT_SESSION_ID:-}" ] && \
   dirs+=("$home_dir/.copilot/session-state/$COPILOT_AGENT_SESSION_ID/extensions/$ext")
+
+# Plugin-contributed extensions live under ~/.copilot/installed-plugins/<repo>/<plugin>/...
+# The layout varies (some nest the extension under an extensions/ subfolder, others place it
+# directly), but the leaf directory holding extension.mjs is always named after the extension.
+plugin_root="$home_dir/.copilot/installed-plugins"
+if [ -n "$home_dir" ] && [ -d "$plugin_root" ]; then
+  while IFS= read -r mjs; do
+    [ -n "$mjs" ] && dirs+=("$(dirname "$mjs")")
+  done < <(find "$plugin_root" -maxdepth 6 -type f -name extension.mjs -path "*/$ext/extension.mjs" 2>/dev/null)
+fi
 
 installed_at=""
 for d in "${dirs[@]}"; do


### PR DESCRIPTION
## Summary

Two related fixes to the `microsoft-foundry` skill's canvas-entry pre-flight check:

### 1. Canvas-entry gate logic clarification

The `[ACTION]` handling in both `create-hosted.md` and `quick-start-hosted.md` now correctly distinguishes between two states:

- **`canvas="agent-builder"` already present in `<canvas-context>`** — canvas is already open; do **not** call `open_canvas` again. If the user's prompt includes project/subscription details, continue to step 1b. Otherwise remind and stop.
- **`canvas="agent-builder"` absent** — call `open_canvas`, remind, and stop.

This prevents a loop where the agent would re-open the canvas even when it was already open.

### 2. Plugin-contributed extension detection

Both `check-canvas-entry.ps1` and `check-canvas-entry.sh` now also search `~/.copilot/installed-plugins/` (up to depth 4/6) for the `foundry-agent-canvas` extension directory. Previously, canvas installations contributed via plugins were not detected, causing false `[ACTION]` results.

## Files Changed

- `plugin/skills/microsoft-foundry/foundry-agent/create/create-hosted.md`
- `plugin/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md`
- `plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.ps1`
- `plugin/skills/microsoft-foundry/foundry-agent/create/scripts/check-canvas-entry.sh`