### PR TITLE
fix: restore MicrosoftSweBench feed

### DIFF
--- a/pipelines/azure-benchmark-report.yml
+++ b/pipelines/azure-benchmark-report.yml
@@ -38,9 +38,9 @@ stages:
         versionSpec: '3.12'
 
     - task: PipAuthenticate@1
-      displayName: 'Authenticate pip with MicrosoftSweBenchMirror feed'
+      displayName: 'Authenticate pip with MicrosoftSweBench feed'
       inputs:
-        artifactFeeds: 'internal/MicrosoftSweBenchMirror'
+        artifactFeeds: 'internal/MicrosoftSweBench'
 
     - task: AzureCLI@2
       name: GenerateBenchmarkReports

--- a/pipelines/azure-benchmarks.yml
+++ b/pipelines/azure-benchmarks.yml
@@ -30,9 +30,9 @@ stages:
         versionSpec: '3.12'
 
     - task: PipAuthenticate@1
-      displayName: 'Authenticate pip with MicrosoftSweBenchMirror feed'
+      displayName: 'Authenticate pip with MicrosoftSweBench feed'
       inputs:
-        artifactFeeds: 'internal/MicrosoftSweBenchMirror'
+        artifactFeeds: 'internal/MicrosoftSweBench'
 
     - task: AzureCLI@2
       name: RunBenchmarks

--- a/pipelines/scripts/Invoke-GenerateBenchmarkReport.ps1
+++ b/pipelines/scripts/Invoke-GenerateBenchmarkReport.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
     This script runs in Azure DevOps under an AzureCLI@2 task with federated authentication.
     Feed authentication is handled by a preceding PipAuthenticate@1 task that sets
-    PIP_EXTRA_INDEX_URL for the azure-sdk/internal/MicrosoftSweBenchMirror feed.
+    PIP_EXTRA_INDEX_URL for the azure-sdk/internal/MicrosoftSweBench feed.
     The script retrieves a GitHub PAT from KeyVault, clones the msbench-benchmarks repo,
     installs MSBench CLI, checks the status of existing benchmark runs, and uses GitHub Copilot
     to generate detailed analysis reports for the specified run IDs.
@@ -85,7 +85,7 @@
     }
 
     # --- Feed auth is handled by the PipAuthenticate@1 pipeline task ---
-    # PipAuthenticate sets PIP_EXTRA_INDEX_URL for the azure-sdk/internal/MicrosoftSweBenchMirror feed.
+    # PipAuthenticate sets PIP_EXTRA_INDEX_URL for the azure-sdk/internal/MicrosoftSweBench feed.
     if ($env:PIP_EXTRA_INDEX_URL) {
         Write-Host "PIP_EXTRA_INDEX_URL is set (feed auth configured by PipAuthenticate task)"
     } else {

--- a/pipelines/scripts/Invoke-RunBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-RunBenchmarks.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
     This script runs in Azure DevOps under an AzureCLI@2 task with federated authentication.
     Feed authentication is handled by a preceding PipAuthenticate@1 task that sets
-    PIP_EXTRA_INDEX_URL for the azure-sdk/internal/MicrosoftSweBenchMirror feed.
+    PIP_EXTRA_INDEX_URL for the azure-sdk/internal/MicrosoftSweBench feed.
     The run requires both a GitHub PAT retrieved from KeyVault and the CAPI integration
     credentials/environment variables expected by MSBench for the selected agent. The script
     clones the msbench-benchmarks repo, installs MSBench CLI, and invokes for each model:
@@ -102,7 +102,7 @@
     }
 
     # --- Feed auth is handled by the PipAuthenticate@1 pipeline task ---
-    # PipAuthenticate sets PIP_EXTRA_INDEX_URL for the azure-sdk/internal/MicrosoftSweBenchMirror feed.
+    # PipAuthenticate sets PIP_EXTRA_INDEX_URL for the azure-sdk/internal/MicrosoftSweBench feed.
     if ($env:PIP_EXTRA_INDEX_URL) {
         Write-Host "PIP_EXTRA_INDEX_URL is set (feed auth configured by PipAuthenticate task)"
     } else {


### PR DESCRIPTION
## Summary

- restore benchmark pipeline authentication to `internal/MicrosoftSweBench`
- update pipeline display names and script documentation to match the restored feed name
- revert the `MicrosoftSweBenchMirror` references introduced by #3066 because the mirror was renamed back to the original feed name

## Validation

- confirmed both benchmark pipeline feed inputs use `internal/MicrosoftSweBench`
- confirmed no `internal/MicrosoftSweBenchMirror` references remain under `pipelines/`

Fixes microsoft/mcp-pr#600