### PR TITLE
chore: bump all skill versions

### DIFF
--- a/plugins/azure-skills/skills/airunway-aks-setup/version.json
+++ b/plugins/azure-skills/skills/airunway-aks-setup/version.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.1",
   "pathFilters": ["."]
 }

--- a/plugins/azure-skills/skills/appinsights-instrumentation/version.json
+++ b/plugins/azure-skills/skills/appinsights-instrumentation/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-ai/version.json
+++ b/plugins/azure-skills/skills/azure-ai/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-aigateway/version.json
+++ b/plugins/azure-skills/skills/azure-aigateway/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "3.1",
+  "version": "3.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-app-onboard-prereq/version.json
+++ b/plugins/azure-skills/skills/azure-app-onboard-prereq/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-app-onboard/version.json
+++ b/plugins/azure-skills/skills/azure-app-onboard/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-cloud-migrate/version.json
+++ b/plugins/azure-skills/skills/azure-cloud-migrate/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2",
+  "version": "1.3",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-compliance/version.json
+++ b/plugins/azure-skills/skills/azure-compliance/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-compute/version.json
+++ b/plugins/azure-skills/skills/azure-compute/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.4",
+  "version": "2.5",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-cost/version.json
+++ b/plugins/azure-skills/skills/azure-cost/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2",
+  "version": "1.3",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-deploy/version.json
+++ b/plugins/azure-skills/skills/azure-deploy/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-diagnostics/version.json
+++ b/plugins/azure-skills/skills/azure-diagnostics/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/version.json
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2",
+  "version": "1.3",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-kubernetes/version.json
+++ b/plugins/azure-skills/skills/azure-kubernetes/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-kusto/version.json
+++ b/plugins/azure-skills/skills/azure-kusto/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-messaging/version.json
+++ b/plugins/azure-skills/skills/azure-messaging/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-prepare/version.json
+++ b/plugins/azure-skills/skills/azure-prepare/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2",
+  "version": "1.3",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-quotas/version.json
+++ b/plugins/azure-skills/skills/azure-quotas/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-reliability/version.json
+++ b/plugins/azure-skills/skills/azure-reliability/version.json
@@ -1,1 +1,6 @@
-{"version":"1.0","pathFilters":["."]}
+{
+    "version": "1.1",
+    "pathFilters": [
+        "."
+    ]
+}

--- a/plugins/azure-skills/skills/azure-resource-lookup/version.json
+++ b/plugins/azure-skills/skills/azure-resource-lookup/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-resource-visualizer/version.json
+++ b/plugins/azure-skills/skills/azure-resource-visualizer/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-storage/version.json
+++ b/plugins/azure-skills/skills/azure-storage/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-upgrade/version.json
+++ b/plugins/azure-skills/skills/azure-upgrade/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/azure-validate/version.json
+++ b/plugins/azure-skills/skills/azure-validate/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/entra-agent-id/version.json
+++ b/plugins/azure-skills/skills/entra-agent-id/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/entra-app-registration/version.json
+++ b/plugins/azure-skills/skills/entra-app-registration/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/microsoft-foundry/version.json
+++ b/plugins/azure-skills/skills/microsoft-foundry/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1",
+  "version": "1.2",
   "pathFilters": [
     "."
   ]

--- a/plugins/azure-skills/skills/python-appservice-deploy/version.json
+++ b/plugins/azure-skills/skills/python-appservice-deploy/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0",
+  "version": "1.1",
   "pathFilters": [
     "."
   ]


### PR DESCRIPTION
## Description

Since all the skill are moved and got their git commit history reset, nbgv generated patch numbers get reset to 0. Bumping the minor number allows future versions to be still increasing.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
