### PR TITLE
fix: persist skill eval artifacts

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -93,3 +93,13 @@ jobs:
             --threshold 0.8
         env:
           COPILOT_GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Upload Vally results
+        if: always()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: skill-eval-results
+          path: |
+            tests/results/
+            tests/reports/
+          retention-days: 30


### PR DESCRIPTION
## Summary
- upload Vally results and reports from the skill evaluation workflow
- run artifact upload even when an eval misses its threshold
- retain artifacts for 30 days for ghtex trajectory analysis