### PR TITLE
chore: add CODEOWNERS entry for azure-kubernetes evals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -87,4 +87,5 @@
 /tests/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter
 
 # Plugin skills evals owners (multi-plugin)
+/evals/azure-skills/azure-kubernetes/ @saikoumudi @chandraneel @gambtho @RickWinter
 /evals/azure-skills/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter


### PR DESCRIPTION
## What

Adds one line to `.github/CODEOWNERS`:

```
/evals/azure-skills/azure-kubernetes/ @saikoumudi @chandraneel @gambtho @RickWinter
```

## Why

The azure-kubernetes eval suite currently has no scoped owner. The only `/evals/` entry is for `microsoft-foundry`, so everything under `evals/azure-skills/azure-kubernetes/` falls through to the default `*` owner, @microsoft/github-copilot-for-azure-writers.

Combined with the org ruleset's `require_code_owner_review`, that means any PR touching both a skill and its evals needs two separate approvals — an AKS owner for the skill files, plus a writers-team member for the eval files — even when the eval change is a small fixture shipping alongside the skill.

#2696 is a live example: 44 skill files approved by an AKS codeowner, blocked on 3 eval fixture files.

## Notes

- Owner list is copied verbatim from the existing `/plugins/azure-skills/skills/azure-kubernetes/` entry, so this grants nothing new — the same four people already own the skill these evals cover.
- Mirrors the established `/evals/azure-skills/microsoft-foundry/` pattern.
- Placed before the `microsoft-foundry` line to keep the block alphabetical. The patterns don't overlap, so ordering has no effect on resolution.
- No other CODEOWNERS changes. The stale `/plugin/skills/` block (lines 10–45, pointing at paths deleted in the multi-plugin restructure) is inert and left alone — happy to clean it up separately if wanted.