### PR TITLE
eval: use tested skill as required skill by default

### DIFF
--- a/tests/vally/vally-executor.ts
+++ b/tests/vally/vally-executor.ts
@@ -37,7 +37,7 @@ export class IntegrationTestAgentRunner implements Executor {
     // Detect the owning plugin of the required skills and construct SkillRef objects for downstream processing
     const plugins = listPlugins();
     const requiredSkillRefs: SkillRef[] = [];
-    requiredSkills?.forEach(skillName => {
+    (requiredSkills ?? [skillName]).forEach(skillName => {
       const owningPlugin = plugins.filter(plugin => plugin.skills.some(skillRef => skillRef.name === skillName)).at(0);
       if (owningPlugin) {
         requiredSkillRefs.push({

--- a/tests/vally/vally-executor.ts
+++ b/tests/vally/vally-executor.ts
@@ -37,12 +37,12 @@ export class IntegrationTestAgentRunner implements Executor {
     // Detect the owning plugin of the required skills and construct SkillRef objects for downstream processing
     const plugins = listPlugins();
     const requiredSkillRefs: SkillRef[] = [];
-    (requiredSkills ?? [skillName]).forEach(skillName => {
-      const owningPlugin = plugins.filter(plugin => plugin.skills.some(skillRef => skillRef.name === skillName)).at(0);
+    (requiredSkills ?? [skillName]).forEach(s => {
+      const owningPlugin = plugins.filter(plugin => plugin.skills.some(skillRef => skillRef.name === s)).at(0);
       if (owningPlugin) {
         requiredSkillRefs.push({
           pluginDirname: owningPlugin.dirname,
-          name: skillName
+          name: s
         });
       }
     });


### PR DESCRIPTION
## Description

Some skills' eval suites don't explicitly define required skills. This change makes the test runner treat the tested skill as the required skill by default. The requiredSkills tag is reserved for situations where the test case requires skills other than the one being tested in the context.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
