### PR TITLE
fix: tighten redaction and remove unnecessary data publishing

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -326,15 +326,6 @@ jobs:
         if: always() && matrix.skill == 'microsoft-foundry'
         run: npm run quality-report || true
 
-      - name: Export report
-        if: always()
-        id: export-report
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: integration-report-${{ matrix.skill }}
-          path: tests/reports/
-          retention-days: 30
-
       # Note: The managed identity must have write permission to the target storage account
       - name: Publish report to Azure Storage
         if: always() && github.event_name == 'schedule' && vars.REPORT_STORAGE_ACCOUNT != ''

--- a/.github/workflows/test-azure-deploy.yml
+++ b/.github/workflows/test-azure-deploy.yml
@@ -201,14 +201,6 @@ jobs:
             echo "No skill report found"
           fi
 
-      - name: Export report
-        if: always()
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
-        with:
-          name: azure-deploy-${{ matrix.test-group }}-reports
-          path: tests/reports/
-          retention-days: 30
-
       # Note: The managed identity must have write permission to the target storage account
       - name: Publish report to Azure Storage
         if: always() && github.event_name == 'schedule' && vars.REPORT_STORAGE_ACCOUNT != ''

--- a/tests/utils/redact.ts
+++ b/tests/utils/redact.ts
@@ -9,7 +9,7 @@ const SECRET_PATTERNS = [
 // Key=value style secrets (including JSON-style properties). Capture the key + separator as group 1
 // so we can preserve the structure and only redact the value.
 const KEY_VALUE_SECRET_PATTERN =
-  /((?:password|passwd|secret|token|api[_-]?key|accountkey|connection[_-]?string)[\\]*["']?\s*[:=]\s*[\\]*["']?)[^\s"',]{8,}/gi;
+  /((?:password|passwd|secret|token|api[_-]?key|account[_-]?key|connection[_-]?string)[\\]*["']?\s*[:=]\s*[\\]*["']?)[^\s"',;]{8,}/gi;
 
 export function redactSecrets(text: string): string {
   let result = text;

--- a/tests/utils/redact.ts
+++ b/tests/utils/redact.ts
@@ -9,7 +9,7 @@ const SECRET_PATTERNS = [
 // Key=value style secrets (including JSON-style properties). Capture the key + separator as group 1
 // so we can preserve the structure and only redact the value.
 const KEY_VALUE_SECRET_PATTERN =
-  /((?:password|passwd|secret|token|api[_-]?key|connection[_-]?string)[\\]*["']?\s*[:=]\s*[\\]*["']?)[^\s"',]{8,}/gi;
+  /((?:password|passwd|secret|token|api[_-]?key|accountkey|connection[_-]?string)[\\]*["']?\s*[:=]\s*[\\]*["']?)[^\s"',]{8,}/gi;
 
 export function redactSecrets(text: string): string {
   let result = text;


### PR DESCRIPTION
## Description

- Tighten redaction logic to cover storage account key in connection strings
- Remove unnecessary data publishing step for test result investigation

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
