### PR TITLE
chore: update CODEOWNERS for azure skill teams

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,10 +2,10 @@
 # Each line is a file pattern followed by one or more code owners.
 
 # Default owners for everything in the repo
-* @microsoft/ghcp4a
+* @microsoft/github-copilot-for-azure-writers
 
 # Workflow files — explicit protection (changes require team review)
-/.github/workflows/ @microsoft/ghcp4a
+/.github/workflows/ @microsoft/github-copilot-for-azure-writers
 
 # Plugin skills owners
 /plugin/skills/ @tmeschter @RickWinter
@@ -17,22 +17,22 @@
 /plugin/skills/azure-compliance/ @saikoumudi @RickWinter
 /plugin/skills/azure-compute/ @alex-thompson @rakal-dyh @joybb @rmmue21 @RickWinter
 /plugin/skills/azure-cost/ @saikoumudi @RickWinter
-/plugin/skills/azure-deploy/ @tmeschter @kvenkatrajan @paulyuk @RickWinter
+/plugin/skills/azure-deploy/ @microsoft/github-copilot-for-azure-writers @paulyuk
 /plugin/skills/azure-diagnostics/ @tmeschter @saikoumudi @RickWinter
 /plugin/skills/azure-enterprise-infra-planner/ @Jbrocket @micha31r @arunrab @RickWinter
 /plugin/skills/azure-kubernetes/ @saikoumudi @chandraneel @gambtho @RickWinter
 /plugin/skills/azure-kusto/ @saikoumudi @RickWinter
 /plugin/skills/azure-messaging/ @kashifkhan @RickWinter
-/plugin/skills/azure-prepare/ @tmeschter @kvenkatrajan @RickWinter
+/plugin/skills/azure-prepare/ @microsoft/github-copilot-for-azure-writers
 /plugin/skills/azure-quotas/ @rakal-dyh @RickWinter
 /plugin/skills/azure-reliability/ @MadhuraBharadwaj-MSFT @saikoumudi @RickWinter
 /plugin/skills/azure-resource-lookup/ @JasonYeMSFT @RickWinter
 /plugin/skills/azure-resource-visualizer/ @tmeschter @RickWinter
 /plugin/skills/azure-storage/ @JasonYeMSFT @RickWinter
 /plugin/skills/azure-upgrade/ @MadhuraBharadwaj-MSFT @saikoumudi @RickWinter
-/plugin/skills/azure-validate/ @tmeschter @kvenkatrajan @RickWinter
+/plugin/skills/azure-validate/ @microsoft/github-copilot-for-azure-writers
 /plugin/skills/entra-agent-id/ @ArLucaID @RickWinter
-/plugin/skills/entra-app-registration/ @JasonYeMSFT @kvenkatrajan @RickWinter
+/plugin/skills/entra-app-registration/ @JasonYeMSFT @RickWinter
 /plugin/skills/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter
 /plugin/skills/microsoft-foundry/foundry-agent/cicd/ @anchenyi @XiaofuHuang @swatDong @RickWinter
 /plugin/skills/microsoft-foundry/foundry-agent/create/ @anchenyi @XiaofuHuang @swatDong @RickWinter


### PR DESCRIPTION
Updates .github/CODEOWNERS:

- Replace `@microsoft/ghcp4a` with `@microsoft/github-copilot-for-azure-writers` (the team with write access) for default and workflow owners.
- Set azure-prepare, azure-validate, and azure-deploy owners to `@microsoft/github-copilot-for-azure-writers` as these skills are largely controlled by this team.
- Remove `@kvenkatrajan` (no write access) from entra-app-registration.