### PR TITLE
refactor: improve re-host scenario in foundry skill

### DIFF
--- a/evals/azure-skills/microsoft-foundry/eval.yaml
+++ b/evals/azure-skills/microsoft-foundry/eval.yaml
@@ -498,7 +498,7 @@ stimuli:
       Create a Python hosted agent for B2B customer onboarding and deploy it to a new Foundry project. Use the Responses protocol. After it is done, run in locally to make sure it can run successfully; then deploy it to foundry and ensure it can respond to users correctly.
 
       Foundry model: gpt-5.4-nano
-      Region: eastus2
+      Region: eastus
     graders:
       - type: skill-invocation
         config:
@@ -534,7 +534,7 @@ stimuli:
       This project is our existing Python customer-support agent built using OpenAI Agents SDK and self-hosted as a container on our internal platform. Re-host it on Microsoft Foundry with the minimum code changes necessary, preserving its existing architecture and behavior. Run it locally to make sure it works, create a new Foundry project with Foundry models and deploy the agent there, then invoke the deployed agent to make sure it works after deployment.
       
       Foundry model: gpt-5.4-nano
-      Region: eastus2
+      Region: eastus
     graders:
       - type: skill-invocation
         config:

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/create-hosted.md
@@ -48,7 +48,9 @@ azd ai agent sample list --language python --output json
 
 Capture the selected sample's `manifestUrl`.
 
-> **Important:** Always select the best-matching sample from `azd ai agent sample list` for the capabilities the user explicitly requested. Use advanced tool samples only when the user explicitly asks for external actions, APIs, tools, connectors, or data lookup. Starting with the right sample helps ensure that the implementation follows the established code patterns and best practices for that type of Foundry hosted agent. If `azd ai agent sample list` does not return a suitable sample, choose one from the official [Foundry samples repository](https://github.com/microsoft-foundry/foundry-samples) and construct the manifest URL from its exact `azure.yaml` path, following the URL format returned by `azd ai agent sample list`.
+> **Important:** Always select the best-matching samples from `azd ai agent sample list` for the capabilities the user explicitly requested. Use advanced tool samples only when the user explicitly asks for external actions, APIs, tools, connectors, or data lookup. Starting with the right sample helps ensure that the implementation follows the established code patterns and best practices for that type of Foundry hosted agent. If `azd ai agent sample list` does not return a suitable sample, choose one from the official [Foundry samples repository](https://github.com/microsoft-foundry/foundry-samples) and construct the manifest URL from its exact `azure.yaml` path, following the URL format returned by `azd ai agent sample list`.
+
+You should pick only one sample for `azd ai agent init`, but you can browse multiple samples relevant to the user's task as code references.
 
 ## Workflow
 
@@ -128,20 +130,21 @@ azd ai agent init --no-prompt \
 After the `azd ai agent init` completes, go to the project folder and set the collected subscription and location on the active azd environment:
 
 ```bash
-azd env set \
-  AZURE_SUBSCRIPTION_ID="<subscription-id>" \
-  AZURE_LOCATION="<region>"
+azd env set AZURE_SUBSCRIPTION_ID "<subscription-id>"
+azd env set AZURE_LOCATION "<region>"
 ```
 
 > `--agent-name` at init sets both the `azure.yaml` service key and its `name:` in one shot; renaming after init requires editing both in `azure.yaml`.
 
-Do not run `azd env new`, `azd env select`, or `azd env set` before `azd ai agent init` in a new temp/workspace; there is no azd project yet, so those commands fail and waste time. For an existing project, `--project-id` is enough during init. Set endpoint/model values immediately after init, once `azure.yaml` and the azd env exist.
+Do not run `azd env new`, `azd env select`, or `azd env set` before `azd ai agent init` in a new temp/workspace; there is no azd project yet, so those commands fail and waste time. Do not chain `azd env set` after `azd ai agent init` on the same command line. The init command may scaffold the project into a subfolder, so run `azd env set` only after initialization completes and after changing to the scaffolded project directory. For an existing project, `--project-id` is enough during init. Set endpoint/model values immediately after init, once `azure.yaml` and the azd env exist.
 
 > Tip: if the manifest declares a `parameters:` block (check by `curl <manifestUrl>`), collect required values before init when an azd project already exists. In a new empty workspace, prefer a sample without required secrets; there is no azd env to set until init creates the project files.
 
 `init` writes `azure.yaml` (or appends the agent service to it), the agent source under `src/<name>/`, and `<service-dir>/.agentignore`. A successful direct-code init produces an `azure.yaml` service block (`host: azure.ai.agent`) with `codeConfiguration:`. For file shapes, see [azd-ai-cli](../azd-guidance/references/azd-ai-cli.md).
 
 #### Model deployments (azd Golden Path)
+
+Read [Foundry Model Reference](./references/foundry-model.md) and follow the steps in it when you want to query model related data.
 
 `azure.yaml services.ai-project.deployments[]` is the **single source of truth** for model deployments in azd-managed Foundry projects. Model deployments live under the dedicated `ai-project` service (`host: azure.ai.project`); the agent service links to it via `uses: [ai-project]` and references the model through its `environmentVariables`. The flow is:
 
@@ -190,35 +193,9 @@ Use when the workspace already contains an agent project or source code.
 First determine whether the workspace is already a Foundry hosted agent project.
 
 - **Existing Foundry hosted agent** -- preserve its project structure, make the requested changes, and continue. For Foundry-specific features, use `azd ai agent sample list` and follow the [azd Sample Selection Guidance](#azd-sample-selection-guidance) to choose a sample for code reference.
-- **Other existing agent** -- infer whether the user wants to re-host it on Foundry and ask only when the intended outcome is unclear. If re-hosting, follow the Re-host steps below.
+- **Other existing agent** -- infer whether the user wants to re-host it on Foundry and ask only when the intended outcome is unclear. If re-hosting, read and follow [Re-host an existing agent](references/re-host.md), then continue to Step 5.
 
-#### Re-host: collect information
-
-Resolve two independent choices before initialization or edits:
-
-1. **Model** -- keep the existing model or use a Foundry model.
-2. **Agent framework** -- keep the existing framework or migrate it.
-
-Infer these choices from the user's request and current code. Ask only for information that remains unclear; skip questions when the intent is explicit or evident, such as an existing Foundry model integration. Do not switch or deploy a model, or migrate the framework, without user intent.
-
-#### Re-host: adapt and initialize
-
-Use `azd ai agent sample list --language <language> --output json` and follow the [azd Sample Selection Guidance](#azd-sample-selection-guidance) to find the closest relevant sample for adapter, protocol, and deployment guidance. Treat samples as boundary patterns, not replacement applications.
-
-After resolving the choices, run:
-
-```bash
-azd ai agent init --no-prompt \
-  --src ./src/my-agent \
-  --agent-name my-agent \
-  --deploy-mode code \
-  --runtime python_3_13 \
-  --entry-point <entry-point>
-```
-
-`--runtime` and `--entry-point` are required with `--deploy-mode code --no-prompt`. Use the existing executable entry point, or a new adapter file only when one is intentionally added. Runtimes: `python_3_13`, `python_3_14`, `dotnet_10`. `--deploy-mode container` builds from `Dockerfile`. For an existing Foundry project, add `--project-id "<resourceId>"`.
-
-Once the agent is configured as a Foundry hosted agent, make the requested changes and continue to the shared flow in Steps 5-8.
+Read [Foundry Model Reference](./references/foundry-model.md) and follow the steps in it when you want to query model related data.
 
 ### Step 5 -- Write the agent instruction file (required)
 

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/quick-start-hosted.md
@@ -18,6 +18,8 @@ Use this when the request is to create a new hosted Foundry agent end-to-end —
 | Region | `northcentralus` | Ask user to confirm or pick another |
 | Foundry project | Ask if the user doesn't mention one | create new → no `--project-id`; existing → pass `--project-id` (ARM ID / endpoint); no mention → stop and ask (existing vs new) |
 | Model deployment | Whatever the sample's manifest declares | If user supplies a deployment name, `azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME` after init |
+| Model version | Whatever the sample's manifest declares | If user supplies a model version, edit `azure.yaml`. If user supplies a model deployment without model version, follow [Foundry Model Reference](./references/foundry-model.md) to query model-related data. If provision fails, follow [Foundry Model Reference](./references/foundry-model.md) to query model-related data. |
+| Model quota | Skip the quota pre-check | If provision fails, follow [Foundry Model Reference](./references/foundry-model.md) to query model-related data. |
 | Deploy mode | `code` (no Docker, no ACR build) | — |
 | Stops at | Deployed agent + remote smoke invoke + eval generation submitted | — |
 
@@ -81,6 +83,8 @@ Capture the `manifestUrl`.
 
 > **Important:** Always select the best-matching sample from `azd ai agent sample list` for the capabilities the user explicitly requested. Use advanced tool samples only when the user explicitly asks for external actions, APIs, tools, connectors, or data lookup. Starting with the right sample helps ensure that the implementation follows the established code patterns and best practices for that type of Foundry hosted agent. If `azd ai agent sample list` does not return a suitable sample, choose one from the official [Foundry samples repository](https://github.com/microsoft-foundry/foundry-samples) and construct the manifest URL from its exact `azure.yaml` path, following the URL format returned by `azd ai agent sample list`.
 
+You should pick only one sample for `azd ai agent init`, but you can browse multiple samples relevant to user's task as code reference.
+
 Step 4 needs `--runtime` and `--entry-point` values. These are CLI args, **not** fields in the manifest — use these standard defaults for the chosen language:
 
 | Language | `--runtime` | `--entry-point` |
@@ -106,9 +110,8 @@ azd ai agent init --no-prompt \
 After the `azd ai agent init` completes, go to the project folder and write the subscription and region collected in Step 2 to the active azd environment:
 
 ```bash
-azd env set \
-  AZURE_SUBSCRIPTION_ID="<id>" \
-  AZURE_LOCATION="<region>"
+azd env set AZURE_SUBSCRIPTION_ID "<id>"
+azd env set AZURE_LOCATION "<region>"
 ```
 
 Values you **must** substitute from Step 3 — do not pass placeholders or guesses:
@@ -121,6 +124,8 @@ If using an existing Foundry project, add `--project-id "<arm-id>"`.
 ⏳ May take time — init resolves the model catalog server-side. Wait for the prompt to return; do not interrupt.
 
 `init` writes `azure.yaml` (appending the agent service), `src/<project>/.agentignore`, and the sample source files under `src/<project>/`.
+
+> **Important:** Do not chain `azd env set` after `azd ai agent init` on the same command line. The init command may scaffold the project into a subfolder, so run `azd env set` only after initialization completes and after changing to the scaffolded project directory.
 
 ### Step 5 — Customize the scaffolded sample (per user's original intent)
 

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/references/foundry-model.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/references/foundry-model.md
@@ -1,0 +1,67 @@
+# Foundry Model Reference
+
+Use this reference to query Microsoft Foundry model-related data.
+
+## Model information
+
+Query the regional model catalog to obtain the model version, format, capabilities, lifecycle status, and supported SKUs:
+
+**PowerShell:**
+
+```pwsh
+$region = "<REGION>"
+$subscription = "<SUBSCRIPTION_ID_OR_NAME>"
+
+az cognitiveservices model list `
+  --location $region `
+  --subscription $subscription `
+  -o json
+```
+
+**Bash:**
+
+```bash
+REGION="<REGION>"
+SUBSCRIPTION="<SUBSCRIPTION_ID_OR_NAME>"
+
+az cognitiveservices model list \
+  --location "$REGION" \
+  --subscription "$SUBSCRIPTION" \
+  -o json
+```
+
+The result provides:
+
+- Model name, version, format, default-version status, and lifecycle status.
+- Capabilities such as Responses, chat completions, and agents support.
+- Supported SKUs, capacity ranges, and usage names.
+
+## Model quota
+
+Query the regional usage record for the exact model and SKU, then calculate the currently available quota:
+
+**PowerShell:**
+
+```pwsh
+$region = "<REGION>"
+$subscription = "<SUBSCRIPTION_ID_OR_NAME>"
+
+az cognitiveservices usage list `
+  --location $region `
+  --subscription $subscription `
+  -o json
+```
+
+**Bash:**
+
+```bash
+REGION="<REGION>"
+SUBSCRIPTION="<SUBSCRIPTION_ID_OR_NAME>"
+
+az cognitiveservices usage list \
+  --location "$REGION" \
+  --subscription "$SUBSCRIPTION" \
+  -o json
+```
+
+The result provides quota usage names, current usage, limits, and units for the subscription and region.

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/references/re-host.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/references/re-host.md
@@ -11,7 +11,7 @@ Infer these choices from the user's request and current code. Ask only for infor
 
 ## Step 2: Initialize and adapt
 
-To scaffold a foundry agent project with existing agent codes, run:
+To scaffold a Foundry agent project with existing agent codes, run:
 
 ```bash
 azd ai agent init --no-prompt \

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/references/re-host.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/references/re-host.md
@@ -1,0 +1,49 @@
+# Re-host an Existing Agent from other platforms
+
+## Step 1: Collect information
+
+Resolve two independent choices before initialization or edits:
+
+1. **Model** -- keep the existing model or use a Foundry model.
+2. **Agent framework** -- keep the existing framework or migrate it.
+
+Infer these choices from the user's request and current code. Ask only for information that remains unclear; skip questions when the intent is explicit or evident, such as an existing Foundry model integration. Do not switch or deploy a model, or migrate the framework, without user intent.
+
+## Step 2: Initialize and adapt
+
+To scaffold a foundry agent project with existing agent codes, run:
+
+```bash
+azd ai agent init --no-prompt \
+  --src ./src/my-agent \
+  --agent-name my-agent \
+  --deploy-mode code \
+  --runtime python_3_13 \
+  --entry-point <entry-point>
+```
+
+Use `--deploy-mode code` by default. `--runtime` and `--entry-point` are required with `--deploy-mode code --no-prompt`. Use the existing executable entry point, or a new adapter file only when one is intentionally added. Runtimes: `python_3_13`, `python_3_14`, `dotnet_10`. `--deploy-mode container` builds from `Dockerfile`. For an existing Foundry project, add `--project-id "<resourceId>"`.
+
+After scaffolding, you must use `azd ai agent sample list --language <language> --output json` and follow the [azd Sample Selection Guidance](../create-hosted.md#azd-sample-selection-guidance) to find the closest relevant samples for adapter, protocol, and deployment guidance. Treat samples as boundary patterns, not replacement applications. Browse the relevant samples as code references.
+
+For reference, here are some awesome samples for re-hosting scenarios:
+1. Re-host agents built with the OpenAI Agents SDK: https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/bring-your-own/responses/openai-agents-sdk
+2. Re-host agents built with the Claude Agent SDK: https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/bring-your-own/invocations/claude-agent-sdk
+
+If users use a Foundry model, you must wire the Foundry model to the agent.
+
+Set `startupCommand` in `azure.yaml`.
+
+Once the agent is configured as a Foundry hosted agent, make the requested changes, return to [create-hosted](../create-hosted.md), and continue with Step 5.
+
+## Step 3: Set azd env
+
+```bash
+azd env set AZURE_SUBSCRIPTION_ID "<id>"
+azd env set AZURE_LOCATION "<region>"
+azd env set AZURE_AI_MODEL_DEPLOYMENT_NAME "<model name>"
+```
+
+## Foundry Model Reference
+
+Read [Foundry Model Reference](./foundry-model.md) and follow the steps in it when you want to query model related data.


### PR DESCRIPTION
## Description

Improve the hosted-agent re-host scenario and some other creation workflow.

- Add a dedicated re-hosting workflow for agents from other platforms.
- Add a Foundry model reference for querying regional model metadata, supported SKUs, and quota usage.
- Clarify that `azd ai agent init` uses one sample while other relevant samples may be consulted as implementation references.
- Run `azd env set` as separate commands after initialization and from the scaffolded project directory.
- Change the hosted-agent and migration E2E eval regions from `eastus2` to `eastus`.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
