### PR TITLE
fix: improve Foundry Copilot app preflight

### DIFF
--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -76,7 +76,7 @@ Then run the bundled verification script before any create/deploy command:
 ./scripts/verify-environment.ps1    # Windows (pwsh)
 ```
 
-Do not continue past Step 1 while any `[ACTION]` from environment verification remains. A declined or failed Copilot canvas extension installation is non-blocking as described above. Never run `az login` or `azd auth login` for the user. Missing authentication is a hard stop before any `azd ai agent init`, `azd provision`, `azd deploy`, or other deploy command.
+Do not continue past Step 1 while any `[ACTION]` from environment verification remains. Never run `az login` or `azd auth login` for the user. Missing authentication is a hard stop before any `azd ai agent init`, `azd provision`, `azd deploy`, or other deploy command.
 
 Act on the summary prefixes:
 

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -67,7 +67,7 @@ Act on the summary prefixes:
 - `[WARN]` -- non-blocking; continue.
 - `[ACTION]` -- try to resolve by using the exact plugin install command emitted by the preflight; ask before installing in interactive mode, and install directly in non-interactive mode.
   - **On successful installation, you MUST print:** "The `microsoft-foundry` canvas extension is installed and will be available in a new session." Then rerun the preflight.
-  - If installation is declined or fails, report a `[WARN]` and continue to environment verification; do not retry or block the workflow.
+  - If installation is declined or fails, warn and continue; do not retry.
 
 Then run the bundled verification script before any create/deploy command:
 

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -54,12 +54,20 @@ Capture the selected sample's `manifestUrl`.
 
 ### Step 1 -- Verify the environment
 
-Run the bundled Copilot app entry preflight directly without asking for approval. It detects the GitHub Copilot app and installs app-specific add-ons only in that environment:
+Run the bundled read-only Copilot app entry preflight without asking for approval; it locates the app's Copilot CLI and reports whether the `microsoft-foundry` canvas plugin needs installation:
 
 ```bash
 ./scripts/check-copilot-app-entry.sh     # macOS / Linux
 ./scripts/check-copilot-app-entry.ps1    # Windows (pwsh)
 ```
+
+Act on the summary prefixes:
+
+- `[OK]` -- nothing to do.
+- `[WARN]` -- non-blocking; continue.
+- `[ACTION]` -- try to resolve by using the exact plugin install command emitted by the preflight; ask before installing in interactive mode, and install directly in non-interactive mode.
+  - **On successful installation, you MUST print:** "The `microsoft-foundry` canvas extension is installed and will be available in a new session." Then rerun the preflight.
+  - If installation is declined or fails, report a `[WARN]` and continue to environment verification; do not retry or block the workflow.
 
 Then run the bundled verification script before any create/deploy command:
 
@@ -68,7 +76,7 @@ Then run the bundled verification script before any create/deploy command:
 ./scripts/verify-environment.ps1    # Windows (pwsh)
 ```
 
-Do not continue past Step 1 while any `[ACTION]` remains. Never run `az login` or `azd auth login` for the user. Missing authentication is a hard stop before any `azd ai agent init`, `azd provision`, `azd deploy`, or other deploy command.
+Do not continue past Step 1 while any `[ACTION]` from environment verification remains. A declined or failed Copilot canvas extension installation is non-blocking as described above. Never run `az login` or `azd auth login` for the user. Missing authentication is a hard stop before any `azd ai agent init`, `azd provision`, `azd deploy`, or other deploy command.
 
 Act on the summary prefixes:
 

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -40,7 +40,7 @@ Act on the summary prefixes:
 - `[WARN]` -- non-blocking; continue.
 - `[ACTION]` -- try to resolve by using the exact plugin install command emitted by the preflight; ask before installing in interactive mode, and install directly in non-interactive mode.
   - **On successful installation, you MUST print:** "The `microsoft-foundry` canvas extension is installed and will be available in a new session." Then rerun the preflight.
-  - If installation is declined or fails, report a `[WARN]` and continue to environment verification; do not retry or block the workflow.
+  - If installation is declined or fails, warn and continue; do not retry.
 
 Then run the bundled verification script:
 

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -27,12 +27,20 @@ Walk through every step in order. **Before Step 2**, scan the user's original pr
 
 ### Step 1 — Verify the environment
 
-Run the bundled Copilot app entry preflight directly without asking for approval. It detects the GitHub Copilot app and installs app-specific add-ons only in that environment:
+Run the bundled read-only Copilot app entry preflight without asking for approval; it locates the app's Copilot CLI and reports whether the `microsoft-foundry` canvas plugin needs installation:
 
 ```bash
 ./scripts/check-copilot-app-entry.sh     # macOS / Linux
 ./scripts/check-copilot-app-entry.ps1    # Windows (pwsh)
 ```
+
+Act on the summary prefixes:
+
+- `[OK]` -- nothing to do.
+- `[WARN]` -- non-blocking; continue.
+- `[ACTION]` -- try to resolve by using the exact plugin install command emitted by the preflight; ask before installing in interactive mode, and install directly in non-interactive mode.
+  - **On successful installation, you MUST print:** "The `microsoft-foundry` canvas extension is installed and will be available in a new session." Then rerun the preflight.
+  - If installation is declined or fails, report a `[WARN]` and continue to environment verification; do not retry or block the workflow.
 
 Then run the bundled verification script:
 

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/scripts/check-copilot-app-entry.ps1
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/scripts/check-copilot-app-entry.ps1
@@ -1,10 +1,13 @@
 <#
 .SYNOPSIS
-    Checks Copilot app entry and installs Copilot app-specific add-ons.
+    Checks Copilot app entry and reports whether its Foundry plugin is installed.
 .DESCRIPTION
-    Detects AI_AGENT=github_copilot_app_agent and, only in that environment,
-    silently installs Copilot app-specific add-ons. Currently, the add-on is
-    microsoft-foundry. Discovery and installation failures are non-blocking.
+    Detects AI_AGENT=github_copilot_app_agent, locates either a PATH-visible
+    Copilot CLI or the CLI bundled by github-copilot-sdk, and inspects the
+    microsoft-foundry plugin. This script never installs the plugin.
+
+    Output lines are prefixed with [OK], [WARN], or [ACTION].
+    Exit code is 1 only when plugin installation is required; otherwise 0.
 #>
 
 $ErrorActionPreference = "Stop"
@@ -12,28 +15,132 @@ $ErrorActionPreference = "Stop"
 $pluginName = "microsoft-foundry"
 $pluginSpec = "microsoft-foundry@awesome-copilot"
 
-function Write-PluginWarning {
-    param([string]$Message)
-    Write-Output "[WARN] $Message"
+function Note-Ok     { param([string]$Message) Write-Output "[OK] $Message" }
+function Note-Warn   { param([string]$Message) Write-Output "[WARN] $Message" }
+function Note-Action { param([string]$Message) Write-Output "[ACTION] $Message" }
+
+function Get-HighestVersionCopilotCli {
+    param(
+        [string]$Root,
+        [string]$ExecutableName
+    )
+
+    if (-not $Root -or -not (Test-Path -LiteralPath $Root -PathType Container)) {
+        return $null
+    }
+
+    $bestPath = $null
+    $bestKey = $null
+    foreach ($directory in Get-ChildItem -LiteralPath $Root -Directory -ErrorAction SilentlyContinue) {
+        if ($directory.Name -notmatch '^(\d+)\.(\d+)\.(\d+)(?:-(\d+))?$') {
+            continue
+        }
+
+        $suffix = if ($Matches[4]) { [long]$Matches[4] } else { [long]::MaxValue }
+        $key = @([long]$Matches[1], [long]$Matches[2], [long]$Matches[3], $suffix)
+        $candidate = Join-Path $directory.FullName $ExecutableName
+        if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+            continue
+        }
+
+        $isNewer = ($null -eq $bestKey)
+        if (-not $isNewer) {
+            for ($index = 0; $index -lt $key.Count; $index++) {
+                if ($key[$index] -gt $bestKey[$index]) {
+                    $isNewer = $true
+                    break
+                }
+                if ($key[$index] -lt $bestKey[$index]) {
+                    break
+                }
+            }
+        }
+
+        if ($isNewer) {
+            $bestPath = $candidate
+            $bestKey = $key
+        }
+    }
+
+    return $bestPath
+}
+
+function Find-CopilotCli {
+    $pathCommand = Get-Command copilot -CommandType Application,ExternalScript -ErrorAction SilentlyContinue |
+        Select-Object -First 1
+    if ($pathCommand) {
+        if ($pathCommand.Path) { return $pathCommand.Path }
+        if ($pathCommand.Source) { return $pathCommand.Source }
+    }
+
+    if ($env:COPILOT_CLI_PATH -and (Test-Path -LiteralPath $env:COPILOT_CLI_PATH -PathType Leaf)) {
+        return $env:COPILOT_CLI_PATH
+    }
+
+    $isWindowsPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+        [System.Runtime.InteropServices.OSPlatform]::Windows)
+    $isMacPlatform = [System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform(
+        [System.Runtime.InteropServices.OSPlatform]::OSX)
+    $executableName = if ($isWindowsPlatform) { "copilot.exe" } else { "copilot" }
+
+    if ($isWindowsPlatform) {
+        $dataRoot = if ($env:LOCALAPPDATA) {
+            Join-Path $env:LOCALAPPDATA "github-copilot-sdk\cli"
+        } else {
+            $null
+        }
+        $cacheRoot = $dataRoot
+    } elseif ($isMacPlatform) {
+        $dataRoot = Join-Path $HOME "Library/Application Support/github-copilot-sdk/cli"
+        $cacheRoot = Join-Path $HOME "Library/Caches/github-copilot-sdk/cli"
+    } else {
+        $dataBase = if ($env:XDG_DATA_HOME) { $env:XDG_DATA_HOME } else { Join-Path $HOME ".local/share" }
+        $dataRoot = Join-Path $dataBase "github-copilot-sdk/cli"
+        $cacheBase = if ($env:XDG_CACHE_HOME -and [IO.Path]::IsPathFullyQualified($env:XDG_CACHE_HOME)) {
+            $env:XDG_CACHE_HOME
+        } else {
+            Join-Path $HOME ".cache"
+        }
+        $cacheRoot = Join-Path $cacheBase "github-copilot-sdk/cli"
+    }
+
+    $appBundledCli = Get-HighestVersionCopilotCli -Root $dataRoot -ExecutableName $executableName
+    if ($appBundledCli) {
+        return $appBundledCli
+    }
+
+    if ($env:COPILOT_CLI_EXTRACT_DIR) {
+        $extractedCli = Join-Path $env:COPILOT_CLI_EXTRACT_DIR $executableName
+        if (Test-Path -LiteralPath $extractedCli -PathType Leaf) {
+            return $extractedCli
+        }
+    }
+
+    return Get-HighestVersionCopilotCli -Root $cacheRoot -ExecutableName $executableName
 }
 
 if ($env:AI_AGENT -ne "github_copilot_app_agent") {
+    Note-Ok "GitHub Copilot app not detected; no plugin check needed."
     exit 0
 }
 
-if (-not (Get-Command copilot -ErrorAction SilentlyContinue)) {
-    Write-PluginWarning "GitHub Copilot CLI is unavailable; skipped $pluginName plugin installation."
+$copilotCli = Find-CopilotCli
+if (-not $copilotCli) {
+    Note-Warn "Could not locate the GitHub Copilot CLI on PATH or in github-copilot-sdk data/cache locations; could not inspect the $pluginName plugin."
     exit 0
 }
 
 try {
-    $pluginsRaw = (& copilot plugins list --kind plugin --json 2>&1) -join "`n"
-    if ($LASTEXITCODE -ne 0) {
+    # External PowerShell command shims do not set $LASTEXITCODE on success.
+    $global:LASTEXITCODE = 0
+    $pluginsRaw = (& $copilotCli plugins list --kind plugin --json 2>&1) -join "`n"
+    $pluginsExitCode = $LASTEXITCODE
+    if ($pluginsExitCode -ne 0) {
         throw $pluginsRaw
     }
     $plugins = $pluginsRaw | ConvertFrom-Json -ErrorAction Stop
 } catch {
-    Write-PluginWarning "Could not inspect installed Copilot plugins: $($_.Exception.Message)"
+    Note-Warn "Could not inspect installed Copilot plugins: $($_.Exception.Message)"
     exit 0
 }
 
@@ -42,19 +149,10 @@ $installed = @($plugins.plugins) |
     Select-Object -First 1
 
 if ($installed) {
+    Note-Ok "Copilot plugin '$pluginName' is installed."
     exit 0
 }
 
-try {
-    $installOutput = (& copilot plugins install $pluginSpec 2>&1) -join "`n"
-    $installExit = $LASTEXITCODE
-} catch {
-    Write-PluginWarning "Could not install ${pluginSpec}: $($_.Exception.Message)"
-    exit 0
-}
-
-if ($installExit -ne 0) {
-    Write-PluginWarning "Could not install ${pluginSpec}: $installOutput"
-}
-
-exit 0
+$quotedCli = "'" + $copilotCli.Replace("'", "''") + "'"
+Note-Action "Copilot plugin '$pluginName' is missing. Run: & $quotedCli plugins install $pluginSpec"
+exit 1

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/scripts/check-copilot-app-entry.sh
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/scripts/check-copilot-app-entry.sh
@@ -1,74 +1,138 @@
 #!/usr/bin/env bash
 # Copilot app entry preflight.
-# Detects AI_AGENT=github_copilot_app_agent and, only in that environment,
-# silently installs Copilot app-specific add-ons. Currently, the add-on is
-# microsoft-foundry. Discovery and installation failures are non-blocking.
+# Detects AI_AGENT=github_copilot_app_agent, locates either a PATH-visible
+# Copilot CLI or the CLI bundled by github-copilot-sdk, and reports whether the
+# microsoft-foundry plugin needs installation. This script is read-only.
+#
+# Output: [OK], [WARN], or [ACTION].
+# Exit code: 1 only when plugin installation is required; otherwise 0.
 
 set -uo pipefail
 
 PLUGIN_NAME="microsoft-foundry"
 PLUGIN_SPEC="microsoft-foundry@awesome-copilot"
+COPILOT_CLI=""
 
-warn() {
-  echo "[WARN] $1" >&2
+note_ok()     { echo "[OK] $1"; }
+note_warn()   { echo "[WARN] $1" >&2; }
+note_action() { echo "[ACTION] $1"; }
+
+# Pick the highest semantic version under github-copilot-sdk/cli/<version>/.
+# An unsuffixed version sorts after the same version with a numeric suffix,
+# matching the SDK locator used by the Copilot app installer.
+pick_highest_cli() {
+  local root="$1"
+  local executable="$2"
+  local dir name candidate
+  local major minor patch suffix
+  local best_major=-1 best_minor=-1 best_patch=-1 best_suffix=-1
+  local best=""
+
+  [ -d "$root" ] || return 1
+
+  for dir in "$root"/*; do
+    [ -d "$dir" ] || continue
+    name="${dir##*/}"
+    if [[ ! "$name" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9]+))?$ ]]; then
+      continue
+    fi
+
+    major=$((10#${BASH_REMATCH[1]}))
+    minor=$((10#${BASH_REMATCH[2]}))
+    patch=$((10#${BASH_REMATCH[3]}))
+    if [ -n "${BASH_REMATCH[5]:-}" ]; then
+      suffix=$((10#${BASH_REMATCH[5]}))
+    else
+      suffix=9223372036854775807
+    fi
+
+    candidate="$dir/$executable"
+    [ -f "$candidate" ] || continue
+
+    if (( major > best_major ||
+          (major == best_major && minor > best_minor) ||
+          (major == best_major && minor == best_minor && patch > best_patch) ||
+          (major == best_major && minor == best_minor && patch == best_patch && suffix > best_suffix) )); then
+      best="$candidate"
+      best_major=$major
+      best_minor=$minor
+      best_patch=$patch
+      best_suffix=$suffix
+    fi
+  done
+
+  [ -n "$best" ] || return 1
+  COPILOT_CLI="$best"
+  return 0
+}
+
+locate_copilot_cli() {
+  local platform data_root cache_root
+
+  if command -v copilot >/dev/null 2>&1; then
+    COPILOT_CLI="$(command -v copilot)"
+    return 0
+  fi
+
+  if [ -n "${COPILOT_CLI_PATH:-}" ] && [ -f "$COPILOT_CLI_PATH" ]; then
+    COPILOT_CLI="$COPILOT_CLI_PATH"
+    return 0
+  fi
+
+  platform="$(uname -s 2>/dev/null || echo Linux)"
+  case "$platform" in
+    Darwin)
+      data_root="${HOME:-}/Library/Application Support/github-copilot-sdk/cli"
+      cache_root="${HOME:-}/Library/Caches/github-copilot-sdk/cli"
+      ;;
+    *)
+      data_root="${XDG_DATA_HOME:-${HOME:-}/.local/share}/github-copilot-sdk/cli"
+      if [ -n "${XDG_CACHE_HOME:-}" ] && [[ "$XDG_CACHE_HOME" = /* ]]; then
+        cache_root="$XDG_CACHE_HOME/github-copilot-sdk/cli"
+      else
+        cache_root="${HOME:-}/.cache/github-copilot-sdk/cli"
+      fi
+      ;;
+  esac
+
+  if pick_highest_cli "$data_root" "copilot"; then
+    return 0
+  fi
+
+  if [ -n "${COPILOT_CLI_EXTRACT_DIR:-}" ] && [ -f "$COPILOT_CLI_EXTRACT_DIR/copilot" ]; then
+    COPILOT_CLI="$COPILOT_CLI_EXTRACT_DIR/copilot"
+    return 0
+  fi
+
+  pick_highest_cli "$cache_root" "copilot"
 }
 
 if [ "${AI_AGENT:-}" != "github_copilot_app_agent" ]; then
+  note_ok "GitHub Copilot app not detected; no plugin check needed."
   exit 0
 fi
 
-if ! command -v copilot >/dev/null 2>&1; then
-  warn "GitHub Copilot CLI is unavailable; skipped $PLUGIN_NAME plugin installation."
+if ! locate_copilot_cli; then
+  note_warn "Could not locate the GitHub Copilot CLI on PATH or in github-copilot-sdk data/cache locations; could not inspect the $PLUGIN_NAME plugin."
   exit 0
 fi
 
-if ! command -v python3 >/dev/null 2>&1; then
-  warn "python3 is unavailable; could not inspect installed Copilot plugins."
-  exit 0
-fi
-
-plugins_json="$(copilot plugins list --kind plugin --json 2>&1)"
+plugins_json="$("$COPILOT_CLI" plugins list --kind plugin --json 2>&1)"
 list_exit=$?
 if [ "$list_exit" -ne 0 ]; then
-  warn "Could not inspect installed Copilot plugins: $plugins_json"
+  note_warn "Could not inspect installed Copilot plugins: $plugins_json"
   exit 0
 fi
 
-python3 -c '
-import json
-import sys
-
-try:
-    data = json.load(sys.stdin)
-except Exception:
-    raise SystemExit(2)
-
-plugins = data.get("plugins", []) if isinstance(data, dict) else []
-name = sys.argv[1]
-raise SystemExit(
-    0
-    if any(isinstance(plugin, dict) and plugin.get("name") == name for plugin in plugins)
-    else 1
-)
-' "$PLUGIN_NAME" <<<"$plugins_json"
-match_exit=$?
-
-case "$match_exit" in
-  0)
-    exit 0
-    ;;
-  1)
-    ;;
-  *)
-    warn "Could not parse installed Copilot plugins; skipped $PLUGIN_NAME plugin installation."
-    exit 0
-    ;;
-esac
-
-install_output="$(copilot plugins install "$PLUGIN_SPEC" 2>&1)"
-install_exit=$?
-if [ "$install_exit" -ne 0 ]; then
-  warn "Could not install $PLUGIN_SPEC: $install_output"
+# The CLI guarantees JSON on a successful --json invocation. Match the fixed
+# plugin name as a complete JSON string value, allowing arbitrary whitespace,
+# so this check needs no Python, jq, or other JSON-parser dependency.
+plugin_name_pattern="\"name\"[[:space:]]*:[[:space:]]*\"${PLUGIN_NAME}\""
+if [[ "$plugins_json" =~ $plugin_name_pattern ]]; then
+  note_ok "Copilot plugin '$PLUGIN_NAME' is installed."
+  exit 0
 fi
 
-exit 0
+printf -v copilot_command '%q' "$COPILOT_CLI"
+note_action "Copilot plugin '$PLUGIN_NAME' is missing. Run: $copilot_command plugins install $PLUGIN_SPEC"
+exit 1

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/scripts/check-copilot-app-entry.sh
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/scripts/check-copilot-app-entry.sh
@@ -14,7 +14,7 @@ PLUGIN_SPEC="microsoft-foundry@awesome-copilot"
 COPILOT_CLI=""
 
 note_ok()     { echo "[OK] $1"; }
-note_warn()   { echo "[WARN] $1" >&2; }
+note_warn()   { echo "[WARN] $1"; }
 note_action() { echo "[ACTION] $1"; }
 
 # Pick the highest semantic version under github-copilot-sdk/cli/<version>/.
@@ -47,7 +47,7 @@ pick_highest_cli() {
     fi
 
     candidate="$dir/$executable"
-    [ -f "$candidate" ] || continue
+    [ -x "$candidate" ] || continue
 
     if (( major > best_major ||
           (major == best_major && minor > best_minor) ||
@@ -74,7 +74,7 @@ locate_copilot_cli() {
     return 0
   fi
 
-  if [ -n "${COPILOT_CLI_PATH:-}" ] && [ -f "$COPILOT_CLI_PATH" ]; then
+  if [ -n "${COPILOT_CLI_PATH:-}" ] && [ -x "$COPILOT_CLI_PATH" ]; then
     COPILOT_CLI="$COPILOT_CLI_PATH"
     return 0
   fi
@@ -99,7 +99,7 @@ locate_copilot_cli() {
     return 0
   fi
 
-  if [ -n "${COPILOT_CLI_EXTRACT_DIR:-}" ] && [ -f "$COPILOT_CLI_EXTRACT_DIR/copilot" ]; then
+  if [ -n "${COPILOT_CLI_EXTRACT_DIR:-}" ] && [ -x "$COPILOT_CLI_EXTRACT_DIR/copilot" ]; then
     COPILOT_CLI="$COPILOT_CLI_EXTRACT_DIR/copilot"
     return 0
   fi


### PR DESCRIPTION
## Description

- locate the GitHub Copilot CLI from PATH, explicit overrides, or GitHub Copilot App SDK data/cache directories
- make the Copilot app preflight read-only and return an actionable plugin install command instead of installing silently
- remove the Bash `python3` dependency while preserving plugin detection
- document consent behavior, successful-install new-session messaging, and non-blocking install failures
- emit an `[OK]` result when the GitHub Copilot App is not detected

