### PR TITLE
eval: add max turn limit for foundry skill e2e

### DIFF
--- a/evals/azure-skills/microsoft-foundry/eval.yaml
+++ b/evals/azure-skills/microsoft-foundry/eval.yaml
@@ -486,6 +486,8 @@ stimuli:
 
   # ── Foundry E2E checks ──
   - name: "Golden Path - Create and deploy hosted agent"
+    constraints:
+      max_turns: 50
     tags:
       id: golden-path-create-and-deploy-hosted-agent
       type: foundry-e2e
@@ -496,7 +498,7 @@ stimuli:
       Create a Python hosted agent for B2B customer onboarding and deploy it to a new Foundry project. Use the Responses protocol. After it is done, run in locally to make sure it can run successfully; then deploy it to foundry and ensure it can respond to users correctly.
 
       Foundry model: gpt-5.4-nano
-      Region: North Central US
+      Region: eastus2
     graders:
       - type: skill-invocation
         config:
@@ -520,6 +522,8 @@ stimuli:
       files:
         - src: fixture/openai-agents-sdk
           dest: .
+    constraints:
+      max_turns: 50
     tags:
       id: migration-openai-agents-sdk-to-foundry
       type: foundry-e2e
@@ -530,7 +534,7 @@ stimuli:
       This project is our existing Python customer-support agent built using OpenAI Agents SDK and self-hosted as a container on our internal platform. Re-host it on Microsoft Foundry with the minimum code changes necessary, preserving its existing architecture and behavior. Run it locally to make sure it works, create a new Foundry project with Foundry models and deploy the agent there, then invoke the deployed agent to make sure it works after deployment.
       
       Foundry model: gpt-5.4-nano
-      Region: North Central US
+      Region: eastus2
     graders:
       - type: skill-invocation
         config:

--- a/evals/azure-skills/microsoft-foundry/eval.yaml
+++ b/evals/azure-skills/microsoft-foundry/eval.yaml
@@ -523,7 +523,7 @@ stimuli:
         - src: fixture/openai-agents-sdk
           dest: .
     constraints:
-      max_turns: 50
+      max_turns: 70
     tags:
       id: migration-openai-agents-sdk-to-foundry
       type: foundry-e2e


### PR DESCRIPTION
## Description

- Add max turn limit for foundry skill e2e
- Adjust region
## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
