### PR TITLE
chore: add azure-app-onboard(-prereq) code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -80,6 +80,8 @@
 /plugins/azure-skills/skills/microsoft-foundry/foundry-agent/routine/ @anchenyi @XiaofuHuang @swatDong @RickWinter
 /plugins/azure-skills/skills/microsoft-foundry/foundry-agent/invocations-ws/ @anchenyi @XiaofuHuang @swatDong @RickWinter
 /plugins/azure-skills/skills/python-appservice-deploy/ @glaming1 @tmeschter @RickWinter
+/plugins/azure-skills/skills/azure-app-onboard/ @vaibbavis @samcdonald-ms @RickWinter
+/plugins/azure-skills/skills/azure-app-onboard-prereq/ @vaibbavis @samcdonald-ms @RickWinter
 
 # Plugin skills tests owners (multi-plugin)
 /tests/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter


### PR DESCRIPTION
## Description

Add azure-app-onboard and azure-app-onboard-prereq code owners.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

fixes #3016 
