### PR TITLE
eval: fix flaky deploy tests

### DIFF
--- a/evals/azure-skills/azure-deploy/deploy-eval.yaml
+++ b/evals/azure-skills/azure-deploy/deploy-eval.yaml
@@ -54,7 +54,7 @@ stimuli:
       - "Create a static whiteboard web app and deploy it to Azure using my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -85,7 +85,7 @@ stimuli:
       - "Create a static portfolio website and deploy it to Azure using my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -121,7 +121,7 @@ stimuli:
       - "Create a discussion board application and deploy it to Azure App Service using my current subscription in the westus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -152,7 +152,7 @@ stimuli:
       - "Create a todo list with frontend and API and deploy it to Azure App Service using my current subscription in the westus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -188,7 +188,7 @@ stimuli:
       - "Create a serverless HTTP API using Azure Functions and deploy it to Azure using my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -218,7 +218,7 @@ stimuli:
       - "Create an event-driven function app to process messages and deploy it to Azure using my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -248,7 +248,7 @@ stimuli:
       - "Create an azure python function app that takes input from a service bus trigger and does message processing and deploy it to Azure using my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -283,7 +283,7 @@ stimuli:
       - "Create a workflow app that orchestrates a multi-step order processing pipeline. Make the app as simple as possible for demonstration purposes only. Then deploy it to Azure using my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -327,7 +327,7 @@ stimuli:
       - "Create a containerized web application and deploy it to Azure Container Apps using my current subscription in the swedencentral region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -373,7 +373,7 @@ stimuli:
       - "Create a simple containerized Node.js hello world app and deploy it to Azure Container Apps using my current subscription in the swedencentral region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -416,7 +416,7 @@ stimuli:
       - "Create a static whiteboard web app and deploy it to Azure using Terraform infrastructure in my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -453,7 +453,7 @@ stimuli:
       - "Create a static portfolio website and deploy it to Azure using Terraform infrastructure in my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -495,7 +495,7 @@ stimuli:
       - "Create a discussion board application and deploy it to Azure App Service, prefer Terraform over Bicep, in my current subscription in the westus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -532,7 +532,7 @@ stimuli:
       - "Create a todo list with frontend and API and deploy to Azure App Service using Terraform in my current subscription in the westus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -574,7 +574,7 @@ stimuli:
       - "Create a serverless HTTP API using Azure Functions and deploy it to Azure using Terraform infrastructure in my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -610,7 +610,7 @@ stimuli:
       - "Create an event-driven function app to process messages and deploy it to Azure Functions using Terraform infrastructure in my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -646,7 +646,7 @@ stimuli:
       - "Create a URL shortener service using Azure Functions that creates short links and redirects users to the original URL and deploy it to Azure using Terraform infrastructure in my current subscription in the eastus2 region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -681,7 +681,7 @@ stimuli:
       - "Create a containerized web application and deploy it to Azure Container Apps using terraform infrastructure in my current subscription in the swedencentral region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -731,7 +731,7 @@ stimuli:
       - "Create a simple containerized Node.js hello world app and deploy it to Azure Container Apps using Terraform infrastructure in my current subscription in the swedencentral region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -769,7 +769,7 @@ stimuli:
       - "Create a simple social media application with likes and comments and deploy to Azure using Terraform infrastructure in my current subscription in the swedencentral region. Use azd as the deployment tool."
       - "Go with recommended options and proceed with Azure deployment."
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -820,7 +820,7 @@ stimuli:
       commands:
         - git clone --depth 1 https://github.com/dotnet/eShop.git .
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -863,7 +863,7 @@ stimuli:
         - git sparse-checkout set aspnetcore/tutorials/first-mvc-app/start-mvc/sample/10.0-completed
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -906,7 +906,7 @@ stimuli:
         - git sparse-checkout set samples/aspire-with-azure-functions
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -949,7 +949,7 @@ stimuli:
         - git sparse-checkout set samples/client-apps-integration
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -993,7 +993,7 @@ stimuli:
         - git sparse-checkout set samples/container-build
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -1037,7 +1037,7 @@ stimuli:
         - git sparse-checkout set samples/custom-resources
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -1075,7 +1075,7 @@ stimuli:
         - git sparse-checkout set samples/database-containers
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -1117,7 +1117,7 @@ stimuli:
         - git sparse-checkout set samples/orleans-voting
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -1164,7 +1164,7 @@ stimuli:
       commands:
         - git clone --depth 1 https://github.com/benc-uk/nodejs-demoapp.git .
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -1207,7 +1207,7 @@ stimuli:
         - git sparse-checkout set samples/aspire-with-javascript
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -1250,7 +1250,7 @@ stimuli:
         - git sparse-checkout set samples/aspire-with-node
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -1293,7 +1293,7 @@ stimuli:
       commands:
         - git clone --depth 1 https://github.com/UltiRequiem/flask-calculator.git .
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full
@@ -1336,7 +1336,7 @@ stimuli:
         - git sparse-checkout set samples/aspire-with-python
         - git checkout -q FETCH_HEAD
     constraints:
-      max_turns: 80
+      max_turns: 100
     tags:
       type: integration
       tier: full

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -617,16 +617,6 @@ function generateMarkdownReport(config: AgentRunConfig, agentMetadata: AgentMeta
         break;
       }
 
-      case "assistant.message_delta": {
-        // Accumulate deltas for streaming - we'll use the final message instead
-        const messageId = event.data.messageId as string;
-        const deltaContent = event.data.deltaContent as string;
-        if (messageId && deltaContent) {
-          messageDeltas[messageId] = (messageDeltas[messageId] || "") + deltaContent;
-        }
-        break;
-      }
-
       case "assistant.reasoning": {
         const content = event.data.content as string;
         if (content) {
@@ -1283,13 +1273,6 @@ export function doesAssistantMessageIncludeKeyword(
   agentMetadata.events.forEach(event => {
     if (event.type === "assistant.message" && event.data.messageId && event.data.content) {
       allMessages[event.data.messageId] = event.data.content;
-    }
-    if (event.type === "assistant.message_delta" && event.data.messageId) {
-      if (allMessages[event.data.messageId]) {
-        allMessages[event.data.messageId] += event.data.deltaContent ?? "";
-      } else {
-        allMessages[event.data.messageId] = event.data.deltaContent ?? "";
-      }
     }
   });
 

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -577,7 +577,6 @@ function generateMarkdownReport(config: AgentRunConfig, agentMetadata: AgentMeta
   lines.push("# Assistant");
   lines.push("");
 
-  // Track message deltas to reconstruct full messages
   const reasoningDeltas: Record<string, string> = {};
   const toolResults: Record<string, { success: boolean; timestamp: string; content?: string; error?: string; }> = {};
 
@@ -1266,7 +1265,8 @@ export function doesAssistantMessageIncludeKeyword(
   keyword: string,
   options: KeywordOptions = {}
 ): boolean {
-  // Merge all messages and message deltas
+  // Merge all messages
+  // message_delta events are skipped since the assistant.message events contain combined content of their corresponding assistant.message_delta events.
   const allMessages: Record<string, string> = {};
 
   agentMetadata.events.forEach(event => {

--- a/tests/utils/agent-runner.ts
+++ b/tests/utils/agent-runner.ts
@@ -578,7 +578,6 @@ function generateMarkdownReport(config: AgentRunConfig, agentMetadata: AgentMeta
   lines.push("");
 
   // Track message deltas to reconstruct full messages
-  const messageDeltas: Record<string, string> = {};
   const reasoningDeltas: Record<string, string> = {};
   const toolResults: Record<string, { success: boolean; timestamp: string; content?: string; error?: string; }> = {};
 

--- a/tests/utils/evaluate.ts
+++ b/tests/utils/evaluate.ts
@@ -490,13 +490,6 @@ export function getAllAssistantMessages(agentMetadata: AgentMetadata): string {
     if (event.type === "assistant.message" && event.data.messageId && event.data.content) {
       allMessages[event.data.messageId] = event.data.content;
     }
-    if (event.type === "assistant.message_delta" && event.data.messageId) {
-      if (allMessages[event.data.messageId]) {
-        allMessages[event.data.messageId] += event.data.deltaContent ?? "";
-      } else {
-        allMessages[event.data.messageId] = event.data.deltaContent ?? "";
-      }
-    }
   });
 
   return Object.values(allMessages).join("\n");


### PR DESCRIPTION
## Description

This PR addressses two issues revealed by the integration tests.

1. Some test runs exceed the 80 max turn without entering loop. I bumped all the max turns to 100 to see if they can consistently finish.
2. There is an inconsistency in how we handle agent response events. See explanation below.

Copilot CLI emits 3 kinds of events for assistant responses meant for the user: assistant.message_start, assistant.message_delta, assistant.message. assistant.message_start indicates the beginning of one response. assistant.message_delta events contain partial pieces of the message associated with the same messageId. assistant.message event contains the full message concatenating all the pieces from the assistant.message_delta events indicating the response is completed. The early terminate code terminates the agent session when the received assistant.message_delta events show that a certain pattern is matched before receiving the actual assistant.message event. However, the code that reconstructs the agent output for vally grader only look at assistant.message events. This causes some graders to fail because it doesn't see the agent response that caused the runner to terminate the session.

Although Copilot SDK had defined the event type assistant.message_delta for quite a while, our test runs never actually saw those events in the past. They had been getting only assistant.message events with full responses. After the upgrade on Aug 13th, Copilot SDK starts emitting assistant.message_delta events and triggers the bug.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
