### PR TITLE
chore: specify plugin and skill in foundry and cloud-migrate

### DIFF
--- a/tests/azure-cloud-migrate/integration.test.ts
+++ b/tests/azure-cloud-migrate/integration.test.ts
@@ -97,6 +97,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "azure-cloud-migrate" }],
           setup: async (workspace: string) => {
             workspacePath = workspace;
             await cloneRepo({
@@ -136,6 +137,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
         let workspacePath: string | undefined;
 
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "azure-cloud-migrate" }],
           setup: async (workspace: string) => {
             workspacePath = workspace;
             await cloneRepo({
@@ -170,6 +172,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     test("invokes skill for Spring Boot to ACA migration prompt", async () => {
       await withTestResult(async () => {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "azure-cloud-migrate" }],
           prompt: "I want to migrate my Spring Boot application from Azure Spring Apps to Azure Container Apps. Can you help me assess compatibility and create a migration plan?",
           nonInteractive: true,
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
@@ -183,6 +186,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     test("invokes skill for Spring Boot containerization prompt", async () => {
       await withTestResult(async () => {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "azure-cloud-migrate" }],
           prompt: "How do I containerize my Spring Boot JAR and deploy it to Azure Container Apps?",
           nonInteractive: true,
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
@@ -202,6 +206,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     test("invokes skill for Fargate to Container Apps migration", async () => {
       await withTestResult(async () => {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "azure-cloud-migrate" }],
           prompt:
             "I want to migrate my AWS Fargate ECS tasks to Azure Container Apps. " +
             "Can you help me assess compatibility and create a migration plan?",
@@ -218,6 +223,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     test("invokes skill for ECS to Azure Container Apps migration", async () => {
       await withTestResult(async () => {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "azure-cloud-migrate" }],
           prompt:
             "Migrate my ECS Fargate containers to Azure Container Apps. " +
             "I need to move from AWS to Azure.",
@@ -236,6 +242,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     test("invokes skill for k8s to ACA migration prompt", async () => {
       await withTestResult(async () => {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "azure-cloud-migrate" }],
           prompt: "I want to migrate my Kubernetes workloads from GKE to Azure Container Apps. Can you help me assess compatibility and create a migration plan?",
           nonInteractive: true,
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME),
@@ -249,6 +256,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
     test("invokes skill for k8s manifest conversion", async () => {
       await withTestResult(async () => {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "azure-cloud-migrate" }],
           prompt: "How do I convert my Kubernetes deployment manifests to Azure Container Apps configuration?",
           nonInteractive: true,
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME),

--- a/tests/microsoft-foundry/finetuning/integration.test.ts
+++ b/tests/microsoft-foundry/finetuning/integration.test.ts
@@ -32,7 +32,7 @@ describeIntegration(`${SKILL_NAME}_finetuning - Integration Tests`, () => {
   test("invokes skill for fine-tuning prompt", () =>
     withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Help me fine-tune gpt-4.1-mini on my dataset",
         shouldEarlyTerminate: (metadata) =>
           isSkillInvoked(metadata, SKILL_NAME) ||
@@ -50,7 +50,7 @@ describeIntegration(`${SKILL_NAME}_finetuning - Integration Tests`, () => {
   test("response mentions fine-tuning concepts", () =>
     withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Help me fine-tune gpt-4.1-mini on my dataset",
         shouldEarlyTerminate: (metadata) =>
           isSkillInvoked(metadata, SKILL_NAME) &&
@@ -65,7 +65,7 @@ describeIntegration(`${SKILL_NAME}_finetuning - Integration Tests`, () => {
   test("invokes skill for RFT grader prompt", () =>
     withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt:
           "Submit a reinforcement fine-tuning job with a Python grader",
         shouldEarlyTerminate: (metadata) =>
@@ -78,7 +78,7 @@ describeIntegration(`${SKILL_NAME}_finetuning - Integration Tests`, () => {
   test("invokes skill for SFT distillation prompt", () =>
     withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Distill gpt-4.1-mini into nano using supervised fine-tuning",
         shouldEarlyTerminate: (metadata) =>
           isSkillInvoked(metadata, SKILL_NAME),

--- a/tests/microsoft-foundry/finetuning/integration.test.ts
+++ b/tests/microsoft-foundry/finetuning/integration.test.ts
@@ -32,6 +32,7 @@ describeIntegration(`${SKILL_NAME}_finetuning - Integration Tests`, () => {
   test("invokes skill for fine-tuning prompt", () =>
     withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Help me fine-tune gpt-4.1-mini on my dataset",
         shouldEarlyTerminate: (metadata) =>
           isSkillInvoked(metadata, SKILL_NAME) ||
@@ -49,6 +50,7 @@ describeIntegration(`${SKILL_NAME}_finetuning - Integration Tests`, () => {
   test("response mentions fine-tuning concepts", () =>
     withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Help me fine-tune gpt-4.1-mini on my dataset",
         shouldEarlyTerminate: (metadata) =>
           isSkillInvoked(metadata, SKILL_NAME) &&
@@ -63,6 +65,7 @@ describeIntegration(`${SKILL_NAME}_finetuning - Integration Tests`, () => {
   test("invokes skill for RFT grader prompt", () =>
     withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt:
           "Submit a reinforcement fine-tuning job with a Python grader",
         shouldEarlyTerminate: (metadata) =>
@@ -75,6 +78,7 @@ describeIntegration(`${SKILL_NAME}_finetuning - Integration Tests`, () => {
   test("invokes skill for SFT distillation prompt", () =>
     withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Distill gpt-4.1-mini into nano using supervised fine-tuning",
         shouldEarlyTerminate: (metadata) =>
           isSkillInvoked(metadata, SKILL_NAME),

--- a/tests/microsoft-foundry/foundry-agent/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/integration.test.ts
@@ -40,6 +40,7 @@ describeIntegration(`${SKILL_NAME}_foundry-agent - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Create a new prompt agent with gpt-4o model in Foundry",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -58,6 +59,7 @@ describeIntegration(`${SKILL_NAME}_foundry-agent - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Troubleshoot my Foundry agent that is returning errors",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/foundry-agent/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/integration.test.ts
@@ -40,7 +40,7 @@ describeIntegration(`${SKILL_NAME}_foundry-agent - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Create a new prompt agent with gpt-4o model in Foundry",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -59,7 +59,7 @@ describeIntegration(`${SKILL_NAME}_foundry-agent - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Troubleshoot my Foundry agent that is returning errors",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/foundry-agent/observe/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/observe/integration.test.ts
@@ -23,6 +23,7 @@ describeIntegration(`${SKILL_NAME}_observe - Integration Tests`, () => {
 
   test("invokes skill for evaluate agent prompt", () => withTestResult(async () => {
     const agentMetadata = await agent.run({
+      requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
       prompt: "Evaluate my Foundry agent and check its quality"
     });
 
@@ -32,6 +33,7 @@ describeIntegration(`${SKILL_NAME}_observe - Integration Tests`, () => {
 
   test("invokes skill for agent observability prompt", () => withTestResult(async () => {
     const agentMetadata = await agent.run({
+      requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
       prompt: "Set up monitoring and evaluation for my Foundry agent"
     });
 

--- a/tests/microsoft-foundry/foundry-agent/observe/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/observe/integration.test.ts
@@ -23,7 +23,7 @@ describeIntegration(`${SKILL_NAME}_observe - Integration Tests`, () => {
 
   test("invokes skill for evaluate agent prompt", () => withTestResult(async () => {
     const agentMetadata = await agent.run({
-      requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+      requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
       prompt: "Evaluate my Foundry agent and check its quality"
     });
 
@@ -33,7 +33,7 @@ describeIntegration(`${SKILL_NAME}_observe - Integration Tests`, () => {
 
   test("invokes skill for agent observability prompt", () => withTestResult(async () => {
     const agentMetadata = await agent.run({
-      requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+      requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
       prompt: "Set up monitoring and evaluation for my Foundry agent"
     });
 

--- a/tests/microsoft-foundry/foundry-agent/trace/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/trace/integration.test.ts
@@ -23,6 +23,7 @@ describeIntegration(`${SKILL_NAME}_trace - Integration Tests`, () => {
 
   test("invokes skill for trace analysis prompt", () => withTestResult(async () => {
     const agentMetadata = await agent.run({
+      requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
       prompt: "Analyze traces for my Foundry agent in App Insights"
     });
 
@@ -32,6 +33,7 @@ describeIntegration(`${SKILL_NAME}_trace - Integration Tests`, () => {
 
   test("invokes skill for failing traces prompt", () => withTestResult(async () => {
     const agentMetadata = await agent.run({
+      requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
       prompt: "Find failing traces and errors for my Foundry agent"
     });
 

--- a/tests/microsoft-foundry/foundry-agent/trace/integration.test.ts
+++ b/tests/microsoft-foundry/foundry-agent/trace/integration.test.ts
@@ -23,7 +23,7 @@ describeIntegration(`${SKILL_NAME}_trace - Integration Tests`, () => {
 
   test("invokes skill for trace analysis prompt", () => withTestResult(async () => {
     const agentMetadata = await agent.run({
-      requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+      requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
       prompt: "Analyze traces for my Foundry agent in App Insights"
     });
 
@@ -33,7 +33,7 @@ describeIntegration(`${SKILL_NAME}_trace - Integration Tests`, () => {
 
   test("invokes skill for failing traces prompt", () => withTestResult(async () => {
     const agentMetadata = await agent.run({
-      requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+      requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
       prompt: "Find failing traces and errors for my Foundry agent"
     });
 

--- a/tests/microsoft-foundry/integration.test.ts
+++ b/tests/microsoft-foundry/integration.test.ts
@@ -41,7 +41,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "How do I deploy an AI model from the Microsoft Foundry catalog?",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -60,7 +60,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Build a RAG application with Microsoft Foundry using knowledge indexes",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -79,7 +79,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Grant a user the Foundry User role on my Foundry project",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -98,7 +98,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Create a service principal for my Foundry CI/CD pipeline",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -117,7 +117,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Set up managed identity roles for my Foundry project to access Azure Storage",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -136,7 +136,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Who has access to my Foundry project? List all role assignments",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -155,7 +155,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Make Bob a project manager in my Azure AI Foundry",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -174,7 +174,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Can I deploy models to my Foundry project? Check my permissions",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -193,7 +193,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Help me build and deploy a Foundry agent",
           shouldEarlyTerminate: (metadata) =>
             isSkillInvoked(metadata, SKILL_NAME),
@@ -213,7 +213,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Create an evaluation dataset from my Foundry agent traces",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -232,7 +232,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Version my Foundry evaluation dataset and compare regressions",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/integration.test.ts
+++ b/tests/microsoft-foundry/integration.test.ts
@@ -41,6 +41,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "How do I deploy an AI model from the Microsoft Foundry catalog?",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -59,6 +60,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Build a RAG application with Microsoft Foundry using knowledge indexes",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -77,6 +79,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Grant a user the Foundry User role on my Foundry project",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -95,6 +98,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Create a service principal for my Foundry CI/CD pipeline",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -113,6 +117,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Set up managed identity roles for my Foundry project to access Azure Storage",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -131,6 +136,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Who has access to my Foundry project? List all role assignments",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -149,6 +155,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Make Bob a project manager in my Azure AI Foundry",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -167,6 +174,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Can I deploy models to my Foundry project? Check my permissions",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -185,6 +193,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Help me build and deploy a Foundry agent",
           shouldEarlyTerminate: (metadata) =>
             isSkillInvoked(metadata, SKILL_NAME),
@@ -204,6 +213,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Create an evaluation dataset from my Foundry agent traces",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -222,6 +232,7 @@ describeIntegration(`${SKILL_NAME}_ - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Version my Foundry evaluation dataset and compare regressions",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/models/deploy/capacity/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/capacity/integration.test.ts
@@ -39,7 +39,7 @@ describeIntegration(`${SKILL_NAME}_capacity - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Find available capacity for gpt-4o across all Azure regions",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -58,7 +58,7 @@ describeIntegration(`${SKILL_NAME}_capacity - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Which Azure regions have gpt-4o available with enough TPM capacity?",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/models/deploy/capacity/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/capacity/integration.test.ts
@@ -39,6 +39,7 @@ describeIntegration(`${SKILL_NAME}_capacity - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Find available capacity for gpt-4o across all Azure regions",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -57,6 +58,7 @@ describeIntegration(`${SKILL_NAME}_capacity - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Which Azure regions have gpt-4o available with enough TPM capacity?",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/models/deploy/customize-deployment/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/customize-deployment/integration.test.ts
@@ -39,7 +39,7 @@ describeIntegration(`${SKILL_NAME}_customize-deployment - Integration Tests`, ()
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Deploy gpt-4o with custom SKU and capacity configuration",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -58,7 +58,7 @@ describeIntegration(`${SKILL_NAME}_customize-deployment - Integration Tests`, ()
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Deploy gpt-4o with provisioned throughput PTU in my Foundry project",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/models/deploy/customize-deployment/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/customize-deployment/integration.test.ts
@@ -39,6 +39,7 @@ describeIntegration(`${SKILL_NAME}_customize-deployment - Integration Tests`, ()
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Deploy gpt-4o with custom SKU and capacity configuration",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -57,6 +58,7 @@ describeIntegration(`${SKILL_NAME}_customize-deployment - Integration Tests`, ()
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Deploy gpt-4o with provisioned throughput PTU in my Foundry project",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/models/deploy/deploy-model-optimal-region/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/deploy-model-optimal-region/integration.test.ts
@@ -39,6 +39,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model-optimal-region - Integration Tes
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Deploy gpt-4o quickly to the optimal region",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -57,6 +58,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model-optimal-region - Integration Tes
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Deploy gpt-4o to the best available region with high availability",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/models/deploy/deploy-model-optimal-region/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/deploy-model-optimal-region/integration.test.ts
@@ -39,7 +39,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model-optimal-region - Integration Tes
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Deploy gpt-4o quickly to the optimal region",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -58,7 +58,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model-optimal-region - Integration Tes
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Deploy gpt-4o to the best available region with high availability",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/models/deploy/deploy-model/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/deploy-model/integration.test.ts
@@ -39,6 +39,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Deploy gpt-4o model to my Azure project",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -57,6 +58,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Where can I deploy gpt-4o? Check capacity across regions",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -75,6 +77,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
+          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
           prompt: "Deploy gpt-4o with custom SKU and capacity settings",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/models/deploy/deploy-model/integration.test.ts
+++ b/tests/microsoft-foundry/models/deploy/deploy-model/integration.test.ts
@@ -39,7 +39,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Deploy gpt-4o model to my Azure project",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -58,7 +58,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Where can I deploy gpt-4o? Check capacity across regions",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });
@@ -77,7 +77,7 @@ describeIntegration(`${SKILL_NAME}_deploy-model - Integration Tests`, () => {
       let invocationCount = 0;
       for (let i = 0; i < RUNS_PER_PROMPT; i++) {
         const agentMetadata = await agent.run({
-          requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+          requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
           prompt: "Deploy gpt-4o with custom SKU and capacity settings",
           shouldEarlyTerminate: (metadata) => shouldEarlyTerminateForSkillInvocation(metadata, SKILL_NAME)
         });

--- a/tests/microsoft-foundry/quota/integration.test.ts
+++ b/tests/microsoft-foundry/quota/integration.test.ts
@@ -40,7 +40,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("View Quota Usage", () => {
     test("invokes skill for quota usage check", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Use the microsoft-foundry skill to show me my current quota usage for Microsoft Foundry resources"
       });
 
@@ -50,7 +50,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("response includes quota-related commands", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "How do I check my Azure AI Foundry quota limits?"
       });
 
@@ -66,7 +66,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("response mentions TPM (Tokens Per Minute)", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Explain quota in Microsoft Foundry"
       });
 
@@ -84,7 +84,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Quota Before Deployment", () => {
     test("provides guidance on checking quota before deployment", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Use the microsoft-foundry skill to check if I have enough quota to deploy GPT-4o to Microsoft Foundry"
       });
 
@@ -103,7 +103,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("suggests capacity calculation", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "How much quota do I need for a production Foundry deployment?"
       });
 
@@ -144,7 +144,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Request Quota Increase", () => {
     test("explains quota increase process", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Using the microsoft-foundry quota skill, how do I request a quota increase for Microsoft Foundry?"
       });
 
@@ -164,7 +164,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("mentions business justification", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Request more TPM quota for Azure AI Foundry and explain what justification is needed"
       });
 
@@ -189,7 +189,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Monitor Quota Across Deployments", () => {
     test("provides monitoring commands", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Use the microsoft-foundry quota skill to monitor quota usage across all my Microsoft Foundry deployments"
       });
 
@@ -211,7 +211,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("explains capacity by model tracking", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Show me quota allocation by model in Azure AI Foundry"
       });
 
@@ -235,7 +235,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Troubleshoot Quota Errors", () => {
     test("troubleshoots QuotaExceeded error", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "My Microsoft Foundry deployment failed with QuotaExceeded error. Help me fix it."
       });
 
@@ -254,7 +254,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("troubleshoots InsufficientQuota error", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "I'm getting an InsufficientQuota error when deploying gpt-4o to eastus in Azure AI Foundry. Use the microsoft-foundry skill to help me troubleshoot and fix this."
       });
 
@@ -264,7 +264,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("troubleshoots DeploymentLimitReached error", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "DeploymentLimitReached error in Microsoft Foundry, what should I do?"
       });
 
@@ -280,7 +280,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("addresses 429 rate limit errors", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Getting 429 rate limit errors from my Foundry deployment"
       });
 
@@ -298,7 +298,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Capacity Planning", () => {
     test("helps with production capacity planning", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Help me plan capacity for production Microsoft Foundry deployment with 1M requests per day"
       });
 
@@ -340,7 +340,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("provides best practices", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "What are best practices for quota management in Azure AI Foundry?"
       });
 
@@ -358,7 +358,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Deployment Listing", () => {
     test("lists deployments using MCP tools or CLI", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Use the microsoft-foundry skill to list all my Microsoft Foundry model deployments and their capacity"
       });
 
@@ -384,7 +384,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Regional Capacity", () => {
     test("explains regional quota distribution", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Using the microsoft-foundry quota skill, explain how quota works across different Azure regions for Foundry"
       });
 
@@ -400,7 +400,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("suggests deploying to different region when quota exhausted", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "I ran out of quota in East US for Microsoft Foundry. What are my options?"
       });
 
@@ -418,7 +418,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Quota Optimization", () => {
     test("provides optimization guidance", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "How can I optimize my Microsoft Foundry quota allocation?"
       });
 
@@ -437,7 +437,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("suggests deleting unused deployments", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "I need to free up quota in Azure AI Foundry"
       });
 
@@ -455,7 +455,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Command Output Explanation", () => {
     test("explains how to interpret quota usage output", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "What does the quota usage output mean in Microsoft Foundry?"
       });
 
@@ -471,7 +471,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("explains TPM concept", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "What is TPM in the context of Microsoft Foundry quotas?"
       });
 
@@ -489,7 +489,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Error Resolution Steps", () => {
     test("provides step-by-step resolution for quota errors", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "Walk me through fixing a quota error in Microsoft Foundry deployment"
       });
 
@@ -508,7 +508,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("offers multiple resolution options", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
-        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
+        requiredSkills: [{ pluginDirname: "azure-skills", name: SKILL_NAME }],
         prompt: "What are my options when I hit quota limits in Azure AI Foundry?"
       });
 

--- a/tests/microsoft-foundry/quota/integration.test.ts
+++ b/tests/microsoft-foundry/quota/integration.test.ts
@@ -40,6 +40,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("View Quota Usage", () => {
     test("invokes skill for quota usage check", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Use the microsoft-foundry skill to show me my current quota usage for Microsoft Foundry resources"
       });
 
@@ -49,6 +50,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("response includes quota-related commands", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "How do I check my Azure AI Foundry quota limits?"
       });
 
@@ -64,6 +66,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("response mentions TPM (Tokens Per Minute)", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Explain quota in Microsoft Foundry"
       });
 
@@ -81,6 +84,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Quota Before Deployment", () => {
     test("provides guidance on checking quota before deployment", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Use the microsoft-foundry skill to check if I have enough quota to deploy GPT-4o to Microsoft Foundry"
       });
 
@@ -99,6 +103,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("suggests capacity calculation", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "How much quota do I need for a production Foundry deployment?"
       });
 
@@ -139,6 +144,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Request Quota Increase", () => {
     test("explains quota increase process", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Using the microsoft-foundry quota skill, how do I request a quota increase for Microsoft Foundry?"
       });
 
@@ -158,6 +164,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("mentions business justification", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Request more TPM quota for Azure AI Foundry and explain what justification is needed"
       });
 
@@ -182,6 +189,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Monitor Quota Across Deployments", () => {
     test("provides monitoring commands", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Use the microsoft-foundry quota skill to monitor quota usage across all my Microsoft Foundry deployments"
       });
 
@@ -203,6 +211,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("explains capacity by model tracking", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Show me quota allocation by model in Azure AI Foundry"
       });
 
@@ -226,6 +235,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Troubleshoot Quota Errors", () => {
     test("troubleshoots QuotaExceeded error", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "My Microsoft Foundry deployment failed with QuotaExceeded error. Help me fix it."
       });
 
@@ -244,6 +254,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("troubleshoots InsufficientQuota error", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "I'm getting an InsufficientQuota error when deploying gpt-4o to eastus in Azure AI Foundry. Use the microsoft-foundry skill to help me troubleshoot and fix this."
       });
 
@@ -253,6 +264,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("troubleshoots DeploymentLimitReached error", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "DeploymentLimitReached error in Microsoft Foundry, what should I do?"
       });
 
@@ -268,6 +280,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("addresses 429 rate limit errors", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Getting 429 rate limit errors from my Foundry deployment"
       });
 
@@ -285,6 +298,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Capacity Planning", () => {
     test("helps with production capacity planning", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Help me plan capacity for production Microsoft Foundry deployment with 1M requests per day"
       });
 
@@ -326,6 +340,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("provides best practices", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "What are best practices for quota management in Azure AI Foundry?"
       });
 
@@ -343,6 +358,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Deployment Listing", () => {
     test("lists deployments using MCP tools or CLI", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Use the microsoft-foundry skill to list all my Microsoft Foundry model deployments and their capacity"
       });
 
@@ -368,6 +384,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Regional Capacity", () => {
     test("explains regional quota distribution", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Using the microsoft-foundry quota skill, explain how quota works across different Azure regions for Foundry"
       });
 
@@ -383,6 +400,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("suggests deploying to different region when quota exhausted", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "I ran out of quota in East US for Microsoft Foundry. What are my options?"
       });
 
@@ -400,6 +418,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Quota Optimization", () => {
     test("provides optimization guidance", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "How can I optimize my Microsoft Foundry quota allocation?"
       });
 
@@ -418,6 +437,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("suggests deleting unused deployments", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "I need to free up quota in Azure AI Foundry"
       });
 
@@ -435,6 +455,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Command Output Explanation", () => {
     test("explains how to interpret quota usage output", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "What does the quota usage output mean in Microsoft Foundry?"
       });
 
@@ -450,6 +471,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("explains TPM concept", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "What is TPM in the context of Microsoft Foundry quotas?"
       });
 
@@ -467,6 +489,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
   describe("Error Resolution Steps", () => {
     test("provides step-by-step resolution for quota errors", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "Walk me through fixing a quota error in Microsoft Foundry deployment"
       });
 
@@ -485,6 +508,7 @@ describeIntegration(`${SKILL_NAME}_quota - Integration Tests`, () => {
 
     test("offers multiple resolution options", () => withTestResult(async () => {
       const agentMetadata = await agent.run({
+        requiredSkills: [{ pluginDirname: "azure-skills", name: "microsoft-foundry" }],
         prompt: "What are my options when I hit quota limits in Azure AI Foundry?"
       });
 


### PR DESCRIPTION
## Description

As a part of the plugin folder restructure, test runs need to declare which skill/plugin it depends on instead of assuming the azure plugin will be loaded. This PR makes microsoft-foundry and azure-cloud-migrate integration tests to tell the runner what skill they depend on so they can be loaded into the context.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
