### PR TITLE
fix: azure-prepare grader glob

### DIFF
--- a/evals/azure-prepare/e2e-eval.yaml
+++ b/evals/azure-prepare/e2e-eval.yaml
@@ -60,7 +60,7 @@ stimuli:
             - azure-prepare
       - type: file-exists
         config:
-          path: "**/deployment-plan.md"
+          path: ".azure/deployment-plan.md"
       - type: output-not-matches
         config:
           pattern: "(?i)fatal error|unhandled exception|stack trace"
@@ -85,7 +85,7 @@ stimuli:
             - azure-prepare
       - type: file-exists
         config:
-          path: "**/deployment-plan.md"
+          path: ".azure/deployment-plan.md"
       - type: file-exists
         config:
           path: "**/azure.yaml"
@@ -119,7 +119,7 @@ stimuli:
             - azure-prepare
       - type: file-exists
         config:
-          path: "**/deployment-plan.md"
+          path: ".azure/deployment-plan.md"
       - type: file-exists
         config:
           path: "**/*.tf"
@@ -150,7 +150,7 @@ stimuli:
             - azure-prepare
       - type: file-exists
         config:
-          path: "**/deployment-plan.md"
+          path: ".azure/deployment-plan.md"
       - type: file-exists
         config:
           path: "**/*.bicep"
@@ -317,7 +317,7 @@ stimuli:
             - azure-prepare
       - type: file-exists
         config:
-          path: "**/deployment-plan.md"
+          path: ".azure/deployment-plan.md"
       - type: file-exists
         config:
           path: "**/azure.yaml"


### PR DESCRIPTION
## Description

These graders are failing because the file vally should be checking for were ignored due to this: https://github.com/microsoft/vally/issues/779

Our instructions say the deployment-plan.md file must be created at the .azure/deployment-plan.md. There is no harm checking for the strictly matching location. https://github.com/microsoft/GitHub-Copilot-for-Azure/blob/59e113438627c8e6f271e05cfdb72aec0f51070e/plugin/skills/azure-prepare/SKILL.md?plain=1#L47

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
