### PR TITLE
fix: switch to managed identity for dashboard

### DIFF
--- a/dashboard/infra/main.bicep
+++ b/dashboard/infra/main.bicep
@@ -101,6 +101,7 @@ module functionApp './modules/function-app.bicep' = {
     environmentName: environmentName
     userAssignedIdentityId: identity.outputs.identityId
     userAssignedIdentityClientId: identity.outputs.identityClientId
+    userAssignedIdentityPrincipalId: identity.outputs.identityPrincipalId
     storageAccountName: storage.outputs.storageAccountName
     tokenUsageTableName: storage.outputs.tokenUsageTableName
     toolUsageTableName: storage.outputs.toolUsageTableName
@@ -119,6 +120,7 @@ module syncFunctionApp './modules/sync-function-app.bicep' = {
     environmentName: environmentName
     userAssignedIdentityId: syncIdentity.outputs.identityId
     userAssignedIdentityClientId: syncIdentity.outputs.identityClientId
+    userAssignedIdentityPrincipalId: syncIdentity.outputs.identityPrincipalId
     msbenchStorageAccountName: msbenchStorageAccountName
     msbenchEvalTableName: msbenchEvalTableName
     msbenchReportsContainerName: msbenchReportsContainerName

--- a/dashboard/infra/modules/function-app.bicep
+++ b/dashboard/infra/modules/function-app.bicep
@@ -15,6 +15,9 @@ param userAssignedIdentityId string
 @description('Client ID of the user-assigned managed identity.')
 param userAssignedIdentityClientId string
 
+@description('Principal ID of the user-assigned managed identity.')
+param userAssignedIdentityPrincipalId string
+
 @description('Name of the storage account for integration reports.')
 param storageAccountName string
 
@@ -59,6 +62,19 @@ resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/con
   name: 'deploymentpackage'
 }
 
+resource deploymentStorageBlobDataContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, userAssignedIdentityPrincipalId, 'Storage Blob Data Contributor')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+    )
+    principalId: userAssignedIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: 'plan-${environmentName}-${resourceSuffix}'
   location: location
@@ -92,8 +108,8 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           type: 'blobContainer'
           value: '${storageAccount.properties.primaryEndpoints.blob}deploymentpackage'
           authentication: {
-            type: 'StorageAccountConnectionString'
-            storageAccountConnectionStringName: 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
+            type: 'UserAssignedIdentity'
+            userAssignedIdentityResourceId: userAssignedIdentityId
           }
         }
       }
@@ -109,12 +125,16 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
     siteConfig: {
       appSettings: [
         {
-          name: 'AzureWebJobsStorage'
-          value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+          name: 'AzureWebJobsStorage__blobServiceUri'
+          value: 'https://${storageAccount.name}.blob.${environment().suffixes.storage}'
         }
         {
-          name: 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
-          value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+          name: 'AzureWebJobsStorage__credential'
+          value: 'managedidentity'
+        }
+        {
+          name: 'AzureWebJobsStorage__clientId'
+          value: userAssignedIdentityId
         }
         { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
         { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }

--- a/dashboard/infra/modules/sync-function-app.bicep
+++ b/dashboard/infra/modules/sync-function-app.bicep
@@ -15,6 +15,9 @@ param userAssignedIdentityId string
 @description('Client ID of the user-assigned managed identity for the sync function.')
 param userAssignedIdentityClientId string
 
+@description('Principal ID of the user-assigned managed identity for the sync function.')
+param userAssignedIdentityPrincipalId string
+
 @description('Name of the existing MSBench nightly data storage account.')
 param msbenchStorageAccountName string
 
@@ -50,6 +53,19 @@ resource deploymentContainer 'Microsoft.Storage/storageAccounts/blobServices/con
   name: 'deploymentpackage'
 }
 
+resource deploymentStorageBlobDataContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, userAssignedIdentityPrincipalId, 'Storage Blob Data Contributor')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+    )
+    principalId: userAssignedIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
 resource hostingPlan 'Microsoft.Web/serverfarms@2024-04-01' = {
   name: 'plan-${environmentName}-sync-${resourceSuffix}'
   location: location
@@ -83,8 +99,8 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
           type: 'blobContainer'
           value: '${storageAccount.properties.primaryEndpoints.blob}deploymentpackage'
           authentication: {
-            type: 'StorageAccountConnectionString'
-            storageAccountConnectionStringName: 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
+            type: 'UserAssignedIdentity'
+            userAssignedIdentityResourceId: userAssignedIdentityId
           }
         }
       }
@@ -101,10 +117,6 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
       appSettings: [
         {
           name: 'AzureWebJobsStorage'
-          value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
-        }
-        {
-          name: 'DEPLOYMENT_STORAGE_CONNECTION_STRING'
           value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
         }
         { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }

--- a/dashboard/infra/modules/sync-function-app.bicep
+++ b/dashboard/infra/modules/sync-function-app.bicep
@@ -116,8 +116,16 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
     siteConfig: {
       appSettings: [
         {
-          name: 'AzureWebJobsStorage'
-          value: 'DefaultEndpointsProtocol=https;AccountName=${storageAccount.name};EndpointSuffix=${environment().suffixes.storage};AccountKey=${storageAccount.listKeys().keys[0].value}'
+          name: 'AzureWebJobsStorage__blobServiceUri'
+          value: 'https://${storageAccount.name}.blob.${environment().suffixes.storage}'
+        }
+        {
+          name: 'AzureWebJobsStorage__credential'
+          value: 'managedidentity'
+        }
+        {
+          name: 'AzureWebJobsStorage__clientId'
+          value: userAssignedIdentityId
         }
         { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
         { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }


### PR DESCRIPTION
## Description

Use managed identity for the dashboard's function app since we disabled local auth.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
