### PR TITLE
fix: unify plugin and changelog versioning

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -68,10 +68,12 @@ function stampPluginVersions() {
   );
   const majorMinor = versionJson.version as string;
 
-  const filteredCommits = getFilteredCommits();
+  const commits = getVersionedCommits();
 
   // The last commit is the most recent commit
-  const patchNumber = filteredCommits.length > 0 ? filteredCommits[filteredCommits.length - 1].height : 0;
+  const patchNumber = commits.length > 0
+    ? commits[commits.length - 1].relativeHeight
+    : 0;
 
   const version = `${majorMinor}.${patchNumber}`;
 
@@ -133,42 +135,114 @@ type Commit = {
   hash: string;
   subject: string;
   height: number;
+
+  /**
+   * The major and minor version number that should be used when generating the version number from this commit.
+   * The major and minor version number is the major and minor version number in the version.json file at the time the commit is created.
+  */
+  majorMinor: string;
+
+  /**
+   * The number of commits between this commit and the most recent one that touched the version.json file before.
+   */
+  relativeHeight: number;
 };
 
-function getFilteredCommits(): Commit[] {
+/**
+ * @returns Commits with their associated version numbers from oldest to newest.
+ */
+function getVersionedCommits(): Commit[] {
+  const pluginDir = "plugin";
+
   // Find the commit that introduced plugin/version.json (the NBGV baseline).
   const baselineCommit = execSync(
-    "git log --diff-filter=A --format=%H --first-parent -- plugin/version.json",
+    `git log --diff-filter=A --format=%H --first-parent -- ${pluginDir}/version.json`,
     { encoding: "utf-8" }
   ).trim();
 
   if (!baselineCommit) {
-    log.warn("Could not find baseline commit for plugin/version.json; skipping changelog generation.");
+    log.warn(`Could not find baseline commit for ${pluginDir}/version.json; skipping changelog generation.`);
     return [];
   }
 
-  // Enumerate first-parent commits touching plugin/ from baseline (inclusive) to HEAD.
-  // We include the baseline itself by using baseline~1..HEAD (or just --ancestry-path from baseline).
-  const logOutput = execSync(
-    `git log --first-parent --format=%H%x00%s --reverse ${baselineCommit}~1..HEAD -- plugin/`,
+  // Enumerate all first-parent commits touching plugin/**/* from baseline (inclusive) to HEAD.
+  const pluginLogOutput = execSync(
+    `git log --first-parent --format=%H%x00%s --reverse ${baselineCommit}~1..HEAD -- ${pluginDir}/`,
     { encoding: "utf-8" }
   ).trim();
 
-  if (!logOutput) {
-    log.warn("No commits found touching plugin/; skipping changelog generation.");
+  if (!pluginLogOutput) {
+    log.warn(`No commits found touching ${pluginDir}/; skipping changelog generation.`);
     return [];
   }
 
-  const commits = logOutput.split("\n").map((line, index) => {
+  // pluginFileCommits is ordered from oldest to newest
+  const pluginFileCommits = pluginLogOutput.split("\n").map((line, index) => {
     const [hash, subject] = line.split("\0", 2);
     return { hash, subject, height: index + 1 };
   });
 
-  // Filter to only include PRs with fix:/feat:/feature:/chore:/misc:/test:/eval: prefixes.
-  const prefixRe = /^(fix|feat|feature|chore|misc|test|eval)(\(.+?\))?:/i;
-  const filtered = commits.filter((c) => prefixRe.test(c.subject));
+  // Enumerate all first-parent commits touching plugin/version.json.
+  const versionLogOutput = execSync(
+    `git log --first-parent --format=%H%x00%s --reverse ${baselineCommit}~1..HEAD -- ${pluginDir}/version.json`,
+    { encoding: "utf-8" }
+  ).trim();
 
-  return filtered;
+  if (!versionLogOutput) {
+    log.warn(`No commits found touching ${pluginDir}/version.json; skipping changelog generation.`);
+    return [];
+  }
+
+  const pluginHeightByHash = new Map(pluginFileCommits.map((commit) => [commit.hash, commit.height]));
+
+  // versionPoints is ordered from oldest to newest
+  const versionPoints = versionLogOutput
+    .split("\n")
+    .map((line) => {
+      const [hash] = line.split("\0", 1);
+      const height = pluginHeightByHash.get(hash);
+
+      if (height === undefined) {
+        return null;
+      }
+
+      const versionJsonAtCommit = JSON.parse(
+        execSync(`git show ${hash}:${pluginDir}/version.json`, { encoding: "utf-8" })
+      ) as { version?: string };
+
+      if (!versionJsonAtCommit.version) {
+        throw new Error(`Missing version in ${pluginDir}/version.json at commit ${hash}`);
+      }
+
+      return {
+        height,
+        majorMinor: versionJsonAtCommit.version,
+      };
+    })
+    .filter((point): point is { height: number; majorMinor: string } => point !== null);
+
+  if (versionPoints.length === 0) {
+    log.warn(`No usable version points found for ${pluginDir}/version.json; skipping changelog generation.`);
+    return [];
+  }
+
+  // Reverse version points to order from newest to oldest
+  const reversedVersionPoints = [...versionPoints.reverse()];
+
+  return pluginFileCommits.map((commit) => {
+    const nearestPrevious = reversedVersionPoints.find((point) => point.height <= commit.height) ?? versionPoints[0];
+    const relativeHeight = nearestPrevious.height <= commit.height
+      ? commit.height - nearestPrevious.height
+      : 0;
+
+    return {
+      hash: commit.hash,
+      subject: commit.subject,
+      height: commit.height,
+      majorMinor: nearestPrevious.majorMinor,
+      relativeHeight,
+    };
+  });
 }
 
 /**
@@ -178,10 +252,12 @@ function getFilteredCommits(): Commit[] {
  * since the NBGV baseline commit (when plugin/version.json was introduced).
  */
 function generateChangelog(): void {
-  const versionJson = JSON.parse(
-    readFileSync("plugin/version.json", "utf-8")
-  );
-  const majorMinor = versionJson.version as string;
+  const versionedCommits = getVersionedCommits();
+
+  if (versionedCommits.length === 0) {
+    log.warn("No commit data available for changelog generation.");
+    return;
+  }
 
   // Determine the repository URL for PR links. Prefer the "upstream" remote
   // (the canonical repo where PRs live) and fall back to "origin".
@@ -196,11 +272,10 @@ function generateChangelog(): void {
   // Build changelog content (newest first).
   let content = "# Changelog\n";
 
-  const filteredCommits = getFilteredCommits();
+  for (let i = versionedCommits.length - 1; i >= 0; i--) {
+    const entry = versionedCommits[i];
+    const version = `${entry.majorMinor}.${entry.relativeHeight}`;
 
-  for (let i = filteredCommits.length - 1; i >= 0; i--) {
-    const entry = filteredCommits[i];
-    const version = `${majorMinor}.${entry.height}`;
     // Turn (#NNN) into a markdown link.
     const subject = entry.subject.replace(
       /\(#(\d+)\)/g,
@@ -211,7 +286,7 @@ function generateChangelog(): void {
 
   mkdirSync("output", { recursive: true });
   writeFileSync("output/CHANGELOG.md", content, "utf-8");
-  log(`generated CHANGELOG.md with ${filteredCommits.length} entries`);
+  log(`generated CHANGELOG.md with ${versionedCommits.length} entries`);
 }
 
 export default build;

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -63,7 +63,17 @@ function stampSkillVersions() {
  * The version is fetched once on the first matching file and cached for the rest.
  */
 function stampPluginVersions() {
-  let pluginVersionPromise: Promise<string> | null = null;
+  const versionJson = JSON.parse(
+    readFileSync("plugin/version.json", "utf-8")
+  );
+  const majorMinor = versionJson.version as string;
+
+  const filteredCommits = getFilteredCommits();
+
+  // The last commit is the most recent commit
+  const patchNumber = filteredCommits.length > 0 ? filteredCommits[filteredCommits.length - 1].height : 0;
+
+  const version = `${majorMinor}.${patchNumber}`;
 
   return new Transform({
     objectMode: true,
@@ -74,13 +84,6 @@ function stampPluginVersions() {
       }
 
       try {
-        if (!pluginVersionPromise) {
-          pluginVersionPromise = nbgv
-            .getVersion(path.resolve("plugin"))
-            .then((v) => v.simpleVersion);
-        }
-        const version = await pluginVersionPromise;
-
         const content = file.contents!.toString();
         const versionPlaceholderPattern =
           /("version":\s*")0\.0\.0-placeholder(")/;
@@ -126,18 +129,13 @@ function build() {
   return pipeline;
 }
 
-/**
- * Generates a CHANGELOG.md in the output directory based on merged PRs
- * that touch plugin/ and have titles starting with fix:, feat:, feature:, chore:, misc:, test:, or eval:.
- * Each version corresponds to a single first-parent commit touching plugin/
- * since the NBGV baseline commit (when plugin/version.json was introduced).
- */
-function generateChangelog(): void {
-  const versionJson = JSON.parse(
-    readFileSync("plugin/version.json", "utf-8")
-  );
-  const majorMinor = versionJson.version as string;
+type Commit = {
+  hash: string;
+  subject: string;
+  height: number;
+};
 
+function getFilteredCommits(): Commit[] {
   // Find the commit that introduced plugin/version.json (the NBGV baseline).
   const baselineCommit = execSync(
     "git log --diff-filter=A --format=%H --first-parent -- plugin/version.json",
@@ -146,7 +144,7 @@ function generateChangelog(): void {
 
   if (!baselineCommit) {
     log.warn("Could not find baseline commit for plugin/version.json; skipping changelog generation.");
-    return;
+    return [];
   }
 
   // Enumerate first-parent commits touching plugin/ from baseline (inclusive) to HEAD.
@@ -158,7 +156,7 @@ function generateChangelog(): void {
 
   if (!logOutput) {
     log.warn("No commits found touching plugin/; skipping changelog generation.");
-    return;
+    return [];
   }
 
   const commits = logOutput.split("\n").map((line, index) => {
@@ -169,6 +167,21 @@ function generateChangelog(): void {
   // Filter to only include PRs with fix:/feat:/feature:/chore:/misc:/test:/eval: prefixes.
   const prefixRe = /^(fix|feat|feature|chore|misc|test|eval)(\(.+?\))?:/i;
   const filtered = commits.filter((c) => prefixRe.test(c.subject));
+
+  return filtered;
+}
+
+/**
+ * Generates a CHANGELOG.md in the output directory based on merged PRs
+ * that touch plugin/ and have titles starting with fix:, feat:, feature:, chore:, misc:, test:, or eval:.
+ * Each version corresponds to a single first-parent commit touching plugin/
+ * since the NBGV baseline commit (when plugin/version.json was introduced).
+ */
+function generateChangelog(): void {
+  const versionJson = JSON.parse(
+    readFileSync("plugin/version.json", "utf-8")
+  );
+  const majorMinor = versionJson.version as string;
 
   // Determine the repository URL for PR links. Prefer the "upstream" remote
   // (the canonical repo where PRs live) and fall back to "origin".
@@ -183,8 +196,10 @@ function generateChangelog(): void {
   // Build changelog content (newest first).
   let content = "# Changelog\n";
 
-  for (let i = filtered.length - 1; i >= 0; i--) {
-    const entry = filtered[i];
+  const filteredCommits = getFilteredCommits();
+
+  for (let i = filteredCommits.length - 1; i >= 0; i--) {
+    const entry = filteredCommits[i];
     const version = `${majorMinor}.${entry.height}`;
     // Turn (#NNN) into a markdown link.
     const subject = entry.subject.replace(
@@ -196,7 +211,7 @@ function generateChangelog(): void {
 
   mkdirSync("output", { recursive: true });
   writeFileSync("output/CHANGELOG.md", content, "utf-8");
-  log(`generated CHANGELOG.md with ${filtered.length} entries`);
+  log(`generated CHANGELOG.md with ${filteredCommits.length} entries`);
 }
 
 export default build;

--- a/plugin/version.json
+++ b/plugin/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": ["."]
 }


### PR DESCRIPTION
## Description

Fixes several bugs in the changelog generation script.

1. If we bump major-minor in version.json and generate the changelog, the new changelog overwrites all entries of prior versions with the new major-minor segment. For example, after bumping from 1.1 to 1.2, entries that used to have 1.1.x become 1.2.x in the new changelog.
2. The version between the changelog and plugin.json may desync. This is because the code generating plugin.json's version uses nbgv but the code generating changelog versions are handcrafted logic that computes them from commit history.

This PR unifies the version generation logic for changelog and plugin.json and fixed these bugs. After the change, the changelog generation ensures the following:

- Version numbers in the plugin.json and changelog are monotonically increasing
- Every commit that end up updating the published plugin files has a changelog entry
- The version of plugin.json is the same as the version of the top changelog entry
- Changelog entries that have been commited won't be overwritten after bumping the major-minor version number
- Whenever we bump the major-minor version number, the patch number of the next version is reset to 0

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

Fixes #2926