### PR TITLE
eval: fix skill file report

### DIFF
--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -377,7 +377,10 @@ function computeToolAndSkillStats(
         }
       }
       if (skillName) {
-        const normalizedSkillDir = normalizedSkillDirs.filter(dir => dir.endsWith(`${skillName}/SKILLS.md`)).at(0);
+        const normalizedSkillDir = normalizedSkillDirs.filter(dir => {
+          const skillMdPath = path.resolve(dir, `${skillName}/SKILL.md`);
+          return fs.existsSync(skillMdPath);
+        }).at(0);
         (skillFilesSet[skillName] ??= new Set()).add(`${normalizedSkillDir}/${skillName}/SKILL.md`);
       }
     }


### PR DESCRIPTION
## Description

Fix the bug causing the reported skill.md path to contain `undefined` as the prefix.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
