### PR TITLE
docs: require executable shell scripts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -182,6 +182,7 @@ Some skills ship helper scripts (under a skill's `scripts/` or `references/**/sc
 ### Bash Scripts
 
 - **Target Bash 3.2** (macOS default) — do not assume Bash 4+. Avoid `declare -A` (associative arrays), `mapfile`, and similar. Use portable alternatives like `while IFS= read -r` loops and small `grep`/`sed` helpers. Use `#!/usr/bin/env bash`.
+- **Mark every shebang-bearing `.sh` script executable in Git** with `git update-index --chmod=+x <path-to-script>`.
 - **Never use `eval`** to run a command string (injection risk + brittle quoting). Pass the command as arguments and invoke via `"$@"`, or pass a function name.
 - **With `set -e`, capture command output via command substitution** (`OUT=$(cmd ...)`), not process substitution (`done < <(cmd ...)`), so a failing command reliably aborts instead of producing a misleading downstream error.
 - **Use fixed-string grep (`grep -F`/`-Fq`) for literal matches** and handle grep's read-error exit code (`2`) explicitly — don't let it be treated as "no match".
@@ -216,6 +217,7 @@ PRs against `main` must pass these checks — run the corresponding local comman
 | Skill Structure | Frontmatter, `tests/skills.json` sync, markdown references | `npm run build && cd scripts && npm run frontmatter && npm run references` |
 | Plugin Version Check | `plugin.json` versions remain `0.0.0-placeholder` | Ensure you never edit version fields |
 | Skill Tests | Unit and trigger tests for changed skills | `cd tests && npm test` |
+| Shell Scripts | Shebang-bearing `.sh` files are executable in Git | `npm run check:shell-scripts` |
 
 ## Commit and PR Conventions
 


### PR DESCRIPTION
This PR contains only contributor guidance changes for executable shell scripts.

- Require every shebang-bearing `.sh` script to be marked executable in Git.
- Document `npm run check:shell-scripts` in the PR validation table.

Related to #2958