### PR TITLE
doc: plugin structure doc

### DIFF
--- a/docs/Onboarding.md
+++ b/docs/Onboarding.md
@@ -39,7 +39,7 @@ cd GitHub-Copilot-for-Azure
 
 ### Plugin Structure
 
-Each plugin has the following files under the `plugins/<plugin>` directory.
+Each plugin has the following files under the `plugins/<plugin>` directory:
 
 ```text
 <repo-root>/
@@ -58,21 +58,23 @@ Each plugin has the following files under the `plugins/<plugin>` directory.
 ├──   version.json          (base version file)
 ```
 
-Each plugin has all its files stored under `plugins/<your-plugin-name>/`, called the plugin root. `plugins/azure-skills/` is a well established plugin you can use as an example.
+Each plugin has all its files stored under `plugins/<your-plugin-name>/`, which is called the plugin root. `plugins/azure-skills/` is a well-established plugin you can use as an example.
 
-`.calude-plugin/` contains the plugin manifest for Claude Code. `.cursor-plugin/` contains the plugin manifest for Cursor. `.plugin/` contains the plugin manifest for Copilot CLI and VS Code. We have to maintain separate plugin manifests because clients use them in different ways. See [plugin-manifest.md](./plugin-manifest.md) for more explanation. Every new plugin should at least provide these manifests to make sure it works for these clients.
+`.claude-plugin/` contains the plugin manifest for Claude Code. `.cursor-plugin/` contains the plugin manifest for Cursor. `.plugin/` contains the plugin manifest for Copilot CLI and VS Code. We have to maintain separate plugin manifests because clients use them in different ways. See [plugin-manifest.md](./plugin-manifest.md) for more information. Every new plugin should provide at least these manifests to make sure it works for these clients.
 
-`hooks/` contains the hooks manifest. Since clients also use hooks manifest in different ways, we have to maintain separate hooks manifests for different clients. See [hooks.md](./hooks.md) for more explanation. Our existing hooks for tracking telemetry are reusable so you can reuse them. If you don't want our hook to collect telemetry for your skill or if you want to do something differently, you can implement your own. If you do so, please make sure to read [hooks.md](./hooks.md) to help make your hook work for the clients.
+`hooks/` contains the hooks manifest. Since clients also use hook manifests in different ways, we have to maintain separate hook manifests for different clients. See [hooks.md](./hooks.md) for more information. Our existing hooks for tracking telemetry are reusable. If you do not want our hook to collect telemetry for your skill, or if you want to do something differently, you can implement your own. If you do so, please read [hooks.md](./hooks.md) to help make your hook work for the clients.
 
-`skills/` contains the skill files. `.mcp.json` file contains the MCP server configuration you want to add to the agent. They are the bread-and-butter that gets added to the agent context to help the agent solve problems. `LICENSE` is the software license of your plugin. We only accept MIT License in this repo. `README.md` is a user facing documentation for users of the plugin. `version.json` sets the base major-minor version numbers so the automated versioning script can generate version numbers for your plugin. See [VERSIONING.md](./VERSIONING.md) to learn how it works.
+`skills/` contains the skill files. The `.mcp.json` file contains the MCP server configuration you want to add to the agent. Skills and MCP configuration are the bread and butter added to the agent context to help the agent solve problems. `LICENSE` is the software license for your plugin. `README.md` is user-facing documentation for users of the plugin. `version.json` sets the base major and minor version numbers so the automated versioning script can generate version numbers for your plugin. See [VERSIONING.md](./VERSIONING.md) to learn how it works.
 
 Unless there is an urgent need to extend an existing plugin, new skills should be contributed as new plugins so they can work independently from existing ones.
 
-You run this command at the repository root and scaffold a new plugin following the instructions.
+Run this command at the repository root to scaffold a new plugin, then add your files to it.
 
 ```bash
 npm run plugin:new
 ```
+
+Skills should be contributed as new plugins unless it's a good fit for an existing plugin and the plugin still has capacity.
 
 ### Skill Structure
 

--- a/docs/Onboarding.md
+++ b/docs/Onboarding.md
@@ -37,12 +37,49 @@ git clone https://github.com/YOUR-USERNAME/GitHub-Copilot-for-Azure.git
 cd GitHub-Copilot-for-Azure
 ```
 
+### Plugin Structure
+
+Each plugin has the following files under the `plugins/<plugin>` directory.
+
+```text
+<repo-root>/
+├── plugins/
+├── azure-skills/           (existing plugin)
+├── <your-plugin-name>/     (your new plugin)
+├──   .claude-plugin/       (claude code plugin manifest)
+├──   .cursor-plugin/       (cursor plugin manifest)
+├──   .plugin/              (Copilot CLI and VS Code plugin manifest)
+├──   assets/               (assets, referenced by Cursor plugin manifest)
+├──   hooks/                (hook files)
+├──   skills/               (skill files)
+├──   .mcp.json             (mcp definition)
+├──   LICENSE               (your plugin LICENSE)
+├──   README.md             (user facing README.md for your plugin)
+├──   version.json          (base version file)
+```
+
+Each plugin has all its files stored under `plugins/<your-plugin-name>/`, called the plugin root. `plugins/azure-skills/` is a well established plugin you can use as an example.
+
+`.calude-plugin/` contains the plugin manifest for Claude Code. `.cursor-plugin/` contains the plugin manifest for Cursor. `.plugin/` contains the plugin manifest for Copilot CLI and VS Code. We have to maintain separate plugin manifests because clients use them in different ways. See [plugin-manifest.md](./plugin-manifest.md) for more explanation. Every new plugin should at least provide these manifests to make sure it works for these clients.
+
+`hooks/` contains the hooks manifest. Since clients also use hooks manifest in different ways, we have to maintain separate hooks manifests for different clients. See [hooks.md](./hooks.md) for more explanation. Our existing hooks for tracking telemetry are reusable so you can reuse them. If you don't want our hook to collect telemetry for your skill or if you want to do something differently, you can implement your own. If you do so, please make sure to read [hooks.md](./hooks.md) to help make your hook work for the clients.
+
+`skills/` contains the skill files. `.mcp.json` file contains the MCP server configuration you want to add to the agent. They are the bread-and-butter that gets added to the agent context to help the agent solve problems. `LICENSE` is the software license of your plugin. We only accept MIT License in this repo. `README.md` is a user facing documentation for users of the plugin. `version.json` sets the base major-minor version numbers so the automated versioning script can generate version numbers for your plugin. See [VERSIONING.md](./VERSIONING.md) to learn how it works.
+
+Unless there is an urgent need to extend an existing plugin, new skills should be contributed as new plugins so they can work independently from existing ones.
+
+You run this command at the repository root and scaffold a new plugin following the instructions.
+
+```bash
+npm run plugin:new
+```
+
 ### Skill Structure
 
-Skills in this repo are organized in an agent plugin. Pre-built skills are located under `plugin/skills/`. Each skill folder contains:
+Skills in this repo are organized in agent plugins. Pre-built skills are located under `plugins/<plugin>/skills`. Each skill folder contains:
 
 ```
-plugin/skills/your-skill-name/
+plugins/<plugin>/skills/your-skill-name/
 ├── SKILL.md              # Main skill definition (required)
 ├── LICENSE.txt           # License file (if applicable)
 ├── references/           # Additional reference documentation
@@ -53,7 +90,7 @@ plugin/skills/your-skill-name/
 
 You should add your new skill as one of the pre-built skills. You may use existing skills as examples on what the file structure look like.
 
-1. **Create your skill folder** under `plugin/skills/your-skill-name/`
+1. **Create your skill folder** under `plugins/<plugin>/skills/your-skill-name/`
 2. **Write your SKILL.md** following the existing patterns
     - Use [sensei](/.github/skills/sensei/SKILL.md) to assist with writing the frontmatter
     - Use [skill-authoring](/.github/skills/skill-authoring/SKILL.md) to assist with writing the SKILL.md and references.
@@ -102,14 +139,14 @@ Use [sensei](/.github/skills/sensei/SKILL.md) to refine the frontmatter to pass 
 Use the `--plugin-dir` flag to point Copilot CLI at your build output:
 
 ```bash
-copilot --plugin-dir ./output
+copilot --plugin-dir ./output/<plugin>
 ```
 
 This loads the locally built plugin instead of any marketplace-installed version. Then prompt the Copilot CLI agent to perform a task and see how the skill is used.
 
-After making changes to skill files under `plugin/`:
+After making changes to skill files under `plugins/<plugin>/skills`:
 
-1. **Rebuild** the plugin to update the `output/` directory:
+1. **Rebuild** the plugin to update the `output/<plugin>` directory:
    ```bash
    npm run build
    ```
@@ -126,7 +163,7 @@ Before submitting a PR for adding the new skill, run the vally eval suites of th
 
 ```bash
 # in repo root
-npx --yes @microsoft/vally-cli@^0.7.0 lint plugin/skills/ --eval-spec evals/ --strict --grader-plugin ./tests/vally/vally-graders.ts
+npx --yes @microsoft/vally-cli@^0.7.0 lint plugins/ --eval-spec evals/ --strict --grader-plugin ./tests/vally/vally-graders.ts
 
 # in tests/
 npm run typecheck

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -12,16 +12,15 @@ This repository uses [Nerdbank.GitVersioning (NBGV)](https://github.com/dotnet/N
 ## Files Managed
 
 The following files have their versions automatically stamped at build time:
-- `plugin/.claude-plugin/plugin.json`
-- `plugin/.cursor-plugin/plugin.json`
-- `plugin/.plugin/plugin.json`
-- `plugin/skills/*/SKILL.md` (each skill gets its own version)
+- `plugins/<plugin>/.claude-plugin/plugin.json`
+- `plugins/<plugin>/.cursor-plugin/plugin.json`
+- `plugins/<plugin>/.plugin/plugin.json`
+- `plugins/<plugin>/skills/*/SKILL.md` (each skill gets its own version)
 
 ## Changelog Generation
 
 The `CHANGELOG.md` is automatically generated at build time by the Gulp pipeline. It includes merged PRs that:
-- Touch the `plugin/` directory
-- Have titles starting with `fix:`, `feat:`, or `feature:`, etc. See [gulpfile](../gulpfile.ts) for the exhaustive list of supported prefixes.
+- Touch the `plugins/<plugin>` directory
 
 Each entry is associated with the NBGV height-based version (`{major}.{minor}.{height}`) of the commit that introduced it.
 
@@ -38,6 +37,6 @@ The GitHub Actions workflow `publish-to-marketplace.yml` automatically:
 2. Syncs the output to `microsoft/skills` and `microsoft/azure-skills` marketplace repos
 
 ### Files That Trigger Version Updates:
-- ✅ Any file under `plugin/` folder (for plugin version)
+- ✅ Any file under `plugins/` folder (for plugin version)
 - ✅ Any file under a skill's directory (for that skill's version)
 - ❌ Files outside tracked paths don't affect versions

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,25 @@
+# Hooks
+
+Hooks manifests are the `hooks.json` files that tells the agent what hooks to execute.
+
+These files are used by clients when running agent sessions. We have to maintain separate plugin manifest for different clients before they work in different ways.
+
+## Copilot CLI
+
+Copilot CLI uses the `hooks.json` hooks manifest. Although it shares the manifest with VS Code, it only uses the `bash` and `powershell` properties defined in it. At runtime, Copilot CLI replaces the `PLUGIN_ROOT` variable to construct the path that can resolve the scripts. On macOS and Linux, it executes the `bash` script. On Windows, it executes the `powershell` script.
+
+## VS Code
+
+VS Code uses the `hooks.json` hooks manifest. Although it shares the manifest with Copilot CLI, it only uses the `windows`, `osx` and `linux` properties defined in it. At runtime, VS Code replaces the `PLUGIN_ROOT` variable to construct the path that can resolve the scripts. It then executes the script matching the host OS.
+
+## Claude Code
+
+Claude Code uses the `claude-hooks.json` hooks manifest. Its manifest defines a nested `hooks` array under each event, making it unique from other clients' hooks manifests. At runtime, Claude Code replaces the `CLAUDE_PLUGIN_ROOT` variable to construct the path that can resolve to the scripts. It then executes the script with bash.
+
+## Cursor
+
+Cursor uses the `cursor-hooks.json` hooks manifest. At runtime, Cursor replaces the `CURSOR_PLUGIN_ROOT` variable to construct the path that can resolve to the scripts. It then executes the script with bash.
+
+## Misc
+
+Most clients look for `hooks/hooks.json` as the default hook configuration and try to use it if no explicit `hooks` property is defined in the plugin manifest. We decided to explicitly define hooks manifest for every client because it's impossible to create one hooks manifest for all clients. Copilot/VS Code, Claude and Cursor use mutually exclusive schema for hooks manifest, which means the manifest is guaranteed to cause syntax errors in one or more clients. Besides, clients use different variables to represent the plugin root. Having the incorrect variable will cause the client to fail to resolve the script path, resulting in runtime failures.

--- a/docs/plugin-manifest.md
+++ b/docs/plugin-manifest.md
@@ -1,0 +1,23 @@
+# Plugin Manifest
+
+Plugin manifests are the `plugin.json` files that describes the information of a plugin and where to look for its content, such as skills, mcp servers and hooks.
+
+These files are used by clients when they installs a plugin. We have to maintain separate plugin manifest for different clients before they work in different ways.
+
+Every plugin manifest references a dedicated hooks manifest because every client supports hooks in incompatible ways.
+
+## Copilot CLI
+
+Copilot CLI looks for the `.plugin/plugin.json` file. It references a hooks manifest shared with VS Code.
+
+## VS Code
+
+Copilot CLI looks for the `.plugin/plugin.json` file. It references a hooks manifest shared with Copilot CLI.
+
+## Claude Code
+
+Claude Code looks for the `.claude-plugin/plugin.json` file. It references its dedicated `claude-hooks.json` hooks manifest.
+
+## Cursor
+
+Cursor looks for the `.cursor-plugin/plugin.json`. It references a dedicated `cursor-hooks.json` hooks manifest. It also has a `logo` property referencing an image file. Cursor marketplace presents the [azure](https://cursor.com/marketplace/azure) plugin with the icon in its website. This log is not required if the plugin is not onboarded to the official Cursor marketplace.


### PR DESCRIPTION
## Description

- Update onboarding doc for new plugin folder structure
- Document plugin folder structure
- Document nuances in plugin manifest and hooks

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
