### PR TITLE
chore: fix aggregated test report

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -305,7 +305,9 @@ jobs:
         id: generate-skill-report
         env:
           SKILL: ${{ matrix.skill }}
-        run: npm run report -- --skill "$SKILL" || true
+        run: |
+          SKILL_NAME="${SKILL##*/}"
+          npm run report -- --skill "$SKILL_NAME" || true
 
       - name: Show skill report
         if: always()


### PR DESCRIPTION
## Description

Fix the aggregated test report generation by giving the correct skill name parsed from plugin/skill string.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
