### PR TITLE
feat: show file count per skill on dashboard skill page

### DIFF
--- a/dashboard/src/skills/App.tsx
+++ b/dashboard/src/skills/App.tsx
@@ -25,6 +25,7 @@ interface Skill {
     name: string;
     description: string;
     descriptionLength: number;
+    fileCount: number;
 }
 
 /** Minimal shape of the health data returned by /api/static. */
@@ -50,7 +51,13 @@ function skillsFromHealthData(data: HealthData): Skill[] {
         // Only plugin skills; the frontmatter check also covers .github/skills.
         if (!isPluginSkillPath(path)) continue;
         const description = String(item.metadata?.description ?? "");
-        skills.push({ name: item.name, description, descriptionLength: description.length });
+        const fileCount = Number(item.metadata?.fileCount ?? 0);
+        skills.push({
+            name: item.name,
+            description,
+            descriptionLength: description.length,
+            fileCount: Number.isFinite(fileCount) ? fileCount : 0,
+        });
     }
     return skills.sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -253,6 +260,9 @@ export default function App() {
                             </p>
                             <p className="skills-desc-length">
                                 Description length: {selectedSkill.descriptionLength} characters
+                            </p>
+                            <p className="skills-file-count">
+                                Files: {selectedSkill.fileCount}
                             </p>
                         </header>
 

--- a/dashboard/src/skills/skills.css
+++ b/dashboard/src/skills/skills.css
@@ -83,6 +83,12 @@
     font-size: 0.9rem;
 }
 
+.skills-file-count {
+    margin: 0;
+    color: var(--color-text-muted);
+    font-size: 0.9rem;
+}
+
 .skills-tests-heading {
     margin: 1.5rem 0 0.75rem;
     font-size: 1.15rem;

--- a/scripts/src/dashboard/__tests__/collectors/frontmatter.test.ts
+++ b/scripts/src/dashboard/__tests__/collectors/frontmatter.test.ts
@@ -316,4 +316,81 @@ describe("frontmatterCollector.collect", () => {
     expect(report.status).toBe("skip");
     expect(report.summary.total).toBe(0);
   });
+
+  it("populates metadata.fileCount from the built skill directory (recursive, incl. nested)", async () => {
+    const { mkdtempSync, mkdirSync, writeFileSync } = await import("node:fs");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+
+    const root = mkdtempSync(join(tmpdir(), "fm-filecount-"));
+    // Built skill: output/skills/skill-a with 2 own files + a nested sub-skill
+    // that contributes 2 more, so the recursive count is 4.
+    const skillDir = join(root, "output", "skills", "skill-a");
+    const nestedDir = join(skillDir, "nested");
+    mkdirSync(nestedDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), "a");
+    writeFileSync(join(skillDir, "version.json"), "b");
+    writeFileSync(join(nestedDir, "SKILL.md"), "c");
+    writeFileSync(join(nestedDir, "notes.md"), "d");
+
+    const jsonOutput = makeFrontmatterJson({
+      skills: [
+        {
+          name: "skill-a",
+          path: "output/skills/skill-a/SKILL.md",
+          status: "pass",
+          errors: [],
+          warnings: [],
+          checks: {},
+        },
+      ],
+      summary: { total: 1, passed: 1, failed: 0, warnings: 0 },
+    });
+
+    vi.doMock("node:child_process", () => ({
+      execSync: () => jsonOutput,
+    }));
+
+    const { frontmatterCollector } = await import(
+      "../../collectors/frontmatter.js"
+    );
+
+    const report = await frontmatterCollector.collect({
+      cwd: root,
+      timeout: 5000,
+    });
+
+    expect(report.items[0].metadata?.fileCount).toBe(4);
+  });
+
+  it("sets fileCount to 0 when the skill directory is missing", async () => {
+    const jsonOutput = makeFrontmatterJson({
+      skills: [
+        {
+          name: "gone",
+          path: "output/skills/gone/SKILL.md",
+          status: "pass",
+          errors: [],
+          warnings: [],
+          checks: {},
+        },
+      ],
+      summary: { total: 1, passed: 1, failed: 0, warnings: 0 },
+    });
+
+    vi.doMock("node:child_process", () => ({
+      execSync: () => jsonOutput,
+    }));
+
+    const { frontmatterCollector } = await import(
+      "../../collectors/frontmatter.js"
+    );
+
+    const report = await frontmatterCollector.collect({
+      cwd: "/fake",
+      timeout: 5000,
+    });
+
+    expect(report.items[0].metadata?.fileCount).toBe(0);
+  });
 });

--- a/scripts/src/dashboard/collectors/frontmatter.ts
+++ b/scripts/src/dashboard/collectors/frontmatter.ts
@@ -6,7 +6,8 @@
  */
 
 import { execSync } from "node:child_process";
-import { resolve } from "node:path";
+import { readdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import type {
   Collector,
   CollectorOptions,
@@ -40,7 +41,50 @@ interface FrontmatterJsonResult {
   };
 }
 
-const COLLECTOR_VERSION = "1.0.0";
+const COLLECTOR_VERSION = "1.1.0";
+
+/**
+ * Count files (not directories) recursively under `dir`.
+ *
+ * Returns 0 when the directory is missing or unreadable. Nested sub-skill
+ * files are intentionally included so a parent skill's count reflects every
+ * file shipped under its directory in the built output.
+ */
+function countFilesRecursive(dir: string): number {
+  let count = 0;
+  let entries;
+  try {
+    entries = readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return 0;
+  }
+  for (const entry of entries) {
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      count += countFilesRecursive(full);
+    } else if (entry.isFile()) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Populate `metadata.fileCount` on each item from the number of files in the
+ * built/output skill directory (the directory containing the skill's
+ * SKILL.md, as recorded in `metadata.path`). Mutates and returns `report`.
+ */
+function addFileCounts(report: CategoryReport, cwd: string): CategoryReport {
+  for (const item of report.items) {
+    const path = item.metadata?.path;
+    if (typeof path !== "string" || path.length === 0) continue;
+    const skillDir = resolve(cwd, dirname(path));
+    const metadata = item.metadata ?? {};
+    metadata.fileCount = countFilesRecursive(skillDir);
+    item.metadata = metadata;
+  }
+  return report;
+}
 
 function mapStatus(status: "pass" | "fail" | "warn"): CategoryStatus {
   return status;
@@ -137,7 +181,7 @@ export const frontmatterCollector: Collector = {
 
       if (typeof execErr.stdout === "string" && execErr.stdout.trim().length > 0) {
         try {
-          return parseFrontmatterJson(execErr.stdout);
+          return addFileCounts(parseFrontmatterJson(execErr.stdout), options.cwd);
         } catch {
           // Fall through to the skip report below when stdout is not valid JSON.
         }
@@ -152,6 +196,6 @@ export const frontmatterCollector: Collector = {
       };
     }
 
-    return parseFrontmatterJson(stdout);
+    return addFileCounts(parseFrontmatterJson(stdout), options.cwd);
   },
 };


### PR DESCRIPTION
Closes #2869.

## What
Each skill's page in the dashboard `Skills` section now shows a count of the number of files in the built/output skill.

## Changes
- **`scripts/src/dashboard/collectors/frontmatter.ts`** — added a `countFilesRecursive` helper and an `addFileCounts` step that populates `metadata.fileCount` for each skill from its directory under `output/skills/`. The count is recursive and includes nested sub-skill files. Applied to both the success and non-zero-exit recovery paths; collector version bumped to `1.1.0`.
- **`dashboard/src/skills/App.tsx`** — added `fileCount` to the `Skill` type, read it from the health-data metadata, and render `Files: N` in the skill detail header.
- **`dashboard/src/skills/skills.css`** — added a matching `.skills-file-count` style.
- **Tests** — added collector tests verifying `fileCount` is computed recursively (including nested sub-skills) and defaults to 0 when the directory is missing.

## Validation
- `scripts` dashboard suite: 188/188 pass (frontmatter collector: 14/14).
- `dashboard` skills tests: 14/14 pass.
- `scripts` typechecks clean; skills App compiles clean (the only `tsc` error is a pre-existing recharts type issue in the unrelated `token-usage/App.tsx`, confirmed present on the base branch).