### PR TITLE
chore: fix telemetry allowlist sync workflow

### DIFF
--- a/.github/workflows/sync-to-azure-mcp.yml
+++ b/.github/workflows/sync-to-azure-mcp.yml
@@ -42,7 +42,7 @@ jobs:
           PLUGIN_PATHS=()
           for plugin_dir in ../plugins/*; do
             if [ -d "$plugin_dir" ]; then
-              PLUGIN_PATHS+=("$plugin_dir")
+              PLUGIN_PATHS+=("$plugin_dir/skills")
             fi
           done
 


### PR DESCRIPTION
## Description

The 1st argument is supposed to be the skills directory instead of the plugin root.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
