### PR TITLE
feat: set azd user agent env

### DIFF
--- a/plugin/skills/microsoft-foundry/SKILL.md
+++ b/plugin/skills/microsoft-foundry/SKILL.md
@@ -19,7 +19,7 @@ Before using Foundry MCP operations, call the Azure MCP `foundry` tool and inspe
 
 > **MANDATORY: Before executing ANY workflow-specific steps, you MUST read the corresponding sub-skill document.** Do not call workflow-specific MCP tools for a workflow without reading its skill document. This applies even if you already know the MCP tool parameters — the skill document contains required workflow steps, pre-checks, and validation logic that must be followed. This rule applies on every new user message that triggers a different workflow, even if the skill is already loaded.
 
-Before executing Foundry-specific azd commands, read [azd-guidance](foundry-agent/azd-guidance/azd-guidance.md) first. Then read any applicable workflow-specific sub-skill. Direct questions about the Foundry azd CLI can use `azd-guidance` independently.
+> **MANDATORY: Before executing ANY azd command, you MUST read [azd-guidance](foundry-agent/azd-guidance/azd-guidance.md) and strictly follow the shared rules defined in it, especially the `AZURE_DEV_USER_AGENT` setting rules.**
 
 This skill includes specialized sub-skills for specific workflows. **Use these instead of the main skill when they match your task:**
 
@@ -44,7 +44,7 @@ This skill includes specialized sub-skills for specific workflows. **Use these i
 | **quota** | Managing quotas and capacity for Microsoft Foundry resources. Use when checking quota usage, troubleshooting deployment failures due to insufficient quota, requesting quota increases, or planning capacity. | [quota/quota.md](quota/quota.md) |
 | **rbac** | Managing RBAC permissions, role assignments, managed identities, and service principals for Microsoft Foundry resources. Use for access control, auditing permissions, and CI/CD setup. | [rbac/rbac.md](rbac/rbac.md) |
 | **finetuning** | Fine-tune models on Azure AI Foundry — SFT distillation, DPO preference optimization, RFT with graders and tool calling. Dataset preparation, grader calibration, training, checkpoint selection, deployment, evaluation. Use for: fine-tune, SFT, DPO, RFT, training data, grader, distillation, fine-tuned model, large file upload. | [finetuning/SKILL.md](finetuning/SKILL.md) |
-| **azd-guidance** | Provide shared azd knowledge and guidance for managing Foundry agents. Read this first for agent lifecycle workflows and use it to answer Foundry-specific azd CLI questions. | [azd-guidance](foundry-agent/azd-guidance/azd-guidance.md) |
+| **azd-guidance** | Provide shared azd knowledge and guidance for managing Foundry agents. Read this first for any workflows related to azd. | [azd-guidance](foundry-agent/azd-guidance/azd-guidance.md) |
 
 > 💡 **Tip:** For a complete onboarding flow: `project/create` (public) or `private-network` (VNet isolation) → `models/deploy-model` → agent workflows (`create` → `deploy` → `invoke`).
 

--- a/plugin/skills/microsoft-foundry/foundry-agent/azd-guidance/azd-guidance.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/azd-guidance/azd-guidance.md
@@ -4,6 +4,16 @@ Read this skill before running any Foundry agent workflow that uses azd. Also us
 
 ## Shared Rules
 
-1. If an azd command or flag is unclear, run the relevant `azd ... --help` command and follow its output.
-2. Unless the user explicitly asks to open a client, run `azd ai agent run --no-client`.
-3. If the needed azd guidance is not covered here or remains unclear, read [azd ai CLI Reference](references/azd-ai-cli.md).
+1. Always set `AZURE_DEV_USER_AGENT=microsoft_foundry_skill` when running azd commands, for example:
+
+   ```bash
+   AZURE_DEV_USER_AGENT=microsoft_foundry_skill azd ai agent init
+   AZURE_DEV_USER_AGENT=microsoft_foundry_skill azd ai agent run --no-client
+   AZURE_DEV_USER_AGENT=microsoft_foundry_skill azd provision
+   AZURE_DEV_USER_AGENT=microsoft_foundry_skill azd deploy
+   AZURE_DEV_USER_AGENT=microsoft_foundry_skill azd ai agent invoke
+   ```
+
+2. If an azd command or flag is unclear, run the relevant `azd ... --help` command and follow its output.
+3. Unless the user explicitly asks to open a client, run `azd ai agent run --no-client`.
+4. If the needed azd guidance is not covered here or remains unclear, read [azd ai CLI Reference](references/azd-ai-cli.md).

--- a/plugin/skills/microsoft-foundry/foundry-agent/azd-guidance/azd-guidance.md
+++ b/plugin/skills/microsoft-foundry/foundry-agent/azd-guidance/azd-guidance.md
@@ -14,6 +14,8 @@ Read this skill before running any Foundry agent workflow that uses azd. Also us
    AZURE_DEV_USER_AGENT=microsoft_foundry_skill azd ai agent invoke
    ```
 
+Set it inline only (as shown above). Never persist it into code or committed config (for example, `azd env set`, `.env`, or `azure.yaml`). It is a local-development-only setting.
+
 2. If an azd command or flag is unclear, run the relevant `azd ... --help` command and follow its output.
 3. Unless the user explicitly asks to open a client, run `azd ai agent run --no-client`.
 4. If the needed azd guidance is not covered here or remains unclear, read [azd ai CLI Reference](references/azd-ai-cli.md).

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.ps1
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.ps1
@@ -12,6 +12,10 @@
 #>
 
 $ErrorActionPreference = "Stop"
+
+# Tag azd/az telemetry
+$env:AZURE_DEV_USER_AGENT = "microsoft_foundry_skill"
+
 $actionRequired = $false
 
 function Note-Ok     { param([string]$m) Write-Output "[OK] $m" }

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.ps1
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.ps1
@@ -13,7 +13,7 @@
 
 $ErrorActionPreference = "Stop"
 
-# Tag azd/az telemetry
+# Tag azd telemetry
 $env:AZURE_DEV_USER_AGENT = "microsoft_foundry_skill"
 
 $actionRequired = $false

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.sh
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.sh
@@ -12,6 +12,9 @@
 
 set -uo pipefail
 
+# Tag azd/az telemetry
+export AZURE_DEV_USER_AGENT="microsoft_foundry_skill"
+
 ACTION_REQUIRED=0
 
 note_ok()     { echo "[OK] $1"; }

--- a/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.sh
+++ b/plugin/skills/microsoft-foundry/foundry-agent/create/scripts/verify-environment.sh
@@ -12,7 +12,7 @@
 
 set -uo pipefail
 
-# Tag azd/az telemetry
+# Tag azd telemetry
 export AZURE_DEV_USER_AGENT="microsoft_foundry_skill"
 
 ACTION_REQUIRED=0


### PR DESCRIPTION
## Description

To identify the azd traffic from foundry skill, we need to let agent set user agent env when running azd.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
