### PR TITLE
feature: document Kustainer emulator container-recreate reattach in azure-kusto skill

### DIFF
--- a/plugin/skills/azure-kusto/SKILL.md
+++ b/plugin/skills/azure-kusto/SKILL.md
@@ -212,6 +212,28 @@ Switch to Azure CLI when:
 - Authentication failures with MCP tools
 - Empty response when database is known to have data
 
+## Local Kusto Emulator (Kustainer / Docker)
+
+Azure Data Explorer ships a Docker emulator (`mcr.microsoft.com/azuredataexplorer/kustainer-linux`) for offline/local development. It exposes the same REST endpoints (`/v1/rest/query`, `/v1/rest/mgmt`) as a real cluster, but has emulator-specific lifecycle behavior that differs from a managed ADX cluster.
+
+**Persisting a database across container restarts** - mount a host folder to `/kustodata` and create the database with an explicit persist path:
+
+```kusto
+.create database MyDb persist (@"/kustodata/dbs/MyDb/md", @"/kustodata/dbs/MyDb/data")
+```
+
+**⚠️ Reattaching after the container is recreated** - stopping/removing and recreating the container (e.g. to change `--memory`, upgrade the image, or move hosts) against the *same* `/kustodata` bind mount does **not** auto-reattach previously-persisted databases. Only an empty built-in `NetDefaultDB` is created on every engine start - this is normal emulator behavior, not data loss.
+
+- **Symptom**: `.show databases` shows only `NetDefaultDB`; querying the expected database returns `BadRequest_EntityNotFound` - even though `/kustodata/dbs/<name>/` is fully intact on disk.
+- **Do NOT** re-run `.create database ... persist(...)` against the existing path. That command creates a *new* database; against metadata that already exists it fails instantly with a generic, unhelpful `Internal service error` regardless of database size - this is not a resource, disk-space, or size problem, it is simply the wrong command.
+- **Do** use the dedicated reattach command instead:
+
+  ```kusto
+  .attach database MyDb from @"/kustodata/dbs/MyDb/md"
+  ```
+
+  This registers existing on-disk metadata with the running engine in milliseconds. It only reads metadata - it does not move, copy, or delete extent/data files - so it's safe to run whenever you're unsure if a database is attached. Run one `.attach database` per previously-existing database after every container stop/rm/recreate before concluding data was lost.
+
 ## Common Issues
 
 - **Access Denied**: Verify database permissions (Viewer role minimum for queries)
@@ -221,6 +243,7 @@ Switch to Azure CLI when:
 - **Cluster Not Found**: Check cluster name format (exclude ".kusto.windows.net" suffix)
 - **High CPU Usage**: Query too broad - add filters, reduce time range, limit aggregations
 - **Ingestion Lag**: Streaming data may have 1-30 second delay depending on ingestion method
+- **Database Missing After Emulator Container Restart**: See "Local Kusto Emulator" above - use `.attach database <name> from @"<md-path>"`, not `.create database ... persist(...)`, to reattach existing on-disk data.
 
 ## Use Cases
 


### PR DESCRIPTION
## What

Adds a "Local Kusto Emulator (Kustainer / Docker)" section to `plugin/skills/azure-kusto/SKILL.md`, documenting how to reattach a previously-persisted database after the emulator container is stopped/removed and recreated against the same `/kustodata` bind mount. Also adds a one-line pointer in "Common Issues".

## Why

Recreating the Kustainer container (e.g. to bump `--memory`) does **not** auto-reattach existing databases - only the empty built-in `NetDefaultDB` is created on engine start. The instinctive fix (re-running the canonical creation command, `.create database ... persist(...)`) fails with a generic `Internal service error` when pointed at metadata that already exists on disk, which is easy to misread as data loss. The correct command is the distinct `.attach database <name> from @"<md-path>"`, which registers existing metadata in milliseconds without touching any data files.

This was root-caused via live, first-party incident reproduction: the failing `.create ... persist(...)` command failed identically and near-instantly (flat CPU/memory) on both a 408KB and a 49GB database, ruling out size/resource causes; `.attach database ... from` succeeded in ~0.15s for both, and post-attach row counts matched pre-incident ground truth exactly on a 40M+ row table.

## Scope

Documentation only - no new MCP tools, activation triggers, or frontmatter changes.

## Validation

- `npm run checkCopilotCliCharBudget` (scripts/): passes, unaffected (description text unchanged).
- `npm run frontmatter -- plugin/skills/azure-kusto/SKILL.md` (scripts/): only the pre-existing `metadata.version "0.0.0-placeholder"` notice appears, confirmed present identically on an untouched skill (`azure-storage`) - i.e. unrelated to this change and expected pre-build (versions are stamped by Nerdbank.GitVersioning at build time per `docs/Onboarding.md`).
- Manual token estimate: SKILL.md is ~2.7k tokens post-change, within the 5k token guidance.
- Did not run the full `vally` eval suite in this environment (requires live agent/Azure integration); this is a targeted textual addition to an existing skill's "Common Issues"/reference material, not a new skill or new trigger surface.

Closes #2924
