### PR TITLE
feature: extend telemetry for new plugins

### DIFF
--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -74,11 +74,17 @@
 #     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
 #     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
 #
-#   Recognized azure-skills install paths:
+#   Recognized install paths (one set per plugin, see $pathPatterns below):
+#     azure-skills:
 #     - .copilot/installed-plugins/azure-skills/azure/skills/...
 #     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
 #     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
 #     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
+#     azure-kusto-graph-skills:
+#     - .copilot/installed-plugins/azure-skills/azure-kusto-graph-skills/skills/...
+#     - .claude/plugins/cache/azure-skills/azure-kusto-graph-skills/<version>/skills/...
+#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/...
+#     shared:
 #     - .agents/skills/...
 #
 #   If the path matches AND is not a SKILL.md file, the relative path after
@@ -268,14 +274,29 @@ function Get-ToolInputPath {
 
 # === STEP 2: Determine what to track for azmcp ===
 
-# Azure-skills path patterns per client (used for SKILL.md and file-reference matching)
+# Path patterns per client, one block per plugin (used for SKILL.md and
+# file-reference matching). Add a new block (with the "azure-skills"
+# segments swapped for the new plugin's name) when onboarding another plugin.
+
+# --- azure-skills plugin ---
 $pathPatternCopilot = '\.copilot/installed-plugins/azure-skills/azure/skills/'
 $pathPatternClaude = '\.claude/plugins/cache/(azure-skills|claude-plugins-official)/azure/[0-9.]+/skills/'
 $pathPatternVscodeAgentPlugins = 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-skills/skills/'
+
+# --- azure-kusto-graph-skills plugin ---
+$pathPatternCopilotKustoGraph = '\.copilot/installed-plugins/azure-skills/azure-kusto-graph-skills/skills/'
+$pathPatternClaudeKustoGraph = '\.claude/plugins/cache/azure-skills/azure-kusto-graph-skills/[0-9.]+/skills/'
+$pathPatternVscodeAgentPluginsKustoGraph = 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-kusto-graph-skills/skills/'
+
+# --- shared across all plugins ---
 $pathPatternAgentsSkills = '\.agents/skills/'
 
 # Put the path patterns into an array for easier iteration
-$pathPatterns = @($pathPatternCopilot, $pathPatternClaude, $pathPatternVscodeAgentPlugins, $pathPatternAgentsSkills)
+$pathPatterns = @(
+    $pathPatternCopilot, $pathPatternClaude, $pathPatternVscodeAgentPlugins,
+    $pathPatternCopilotKustoGraph, $pathPatternClaudeKustoGraph, $pathPatternVscodeAgentPluginsKustoGraph,
+    $pathPatternAgentsSkills
+)
 
 # If $env:AZURE_SKILLS_PLUGIN_ROOT is set, add it to the path patterns for local skill development
 if ($env:AZURE_SKILLS_PLUGIN_ROOT) {

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -76,11 +76,18 @@
 #     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
 #     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
 #
-#   Recognized azure-skills install paths:
+#   Recognized install paths (one set per plugin, see is_azure_skills_path):
+#     azure-skills:
 #     - .copilot/installed-plugins/azure-skills/azure/skills/...
 #     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
 #     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
 #     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
+#     azure-kusto-graph-skills:
+#     - .copilot/installed-plugins/azure-kusto-graph-skills/azure-kusto-graph-skills/skills/...
+#     - .claude/plugins/cache/azure-kusto-graph-skills/azure-kusto-graph-skills/<version>/skills/...
+#     - .claude/plugins/cache/claude-plugins-official/azure-kusto-graph-skills/<version>/skills/...
+#     - .vscode/agent-plugins/github.com/microsoft/azure-kusto-graph-skills/.github/plugins/azure-kusto-graph-skills/skills/...
+#     shared:
 #     - .agents/skills/...
 #
 #   If the path matches AND is not a SKILL.md file, the relative path after
@@ -275,15 +282,27 @@ fi
 
 # === STEP 2: Determine what to track for azmcp ===
 
-# Check if a path matches any known azure-skills folder structure
-# Returns 0 (true) if matched, 1 (false) otherwise
+# Check if a path matches any known plugin skills folder structure.
+# Each plugin has its own block below — add a new block (with the
+# "azure-skills" segments swapped for the new plugin's name) when onboarding
+# another plugin. Returns 0 (true) if matched, 1 (false) otherwise.
 is_azure_skills_path() {
     local p="$1"
+
+    # --- azure-skills plugin ---
     [[ "$p" == *".copilot/installed-plugins/azure-skills/azure/skills/"* ]] && return 0
     [[ "$p" == *".claude/plugins/cache/azure-skills/azure/"*"/skills/"* ]] && return 0
     [[ "$p" == *".claude/plugins/cache/claude-plugins-official/azure/"*"/skills/"* ]] && return 0
     [[ "$p" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/"* ]] && return 0
+
+    # --- azure-kusto-graph-skills plugin ---
+    [[ "$p" == *".copilot/installed-plugins/azure-skills/azure-kusto-graph-skills/skills/"* ]] && return 0
+    [[ "$p" == *".claude/plugins/cache/azure-skills/azure-kusto-graph-skills/"*"/skills/"* ]] && return 0
+    [[ "$p" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/"* ]] && return 0
+
+    # --- shared across all plugins ---
     [[ "$p" == *".agents/skills/"* ]] && return 0
+
     # Local plugin development: match paths under AZURE_SKILLS_PLUGIN_ROOT/skills/
     # (e.g. when loading a local plugin via `--plugin-dir`)
     if [ -n "$AZURE_SKILLS_PLUGIN_ROOT" ]; then

--- a/scripts/src/generate-mcp-allowlists.ts
+++ b/scripts/src/generate-mcp-allowlists.ts
@@ -43,42 +43,50 @@ function walkDir(dir: string): string[] {
   return results;
 }
 
-function generateAllowlists(skillsDir: string, outputDir: string): void {
-  if (!fs.existsSync(skillsDir) || !fs.statSync(skillsDir).isDirectory()) {
-    console.error(`ERROR: skills directory not found: ${skillsDir}`);
-    process.exit(1);
-  }
-
-  // Get sorted list of skill directory names (exclude hidden directories)
-  const skillNames = fs
-    .readdirSync(skillsDir, { withFileTypes: true })
-    .filter((e) => e.isDirectory() && !e.name.startsWith("."))
-    .map((e) => e.name)
-    .sort();
-
-  if (skillNames.length === 0) {
-    console.error(
-      `ERROR: No skills found in ${skillsDir} - aborting to prevent empty sync`
-    );
-    process.exit(1);
-  }
-
-  // Collect all reference file paths (Windows-style backslash separators).
-  // Exclude SKILL.md, version.json, and license files.
+function generateAllowlists(skillsDirs: string[], outputDir: string): void {
+  const allSkillNames: string[] = [];
   const referenceFiles: string[] = [];
-  for (const skill of skillNames) {
-    const skillPath = path.join(skillsDir, skill);
-    for (const filePath of walkDir(skillPath)) {
-      const filename = path.basename(filePath);
-      if (EXCLUDED_FILENAMES.has(filename)) {
-        continue;
+
+  for (const skillsDir of skillsDirs) {
+    if (!fs.existsSync(skillsDir) || !fs.statSync(skillsDir).isDirectory()) {
+      console.error(`ERROR: skills directory not found: ${skillsDir}`);
+      process.exit(1);
+    }
+
+    // Get sorted list of skill directory names (exclude hidden directories)
+    const skillNames = fs
+      .readdirSync(skillsDir, { withFileTypes: true })
+      .filter((e) => e.isDirectory() && !e.name.startsWith("."))
+      .map((e) => e.name)
+      .sort();
+
+    if (skillNames.length === 0) {
+      console.error(
+        `ERROR: No skills found in ${skillsDir} - aborting to prevent empty sync`
+      );
+      process.exit(1);
+    }
+
+    allSkillNames.push(...skillNames);
+
+    // Collect all reference file paths (Windows-style backslash separators).
+    // Exclude SKILL.md, version.json, and license files.
+    for (const skill of skillNames) {
+      const skillPath = path.join(skillsDir, skill);
+      for (const filePath of walkDir(skillPath)) {
+        const filename = path.basename(filePath);
+        if (EXCLUDED_FILENAMES.has(filename)) {
+          continue;
+        }
+        const relPath = path
+          .relative(skillsDir, filePath)
+          .replace(/\//g, "\\");
+        referenceFiles.push(relPath);
       }
-      const relPath = path
-        .relative(skillsDir, filePath)
-        .replace(/\//g, "\\");
-      referenceFiles.push(relPath);
     }
   }
+
+  const skillNames = [...new Set(allSkillNames)].sort();
 
   // Sort globally to guarantee stable lexicographic ordering
   referenceFiles.sort();
@@ -101,17 +109,17 @@ function generateAllowlists(skillsDir: string, outputDir: string): void {
 
 function main(): void {
   const args = process.argv.slice(2);
-  if (args.length < 1 || args.length > 2) {
+  if (args.length < 2) {
     console.error(
-      "Usage: node generate-mcp-allowlists.ts <skills_dir> [output_dir]"
+      "Usage: node generate-mcp-allowlists.ts <skills_dir_1> ... <skills_dir_N> <output_dir>"
     );
     process.exit(1);
   }
 
-  const skillsDir = path.resolve(args[0]);
-  const outputDir = args[1] ? path.resolve(args[1]) : process.cwd();
+  const outputDir = path.resolve(args[args.length - 1]);
+  const skillsDirs = args.slice(0, -1).map((dir) => path.resolve(dir));
 
-  generateAllowlists(skillsDir, outputDir);
+  generateAllowlists(skillsDirs, outputDir);
 }
 
 main();

--- a/scripts/src/generate-mcp-allowlists.ts
+++ b/scripts/src/generate-mcp-allowlists.ts
@@ -43,15 +43,38 @@ function walkDir(dir: string): string[] {
   return results;
 }
 
+/**
+ * JSON schema of the allowed-skill-names.json output
+ */
+type AllowedSkillNames = {
+  /**
+   * Plugin dirname to its skill names
+   */
+  skills: Record<string, string[]>;
+};
+
+/**
+ * JSON schema of the allowed-plugin-file-references.json output
+ */
+type AllowedPluginFileReferences = {
+  /**
+   * Plugin dirname to its reference file names
+   */
+  references: Record<string, string[]>;
+};
+
 function generateAllowlists(skillsDirs: string[], outputDir: string): void {
-  const allSkillNames: string[] = [];
-  const referenceFiles: string[] = [];
+  const allSkillNames: AllowedSkillNames = { skills: {} };
+  const allReferenceFiles: AllowedPluginFileReferences = { references: {} };
 
   for (const skillsDir of skillsDirs) {
     if (!fs.existsSync(skillsDir) || !fs.statSync(skillsDir).isDirectory()) {
       console.error(`ERROR: skills directory not found: ${skillsDir}`);
       process.exit(1);
     }
+
+    // skillsDir ends with <plugin-dirname>/skills
+    const pluginDirname = skillsDir.split(/\/|\\/).at(-2) as string;
 
     // Get sorted list of skill directory names (exclude hidden directories)
     const skillNames = fs
@@ -67,8 +90,9 @@ function generateAllowlists(skillsDirs: string[], outputDir: string): void {
       process.exit(1);
     }
 
-    allSkillNames.push(...skillNames);
+    allSkillNames.skills[pluginDirname] = skillNames;
 
+    const referenceFiles: string[] = [];
     // Collect all reference file paths (Windows-style backslash separators).
     // Exclude SKILL.md, version.json, and license files.
     for (const skill of skillNames) {
@@ -84,26 +108,23 @@ function generateAllowlists(skillsDirs: string[], outputDir: string): void {
         referenceFiles.push(relPath);
       }
     }
+
+    allReferenceFiles.references[pluginDirname] = referenceFiles.sort();
   }
-
-  const skillNames = [...new Set(allSkillNames)].sort();
-
-  // Sort globally to guarantee stable lexicographic ordering
-  referenceFiles.sort();
 
   // Write allowed-skill-names.json
   const skillNamesPath = path.join(outputDir, "allowed-skill-names.json");
-  fs.writeFileSync(skillNamesPath, JSON.stringify(skillNames, null, 2) + "\n");
+  fs.writeFileSync(skillNamesPath, JSON.stringify(allSkillNames, null, 2) + "\n");
 
   // Write allowed-plugin-file-references.json
   const referencesPath = path.join(
     outputDir,
     "allowed-plugin-file-references.json"
   );
-  fs.writeFileSync(referencesPath, JSON.stringify(referenceFiles, null, 2) + "\n");
+  fs.writeFileSync(referencesPath, JSON.stringify(allReferenceFiles, null, 2) + "\n");
 
   console.log(
-    `Generated ${skillNames.length} skill names and ${referenceFiles.length} reference file paths.`
+    `Generated mcp allowlist for ${Object.keys(allSkillNames.skills).length} plugins.`
   );
 }
 


### PR DESCRIPTION
## Description

Expand the path prefix allowlist in hook script to allow sending telemetry for azure-kusto-graph-skills plugin. Expand the generate-mcp-allowlists script to generate allow list for files of all plugins.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

resolves #3052
