### PR TITLE
update enterprise-infra-planner owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,7 +19,7 @@
 /plugin/skills/azure-cost/ @saikoumudi @RickWinter
 /plugin/skills/azure-deploy/ @microsoft/github-copilot-for-azure-writers @paulyuk
 /plugin/skills/azure-diagnostics/ @tmeschter @saikoumudi @RickWinter
-/plugin/skills/azure-enterprise-infra-planner/ @Jbrocket @micha31r @arunrab @RickWinter
+/plugin/skills/azure-enterprise-infra-planner/ @micha31r @arunrab @RickWinter
 /plugin/skills/azure-kubernetes/ @saikoumudi @chandraneel @gambtho @RickWinter
 /plugin/skills/azure-kusto/ @saikoumudi @RickWinter
 /plugin/skills/azure-messaging/ @kashifkhan @RickWinter


### PR DESCRIPTION
## Description

Jbrocket is no longer on the project.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues