### PR TITLE
feat: Added Referenced Workloads Updates to Azure Enterprise Infra Planner Skills (feature: Referenced Workloads)

### DIFF
--- a/evals/azure-skills/azure-enterprise-infra-planner/eval.yaml
+++ b/evals/azure-skills/azure-enterprise-infra-planner/eval.yaml
@@ -31,15 +31,17 @@ defaults:
 scoring:
   threshold: 0.8
   weights:
-    completed: 0.1
-    file-exists: 0.1
-    file-matches: 0.1
-    file-not-exists: 0.1
-    output-contains: 0.1
-    output-matches: 0.1
-    output-not-matches: 0.1
-    json-object-rules: 0.1
-    skill-invocation: 0.2
+    completed: 0.06
+    file-exists: 0.06
+    file-matches: 0.06
+    file-not-exists: 0.06
+    file-not-matches: 0.2
+    output-contains: 0.06
+    output-matches: 0.06
+    output-not-matches: 0.06
+    json-object-rules: 0.06
+    shell-command-invoked: 0.2
+    skill-invocation: 0.12
 
 stimuli:
   # ── invoke-simple-plan ──
@@ -384,6 +386,33 @@ stimuli:
       - type: file-exists
         config:
           path: "**/infra/main.tf"
+      # Phase 6 hardened gate: local validation and security scanning must run.
+      - type: shell-command-invoked
+        config:
+          required:
+            - command: '(?i)terraform(?:\s+-chdir=\S+)?\s+init\s+-backend=false\b'
+              description: "Terraform initialized without a backend"
+            - command: '(?i)terraform(?:\s+-chdir=\S+)?\s+validate\b'
+              description: "Terraform configuration validated"
+            - command: '(?i)checkov\s+-d\s+[^\r\n]*infra[/\\]?'
+              description: "Generated Terraform scanned with Checkov"
+          disallowed:
+            - command: '(?i)terraform\s+(apply|destroy)\b|az\s+deployment\s+(group|sub|mg|tenant)\s+create\b'
+              description: "Phase 6 must not deploy infrastructure"
+      # The response must prove the gate ran and emit the documented self-check.
+      - type: output-matches
+        config:
+          pattern: '(?is)(terraform\s+validate|terraform validation).{0,500}(exit\s+(code|status)\s*:?\s*0|success|succeed|pass|unavailable|not installed|not found)'
+      - type: output-matches
+        config:
+          pattern: '(?is)checkov.{0,500}(0\s+failed|pass|no unresolved (high|critical)|unavailable|not installed|not found)'
+      - type: output-matches
+        config:
+          pattern: '(?is)validation ran.{0,2000}checkov.{0,2000}secure-by-default.{0,2000}files under'
+      - type: file-not-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?i)(password|client_secret|account_key)\s*=\s*"[^"]+"'
       # Global: has_output
       - type: completed
       # Global: no_runtime_failure
@@ -684,6 +713,43 @@ stimuli:
       - type: file-exists
         config:
           path: "**/infra/main.bicep"
+      # Phase 6 hardened gate: compile and scan the generated template.
+      - type: shell-command-invoked
+        config:
+          required:
+            - command: '(?i)az\s+bicep\s+build\b[^\r\n]*--file\s+[^\r\n]*infra[/\\]main\.bicep'
+              description: "Bicep template compiled successfully"
+            - command: '(?i)checkov\s+-d\s+[^\r\n]*infra[/\\]?'
+              description: "Generated Bicep scanned with Checkov"
+          disallowed:
+            - command: '(?i)az\s+deployment\s+(group|sub|mg|tenant)\s+create\b|terraform\s+(apply|destroy)\b'
+              description: "Phase 6 must not deploy infrastructure"
+      - type: output-matches
+        config:
+          pattern: '(?is)(az\s+bicep\s+build|bicep validation).{0,500}(exit\s+(code|status)\s*:?\s*0|success|succeed|pass|unavailable|not installed|not found)'
+      - type: output-matches
+        config:
+          pattern: '(?is)checkov.{0,500}(0\s+failed|pass|no unresolved (high|critical)|unavailable|not installed|not found)'
+      - type: output-matches
+        config:
+          pattern: '(?is)validation ran.{0,2000}checkov.{0,2000}secure-by-default.{0,2000}files under'
+      # The SAP scenario includes Key Vault; verify the new secure defaults on disk.
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "enablePurgeProtection\\s*:\\s*true"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "enableRbacAuthorization\\s*:\\s*true"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "publicNetworkAccess\\s*:\\s*'Disabled'"
+      - type: file-not-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?i)(password|clientSecret|accountKey)\\s*:\\s*'[^']+'"
 
   # ── plan-hub-spoke-iot-001 ──
   # Adapted from removed IoT Telemetry → hub-spoke ingestion network topology
@@ -1038,3 +1104,396 @@ stimuli:
       - type: skill-invocation
         config:
           required: ["azure-enterprise-infra-planner"]
+
+  # ── Brownfield: referenced workloads (2) ──
+  # Declared Bicep infrastructure must be referenced and wired, never recreated.
+  - name: "Brownfield Workload - Existing Bicep is reused and wired"
+    turns:
+      - |
+        The resources declared in existing-infrastructure.bicep are already deployed.
+        Add a secure Storage account with a private endpoint in the existing
+        private-endpoints subnet. Send its diagnostics to the existing Log Analytics
+        workspace and grant a new user-assigned managed identity access to the existing
+        Key Vault. Treat every resource in the supplied file as existing: inventory and
+        reference it, wire the new resources to it, and never recreate or modify it.
+        Assume sensible defaults and prepare the preliminary resource list. Do not deploy.
+      - "Incorporate all three existing resources. The resource list looks good; proceed with the plan."
+      - "Approve the plan as-is."
+      - "Yes, generate the Bicep IaC for the approved plan. Do not deploy."
+    environment:
+      files:
+        - src: fixture/existing-infrastructure.bicep
+          dest: existing-infrastructure.bicep
+    tags:
+      type: integration
+      tier: full
+      cost: llm+execute
+      area: output-files
+      category: brownfield
+      skill: azure-enterprise-infra-planner
+    constraints:
+      max_turns: 100
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["azure-enterprise-infra-planner"]
+      - type: file-exists
+        config:
+          path: "**/.azure/infrastructure-plan.json"
+      - type: file-exists
+        config:
+          path: "**/infra/main.bicep"
+
+      # The provided declaration remains present with its original identifying content.
+      - type: file-matches
+        config:
+          path: "existing-infrastructure.bicep"
+          pattern: "(?s)fixture-id: enterprise-planner-referenced-v1.*corp-hub-vnet.*10\\.20\\.0\\.0/16.*corp-ops-law.*corp-shared-kv"
+
+      # All supplied resources are references in generated IaC, never new declarations.
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?s)resource\\s+\\w+\\s+'Microsoft\\.Network/virtualNetworks@[^']+'\\s+existing\\s*="
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?s)resource\\s+\\w+\\s+'Microsoft\\.Network/virtualNetworks/subnets@[^']+'\\s+existing\\s*="
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?s)resource\\s+\\w+\\s+'Microsoft\\.OperationalInsights/workspaces@[^']+'\\s+existing\\s*="
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?s)resource\\s+\\w+\\s+'Microsoft\\.KeyVault/vaults@[^']+'\\s+existing\\s*="
+      - type: file-not-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?s)resource\\s+\\w+\\s+'Microsoft\\.(Network/virtualNetworks(?:/subnets)?|OperationalInsights/workspaces|KeyVault/vaults)@[^']+'\\s*="
+
+      # New resources are connected to each of the three existing integration points.
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?is)Microsoft\\.Network/privateEndpoints.*subnet\\s*:\\s*\\{.*id\\s*:"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?is)Microsoft\\.Insights/diagnosticSettings.*workspaceId\\s*:"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?is)Microsoft\\.Authorization/roleAssignments.*(scope\\s*:.*keyVault|keyVault.*scope\\s*:)"
+
+      # Referenced mode still produces artifacts, but deployment remains gated.
+      - type: output-matches
+        config:
+          pattern: "(?is)(existing|referenc|additive).*(confirm|confirmation).{0,160}(deploy|deployment)|(deploy|deployment).{0,160}(confirm|confirmation)"
+      - type: shell-command-invoked
+        config:
+          disallowed:
+            - command: '(?i)az\s+deployment\s+(group|sub|mg|tenant)\s+create\b|terraform\s+(apply|destroy)\b|--mode\s+complete\b'
+              description: "No deployment or destructive mode before confirmation"
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|crashed|unhandled exception|panic:"
+
+  # Declared Terraform infrastructure must use data sources and remain untouched.
+  - name: "Brownfield Workload - Existing Terraform is reused and wired"
+    turns:
+      - |
+        The resources declared in existing-infrastructure.tf are already deployed.
+        Add a secure Storage account with a private endpoint in the existing
+        private-endpoints subnet. Send diagnostics to the existing Log Analytics
+        workspace and grant a new user-assigned managed identity access to the existing
+        Key Vault. Incorporate all existing resources through Terraform data sources;
+        never recreate or modify them. Assume sensible defaults and prepare the
+        preliminary resource list. Do not deploy.
+      - "Incorporate all existing resources. The resource list looks good; proceed with the plan."
+      - "Approve the plan as-is."
+      - "Yes, generate the Terraform IaC for the approved plan. Do not deploy."
+    environment:
+      files:
+        - src: fixture/existing-infrastructure.tf
+          dest: existing-infrastructure.tf
+    tags:
+      type: integration
+      tier: full
+      cost: llm+execute
+      area: output-files
+      category: brownfield
+      skill: azure-enterprise-infra-planner
+    constraints:
+      max_turns: 100
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["azure-enterprise-infra-planner"]
+      - type: file-exists
+        config:
+          path: "**/.azure/infrastructure-plan.json"
+      - type: file-exists
+        config:
+          path: "**/infra/main.tf"
+      - type: file-matches
+        config:
+          path: "existing-infrastructure.tf"
+          pattern: "(?s)fixture-id: enterprise-planner-referenced-tf-v1.*corp-hub-vnet-tf.*10\\.30\\.0\\.0/16.*corp-ops-law-tf.*corp-shared-kv-tf"
+
+      # Every dependency is looked up rather than placed under Terraform management.
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)data\s+"azurerm_resource_group"\s+"[^"]+"\s*\{'
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)data\s+"azurerm_virtual_network"\s+"[^"]+"\s*\{'
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)data\s+"azurerm_subnet"\s+"[^"]+"\s*\{'
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)data\s+"azurerm_log_analytics_workspace"\s+"[^"]+"\s*\{'
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)data\s+"azurerm_key_vault"\s+"[^"]+"\s*\{'
+      - type: file-not-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)resource\s+"azurerm_(resource_group|virtual_network|subnet|log_analytics_workspace|key_vault)"\s+"[^"]+"\s*\{'
+
+      # New resources are wired to all three shared services.
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)resource\s+"azurerm_private_endpoint".*subnet_id\s*=.*data\.azurerm_subnet\.'
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)resource\s+"azurerm_monitor_diagnostic_setting".*log_analytics_workspace_id\s*=.*data\.azurerm_log_analytics_workspace\.'
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)resource\s+"azurerm_role_assignment".*scope\s*=.*data\.azurerm_key_vault\.'
+      - type: output-matches
+        config:
+          pattern: "(?is)(existing|data source|referenc|additive).*(confirm|confirmation).{0,160}(deploy|deployment)|(deploy|deployment).{0,160}(confirm|confirmation)"
+      - type: shell-command-invoked
+        config:
+          disallowed:
+            - command: '(?i)terraform\s+(apply|destroy)\b|az\s+deployment\s+(group|sub|mg|tenant)\s+create\b'
+              description: "No deployment or destructive action before confirmation"
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|crashed|unhandled exception|panic:"
+
+  # ── Brownfield: reference material (3) ──
+  # A security baseline must shape the generated plan and Bicep without being edited.
+  - name: "Brownfield Reference Material - Security baseline"
+    turns:
+      - |
+        Use security-baseline.md as authoritative reference material for a confidential
+        document archive. Plan a Storage account, Key Vault, private endpoints, a
+        user-assigned managed identity, and Log Analytics diagnostics. Apply every
+        relevant requirement from the document. Assume sensible defaults and prepare
+        the preliminary resource list. Do not deploy.
+      - "The resource list looks good; proceed with the plan."
+      - "Approve the plan as-is."
+      - "Yes, generate the Bicep IaC for the approved plan. Do not deploy."
+    environment:
+      files:
+        - src: fixture/security-baseline.md
+          dest: security-baseline.md
+    tags:
+      type: integration
+      tier: full
+      cost: llm+execute
+      area: output-files
+      category: brownfield
+      skill: azure-enterprise-infra-planner
+    constraints:
+      max_turns: 100
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["azure-enterprise-infra-planner"]
+      - type: file-exists
+        config:
+          path: "**/.azure/infrastructure-plan.json"
+      - type: file-exists
+        config:
+          path: "**/infra/main.bicep"
+      - type: file-matches
+        config:
+          path: "security-baseline.md"
+          pattern: "(?s)fixture-id: enterprise-planner-security-v1.*data-classification.*confidential.*cost-center.*CC-4100"
+      - type: file-matches
+        config:
+          path: "**/.azure/infrastructure-plan.json"
+          pattern: "(?i)confidential|CC-4100"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?s)allowSharedKeyAccess\\s*:\\s*false.*minimumTlsVersion\\s*:\\s*'TLS1_2'|minimumTlsVersion\\s*:\\s*'TLS1_2'.*allowSharedKeyAccess\\s*:\\s*false"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?s)enableRbacAuthorization\\s*:\\s*true.*enablePurgeProtection\\s*:\\s*true|enablePurgeProtection\\s*:\\s*true.*enableRbacAuthorization\\s*:\\s*true"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "publicNetworkAccess\\s*:\\s*'Disabled'"
+      - type: file-not-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?i)(password|clientSecret|accountKey)\\s*:\\s*'[^']+'"
+      - type: shell-command-invoked
+        config:
+          disallowed:
+            - command: '(?i)az\s+deployment\s+(group|sub|mg|tenant)\s+create\b|terraform\s+(apply|destroy)\b'
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|crashed|unhandled exception|panic:"
+
+  # Network standards must carry through to a generated Terraform topology.
+  - name: "Brownfield Reference Material - Network standards"
+    turns:
+      - |
+        Use network-standards.md as reference material to plan a private Azure
+        Container Apps environment with Azure Container Registry and Blob Storage.
+        Apply its region, naming, address-space, subnet, DNS, egress, and tagging
+        requirements. Assume sensible defaults and prepare the preliminary resource
+        list. Do not deploy.
+      - "The resource list looks good; proceed with the plan."
+      - "Approve the plan as-is."
+      - "Yes, generate the Terraform IaC for the approved plan. Do not deploy."
+    environment:
+      files:
+        - src: fixture/network-standards.md
+          dest: network-standards.md
+    tags:
+      type: integration
+      tier: full
+      cost: llm+execute
+      area: output-files
+      category: brownfield
+      skill: azure-enterprise-infra-planner
+    constraints:
+      max_turns: 100
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["azure-enterprise-infra-planner"]
+      - type: file-exists
+        config:
+          path: "**/.azure/infrastructure-plan.json"
+      - type: file-exists
+        config:
+          path: "**/infra/main.tf"
+      - type: file-matches
+        config:
+          path: "network-standards.md"
+          pattern: "(?s)fixture-id: enterprise-planner-network-v1.*westus3.*10\\.42\\.0\\.0/16.*private-endpoints.*privatelink\\.blob\\.core\\.windows\\.net"
+      - type: file-matches
+        config:
+          path: "**/.azure/infrastructure-plan.json"
+          pattern: "(?i)westus3|10\\.42\\.0\\.0/16|NW-PROD"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)resource\s+"azurerm_virtual_network".*10\.42\.0\.0/16'
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)resource\s+"azurerm_subnet".*10\.42\.2\.0/24'
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?i)privatelink\.blob\.core\.windows\.net'
+      - type: file-not-matches
+        config:
+          path: "**/infra/**/*.tf"
+          pattern: '(?s)resource\s+"azurerm_public_ip"'
+      - type: shell-command-invoked
+        config:
+          disallowed:
+            - command: '(?i)terraform\s+(apply|destroy)\b|az\s+deployment\s+(group|sub|mg|tenant)\s+create\b'
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|crashed|unhandled exception|panic:"
+
+  # Governance requirements must produce subscription-scope policy and RBAC IaC.
+  - name: "Brownfield Reference Material - Governance requirements"
+    turns:
+      - |
+        Use governance-requirements.md as authoritative reference material to plan a
+        subscription landing-zone extension. Apply all location, policy, RBAC, required
+        tag, and audit requirements from the document. Assume sensible defaults and
+        prepare the preliminary resource list. Do not deploy.
+      - "The resource list looks good; proceed with the plan."
+      - "Approve the plan as-is."
+      - "Yes, generate the Bicep IaC for the approved plan. Do not deploy."
+    environment:
+      files:
+        - src: fixture/governance-requirements.md
+          dest: governance-requirements.md
+    tags:
+      type: integration
+      tier: full
+      cost: llm+execute
+      area: output-files
+      category: brownfield
+      skill: azure-enterprise-infra-planner
+    constraints:
+      max_turns: 100
+    graders:
+      - type: skill-invocation
+        config:
+          required: ["azure-enterprise-infra-planner"]
+      - type: file-exists
+        config:
+          path: "**/.azure/infrastructure-plan.json"
+      - type: file-exists
+        config:
+          path: "**/infra/main.bicep"
+      - type: file-matches
+        config:
+          path: "governance-requirements.md"
+          pattern: "(?s)fixture-id: enterprise-planner-governance-v1.*eastus2.*westus3.*owner.*cost-center.*environment"
+      - type: file-matches
+        config:
+          path: "**/.azure/infrastructure-plan.json"
+          pattern: "(?i)policy|role assignment|rbac|governance"
+      - type: file-matches
+        config:
+          path: "**/infra/main.bicep"
+          pattern: "targetScope\\s*=\\s*'subscription'"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "Microsoft\\.Authorization/policyAssignments@"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "Microsoft\\.Authorization/roleAssignments@"
+      - type: file-matches
+        config:
+          path: "**/infra/**/*.bicep"
+          pattern: "(?is)owner.*cost-center.*environment|environment.*cost-center.*owner"
+      - type: shell-command-invoked
+        config:
+          disallowed:
+            - command: '(?i)az\s+deployment\s+(group|sub|mg|tenant)\s+create\b|terraform\s+(apply|destroy)\b'
+      - type: completed
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|crashed|unhandled exception|panic:"

--- a/evals/azure-skills/azure-enterprise-infra-planner/fixture/existing-infrastructure.bicep
+++ b/evals/azure-skills/azure-enterprise-infra-planner/fixture/existing-infrastructure.bicep
@@ -1,0 +1,55 @@
+// fixture-id: enterprise-planner-referenced-v1
+targetScope = 'resourceGroup'
+
+param location string = 'eastus2'
+
+resource hubVnet 'Microsoft.Network/virtualNetworks@2024-05-01' = {
+  name: 'corp-hub-vnet'
+  location: location
+  properties: {
+    addressSpace: {
+      addressPrefixes: [
+        '10.20.0.0/16'
+      ]
+    }
+    subnets: [
+      {
+        name: 'private-endpoints'
+        properties: {
+          addressPrefix: '10.20.2.0/24'
+          privateEndpointNetworkPolicies: 'Disabled'
+        }
+      }
+    ]
+  }
+}
+
+resource operationsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+  name: 'corp-ops-law'
+  location: location
+  properties: {
+    retentionInDays: 30
+    sku: {
+      name: 'PerGB2018'
+    }
+    features: {
+      enableLogAccessUsingOnlyResourcePermissions: true
+    }
+  }
+}
+
+resource sharedKeyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+  name: 'corp-shared-kv'
+  location: location
+  properties: {
+    tenantId: subscription().tenantId
+    sku: {
+      family: 'A'
+      name: 'standard'
+    }
+    accessPolicies: []
+    enableRbacAuthorization: true
+    enablePurgeProtection: true
+    publicNetworkAccess: 'Disabled'
+  }
+}

--- a/evals/azure-skills/azure-enterprise-infra-planner/fixture/existing-infrastructure.tf
+++ b/evals/azure-skills/azure-enterprise-infra-planner/fixture/existing-infrastructure.tf
@@ -1,0 +1,53 @@
+# fixture-id: enterprise-planner-referenced-tf-v1
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_client_config" "current" {}
+
+resource "azurerm_resource_group" "shared" {
+  name     = "corp-shared-rg-tf"
+  location = "eastus2"
+}
+
+resource "azurerm_virtual_network" "hub" {
+  name                = "corp-hub-vnet-tf"
+  location            = azurerm_resource_group.shared.location
+  resource_group_name = azurerm_resource_group.shared.name
+  address_space       = ["10.30.0.0/16"]
+}
+
+resource "azurerm_subnet" "private_endpoints" {
+  name                 = "private-endpoints"
+  resource_group_name  = azurerm_resource_group.shared.name
+  virtual_network_name = azurerm_virtual_network.hub.name
+  address_prefixes     = ["10.30.2.0/24"]
+}
+
+resource "azurerm_log_analytics_workspace" "operations" {
+  name                = "corp-ops-law-tf"
+  location            = azurerm_resource_group.shared.location
+  resource_group_name = azurerm_resource_group.shared.name
+  sku                 = "PerGB2018"
+  retention_in_days   = 30
+}
+
+resource "azurerm_key_vault" "shared" {
+  name                          = "corp-shared-kv-tf"
+  location                      = azurerm_resource_group.shared.location
+  resource_group_name           = azurerm_resource_group.shared.name
+  tenant_id                     = data.azurerm_client_config.current.tenant_id
+  sku_name                      = "standard"
+  enable_rbac_authorization     = true
+  purge_protection_enabled      = true
+  public_network_access_enabled = false
+}

--- a/evals/azure-skills/azure-enterprise-infra-planner/fixture/governance-requirements.md
+++ b/evals/azure-skills/azure-enterprise-infra-planner/fixture/governance-requirements.md
@@ -1,0 +1,11 @@
+# Subscription Governance Requirements
+
+<!-- fixture-id: enterprise-planner-governance-v1 -->
+
+- Generate subscription-scope infrastructure for a landing-zone extension.
+- Restrict resource locations to `eastus2` and `westus3` using Azure Policy.
+- Deny public IP creation unless an exemption is approved.
+- Require the tags `owner`, `cost-center`, and `environment` on resource groups and resources.
+- Assign built-in least-privilege RBAC roles to platform operators and auditors.
+- Send policy and activity audit data to a central Log Analytics workspace.
+- All policy and role assignment names must be deterministic across deployments.

--- a/evals/azure-skills/azure-enterprise-infra-planner/fixture/network-standards.md
+++ b/evals/azure-skills/azure-enterprise-infra-planner/fixture/network-standards.md
@@ -1,0 +1,11 @@
+# Platform Network Standards
+
+<!-- fixture-id: enterprise-planner-network-v1 -->
+
+- Deploy production platform networks in `westus3` with the naming prefix `NW-PROD`.
+- Allocate VNet address space `10.42.0.0/16`.
+- Use `10.42.0.0/24` for ingress, `10.42.1.0/24` for applications, and `10.42.2.0/24` for private endpoints.
+- Workloads must have controlled outbound egress and no public IP resources.
+- Use private endpoints for registries and data services.
+- Create and link private DNS zones, including `privatelink.blob.core.windows.net`.
+- Tag resources with `network-zone=production` and `cost-center=CC-4200`.

--- a/evals/azure-skills/azure-enterprise-infra-planner/fixture/security-baseline.md
+++ b/evals/azure-skills/azure-enterprise-infra-planner/fixture/security-baseline.md
@@ -1,0 +1,13 @@
+# Enterprise Security Baseline
+
+<!-- fixture-id: enterprise-planner-security-v1 -->
+
+Apply these controls to every new workload:
+
+- Primary region: `eastus2`.
+- Tag all resources with `data-classification=confidential` and `cost-center=CC-4100`.
+- Data services must disable public network access and use private endpoints.
+- Storage must set `allowSharedKeyAccess=false`, require TLS 1.2, and use managed identity with RBAC.
+- Key Vault must use RBAC, soft delete, purge protection, and no public network access.
+- Secrets and access keys must never appear in source or outputs.
+- Send audit and resource logs to Log Analytics with 90-day retention.

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/SKILL.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: azure-enterprise-infra-planner
-description: "Architect and provision enterprise Azure infrastructure from workload descriptions. For cloud architects and platform engineers planning networking, identity, security, compliance, and multi-resource topologies with WAF alignment. Generates Bicep or Terraform directly (no azd). Hardened validation and security gates: every generated template is validated, security-scanned, and secure-by-default before it is offered. WHEN: 'plan Azure infrastructure', 'architect Azure landing zone', 'design hub-spoke network', 'plan multi-region DR topology', 'set up VNets firewalls and private endpoints', 'subscription-scope Bicep deployment', 'Azure Backup for VM workloads'. PREFER azure-prepare FOR app-centric workflows."
+description: "Architect WAF-aligned enterprise Azure infrastructure for networking, identity, security, compliance, and multi-resource topologies. Generates secure, validated Bicep or Terraform (no azd). WHEN: 'plan Azure infrastructure', 'architect Azure landing zone', 'design hub-spoke network', 'plan multi-region DR topology', 'set up VNets firewalls and private endpoints', 'subscription-scope Bicep deployment', 'Azure Backup for VM workloads'. PREFER azure-prepare FOR app-centric workflows."
 license: MIT
 metadata:
   author: Microsoft
-  version: "2.0.0"
+  version: "0.0.0-placeholder"
 ---
 
 # Azure Enterprise Infra Planner

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/SKILL.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/SKILL.md
@@ -4,7 +4,7 @@ description: "Architect and provision enterprise Azure infrastructure from workl
 license: MIT
 metadata:
   author: Microsoft
-  version: "2.0.0"
+  version: "0.0.0-placeholder"
 ---
 
 # Azure Enterprise Infra Planner

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/SKILL.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: azure-enterprise-infra-planner
-description: "Architect and provision enterprise Azure infrastructure from workload descriptions. For cloud architects and platform engineers planning networking, identity, security, compliance, and multi-resource topologies with WAF alignment. Generates Bicep or Terraform directly (no azd). WHEN: 'plan Azure infrastructure', 'architect Azure landing zone', 'design hub-spoke network', 'plan multi-region DR topology', 'set up VNets firewalls and private endpoints', 'subscription-scope Bicep deployment', 'Azure Backup for VM workloads'. PREFER azure-prepare FOR app-centric workflows."
+description: "Architect and provision enterprise Azure infrastructure from workload descriptions. For cloud architects and platform engineers planning networking, identity, security, compliance, and multi-resource topologies with WAF alignment. Generates Bicep or Terraform directly (no azd). Hardened validation and security gates: every generated template is validated, security-scanned, and secure-by-default before it is offered. WHEN: 'plan Azure infrastructure', 'architect Azure landing zone', 'design hub-spoke network', 'plan multi-region DR topology', 'set up VNets firewalls and private endpoints', 'subscription-scope Bicep deployment', 'Azure Backup for VM workloads'. PREFER azure-prepare FOR app-centric workflows."
 license: MIT
 metadata:
   author: Microsoft
-  version: "0.0.0-placeholder"
+  version: "2.0.0"
 ---
 
 # Azure Enterprise Infra Planner
@@ -24,13 +24,65 @@ Activate this skill when user wants to:
 | Property | Details |
 |---|---|
 | MCP tools | `insights_get`, `get_azure_bestpractices_get`, `wellarchitectedframework_serviceguide_get`, `microsoft_docs_fetch`, `microsoft_docs_search`, `bicepschema_get` |
-| CLI commands | `az deployment group create`, `az bicep build`, `az resource list`, `terraform init`, `terraform plan`, `terraform validate`, `terraform apply` |
+| CLI commands | `az deployment group create`, `az bicep build`, `az resource list`, `terraform init`, `terraform plan`, `terraform validate`, `terraform apply`, `checkov` |
 | Output schema | [schema.md](references/schema.md) |
 | Key references | [workflow.md](references/workflow.md), [waf-checklist.md](references/waf-checklist.md), [resources/](references/resources/README.md), [constraints/](references/constraints/README.md) |
 
 ## Workflow (Start Here)
 
 Follow the step-by-step instructions in [workflow.md](references/workflow.md) to execute the 7 phases of infrastructure planning and provisioning.
+
+## Architecture
+
+The skill runs a **7-phase, gated pipeline**. Input is triaged into one of two flows:
+
+- **Greenfield** — only new requirements; run the phases straight through.
+- **Referenced (brownfield)** — the user supplies something that already exists (a live resource /
+  resource group / subscription, IaC or an infra plan, or a requirements doc). The same phases run, plus
+  [referenced-workload.md](references/referenced-workload.md): existing resources are inventoried and
+  referenced (never recreated), the new workload is wired into them, and **Phase 7 deploys additively**
+  (incremental only — never modifying or destroying the referenced resources).
+
+Every phase advances only after its gate passes. Phase 5 requires explicit user approval; **Phase 6 is a
+hardened, self-verifying gate** — the generated IaC must be secure-by-default, pass local validation
+(`az bicep build` / `terraform validate`) with zero errors, pass a `checkov` security scan with no
+unresolved high/critical findings, and the skill must **show the command output** and emit a completion
+self-check before advancing; Phase 7 requires an explicit, risk-acknowledged deploy confirmation.
+
+```mermaid
+flowchart TD
+    IN([Input]) --> TRIAGE{Existing infra<br/>referenced?}
+    TRIAGE -- "No (greenfield)" --> P1
+    TRIAGE -- "Yes (referenced)" --> RW[/referenced-workload.md:<br/>inventory + assign roles<br/>reference, never recreate/]
+    RW --> P1
+
+    subgraph PIPE [7-phase gated pipeline]
+        direction TB
+        P1[Phase 1 · Extract insights] --> P2[Phase 2 · Research best practices]
+        P2 --> P3[Phase 3 · Research resources]
+        P3 --> P4[Phase 4 · Generate plan]
+        P4 --> P5{Phase 5 · Verify<br/>user approves?}
+        P5 -- "no" --> P4
+        P5 -- "approved" --> P6[Phase 6 · Generate IaC]
+        P6 --> VAL{Validate<br/>az bicep build /<br/>terraform validate}
+        VAL -- "errors" --> P6
+        VAL -- "clean" --> P7{Phase 7 · Deploy<br/>risk-ack confirm?}
+    end
+
+    P7 -- "greenfield" --> DEP[az deployment / terraform apply]
+    P7 -- "referenced" --> DEPADD[Additive deploy · incremental only<br/>what-if preview · no destroy of<br/>referenced resources]
+    DEP --> OUT([Deployed])
+    DEPADD --> OUT
+
+    classDef gate fill:#fff3cd,stroke:#d39e00,color:#000;
+    classDef ref fill:#e2f0d9,stroke:#548235,color:#000;
+    class P5,VAL,P7,TRIAGE gate;
+    class RW,DEPADD ref;
+```
+
+**Artifacts** (written under `<project-root>/`): `.azure/insights.json` (Phase 1),
+`.azure/infrastructure-plan.json` (Phase 4, status `draft`→`approved`→`deployed`), and
+`infra/main.bicep` + `infra/modules/*` or `infra/main.tf` + `infra/modules/**` (Phase 6).
 
 ## MCP Tools
 

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/SKILL.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: azure-enterprise-infra-planner
-description: "Architect WAF-aligned enterprise Azure infrastructure for networking, identity, security, compliance, and multi-resource topologies. Generates secure, validated Bicep or Terraform (no azd). WHEN: 'plan Azure infrastructure', 'architect Azure landing zone', 'design hub-spoke network', 'plan multi-region DR topology', 'set up VNets firewalls and private endpoints', 'subscription-scope Bicep deployment', 'Azure Backup for VM workloads'. PREFER azure-prepare FOR app-centric workflows."
+description: "Architect and provision enterprise Azure infrastructure from workload descriptions. For cloud architects and platform engineers planning networking, identity, security, compliance, and multi-resource topologies with WAF alignment. Generates Bicep or Terraform directly (no azd). WHEN: 'plan Azure infrastructure', 'architect Azure landing zone', 'design hub-spoke network', 'plan multi-region DR topology', 'set up VNets firewalls and private endpoints', 'subscription-scope Bicep deployment', 'Azure Backup for VM workloads'. PREFER azure-prepare FOR app-centric workflows."
 license: MIT
 metadata:
   author: Microsoft

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/bicep-generation.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/bicep-generation.md
@@ -69,3 +69,25 @@ infra/
 ## Validation Before Deployment
 
 Run `az bicep build --file infra/main.bicep` to validate syntax before deploying.
+
+## Correctness Checklist (must pass `az bicep build` with zero errors)
+
+Generate against these rules, then run `az bicep build` and fix in-place until clean. These are the
+failures that most often break validation:
+
+1. **No undeclared symbols.** Every `param`, `var`, `resource`, and `module` symbol you reference is
+   declared in the same file. Cross-file values flow only through `module` params and `output`s.
+2. **Cross-module outputs (BCP053).** When one module consumes `moduleX.outputs.Y`, that module MUST
+   declare `output Y ...`. Verify every consumed output exists on the producing module.
+3. **`existing` references are complete.** Referenced resources use the `existing` keyword with the
+   correct type, `name` (and `scope`/`parent` where required); never emit a new `resource` for them.
+4. **Required properties present.** Use the schema fetched in step 3 — include every required property
+   and use only allowed enum values and a valid, real `@apiVersion` for each type.
+5. **Types match.** Parameter/variable types match their usage; no string passed where an object/int is
+   expected; array vs. single-object usage is consistent.
+6. **`main.bicepparam` matches `main.bicep`.** Every `param` assigned in `.bicepparam` exists in
+   `main.bicep`; every required (non-defaulted) param is assigned; `using` points at `./main.bicep`.
+7. **`targetScope` matches the deploy command** and any `resourceGroup()`/`subscription()` usage.
+8. **No secrets in output.** Never `output` a secret; mark secret params `@secure()`.
+
+If `az bicep build` is unavailable, self-review every item above before presenting.

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/phases/1-extract-insights.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/phases/1-extract-insights.md
@@ -2,7 +2,7 @@
 
 > The goal of this phase is to extract insights from the user's existing Azure environment. These insights will be used to guide the planning process in later phases.
 
-1. Check whether insights already exist at `<project-root>/.azure/insights.json`. If they do, reuse the existing entries and skip the tenant scan in steps 2–6. In referenced mode, still execute step 7 before completing the gate; in greenfield mode, proceed to the gate.
+1. Check whether insights already exist at `<project-root>/.azure/insights.json`. If they do, reuse the existing entries and skip the scan in steps 2–6. In referenced mode, still execute step 7 before completing the gate; in greenfield mode, proceed to the gate.
 2. If no insights file exists, check whether the `insights_get` tool is available. If it is not, initialize the file with `[]`, then continue to step 7 in referenced mode or proceed to the gate in greenfield mode.
 3. Ask the user which scope to use for generating insights. Present these three options:
    a. "Subscription-scoped (default subscription)" — use this as the default if the user does not respond.
@@ -17,7 +17,7 @@
    f. "Other" — this should be a custom input field.
 5. Run the `insights_get` tool using a general-purpose subagent. Pass a one-line summary via the `--query` option that describes the user's infrastructure and the types of insights to prioritise. Do not pass the `--nocache` flag unless the user has explicitly asked for it. Begin Phase 2 while this tool runs.
 6. Once the tool finishes, save the resulting JSON to `<project-root>/.azure/insights.json`. Do not include tool call metadata. If the tool errors or returns no insights, write an empty array `[]` to the file instead.
-7. In referenced mode, merge one insight entry for every existing resource into the current insights array. Set `existingResource.id`, `type`, `name`, `role`, `must_not_recreate: true`, and `integrationPoints` using the normalized inventory. Preserve full ARM IDs for actual-state resources and do not duplicate an entry already identified by the same resource ID. Do this even when the resource produces no broader tenant insight.
+7. In referenced mode, merge one insight entry for every existing resource into the current insights array. Set `existingResource.id`, `type`, `name`, `role`, `must_not_recreate: true`, and `integrationPoints` using the normalized inventory. Preserve full ARM IDs for actual-state resources and do not duplicate an entry already identified by the same resource ID. Do this even when the resource produces no broader insight.
 
 ## Gate
 

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/phases/1-extract-insights.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/phases/1-extract-insights.md
@@ -2,8 +2,8 @@
 
 > The goal of this phase is to extract insights from the user's existing Azure environment. These insights will be used to guide the planning process in later phases.
 
-1. Check whether insights already exist at `<project-root>/.azure/insights.json`. If they do, reuse them and skip the rest of this phase.
-2. Check whether the `insights_get` tool is available. If it is not, skip this phase.
+1. Check whether insights already exist at `<project-root>/.azure/insights.json`. If they do, reuse the existing entries and skip the tenant scan in steps 2–6. In referenced mode, still execute step 7 before completing the gate; in greenfield mode, proceed to the gate.
+2. If no insights file exists, check whether the `insights_get` tool is available. If it is not, initialize the file with `[]`, then continue to step 7 in referenced mode or proceed to the gate in greenfield mode.
 3. Ask the user which scope to use for generating insights. Present these three options:
    a. "Subscription-scoped (default subscription)" — use this as the default if the user does not respond.
    b. "Subscription-scoped (choose a subscription)" — if selected, ask the user to provide a subscription name or ID.
@@ -17,7 +17,9 @@
    f. "Other" — this should be a custom input field.
 5. Run the `insights_get` tool using a general-purpose subagent. Pass a one-line summary via the `--query` option that describes the user's infrastructure and the types of insights to prioritise. Do not pass the `--nocache` flag unless the user has explicitly asked for it. Begin Phase 2 while this tool runs.
 6. Once the tool finishes, save the resulting JSON to `<project-root>/.azure/insights.json`. Do not include tool call metadata. If the tool errors or returns no insights, write an empty array `[]` to the file instead.
+7. In referenced mode, merge one insight entry for every existing resource into the current insights array. Set `existingResource.id`, `type`, `name`, `role`, `must_not_recreate: true`, and `integrationPoints` using the normalized inventory. Preserve full ARM IDs for actual-state resources and do not duplicate an entry already identified by the same resource ID. Do this even when the resource produces no broader tenant insight.
 
 ## Gate
 
 - `insights.json` must exist and match the Insights Schema defined in [schema.md](../schema.md). If the tool errored or returned no insights, the file should contain an empty array `[]`.
+- In referenced mode, every inventoried existing resource has an `existingResource` entry with `must_not_recreate: true`; actual-state entries preserve their full ARM IDs.

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/phases/6-generate-iac.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/phases/6-generate-iac.md
@@ -2,8 +2,27 @@
 
 > Important: Before continuing this phase, `meta.status` must be set to `approved` as required by Phase 5.
 
-1. Ask the user whether to generate Bicep, Terraform, or stop here. Never accept vague statements such as "continue", "yes", "go ahead", "proceed", or "make it". Only continue if the user instructs you to generate IaC and names the flavor (e.g. "yes, generate the Bicep" or "go ahead with Terraform").
+1. Ask the user whether to generate Bicep or Terraform.
 2. Generate IaC from the approved plan. Refer to [bicep-generation.md](../bicep-generation.md) for Bicep or [terraform-generation.md](../terraform-generation.md) for Terraform.
+3. **Apply secure-by-default (mandatory).** Unless the approved plan explicitly overrides a control, every generated resource must use:
+   - Private endpoints and `publicNetworkAccess: Disabled` on data/PaaS services — no unnecessary public exposure.
+   - Managed identity + RBAC instead of keys/connection strings; no secrets in code (`@secure()` / `sensitive = true`).
+   - Storage `allowSharedKeyAccess: false`; Key Vault soft-delete + purge protection; AKS managed identity with local accounts disabled.
+   - Minimum TLS 1.2 and encryption in transit.
+4. **Validate, security-scan, and fix until clean (mandatory, self-verifying).** No-deploy, purely local:
+   - **Bicep:** run `az bicep build --file infra/main.bicep`.
+   - **Terraform:** run `terraform init -backend=false` then `terraform validate` in `infra/`.
+   - **Security scan:** run `checkov -d infra/` and resolve every high/critical finding.
+   - If any command reports errors or unresolved high/critical findings, fix the files in-place and re-run. Repeat until every command exits cleanly.
+   - **Prove it:** paste the exact command(s) run and their final exit status / summary into your response. Do not claim the gate passed without showing the output. If a tool is genuinely unavailable, say so explicitly and self-review against the generation correctness checklist and the secure-by-default list above.
+5. **Emit the completion self-check.** End Phase 6 with this checklist, each line marked pass/fail with a one-line reason:
+   - [ ] Validation ran and exited clean (output shown)
+   - [ ] `checkov` ran; no unresolved high/critical findings
+   - [ ] Secure-by-default applied (private endpoints, MI/RBAC, TLS 1.2, no secrets)
+   - [ ] Referenced resources wired, none recreated (referenced mode only)
+   - [ ] Files under `infra/`; original source artifacts untouched
 
 ## Gate
-- All required IaC files generated and saved to disk.
+- All required IaC files generated and saved to disk under `<project-root>/infra/`.
+- `az bicep build` (Bicep) or `terraform validate` (Terraform) **and** `checkov` complete with zero errors and no unresolved high/critical findings, **with the command output shown in the response**.
+- The completion self-check is emitted with every item passing (or an explicit, justified exception).

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/referenced-workload.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/referenced-workload.md
@@ -1,0 +1,99 @@
+# Referenced-Workload Handling (on-demand)
+
+> Read this when the user provides something that already EXISTS — a live Azure resource / resource
+> group / subscription, IaC (Bicep/Terraform/ARM) or an infra plan, or a general doc describing current
+> infrastructure/requirements. If the input is purely NEW requirements with nothing existing, it's
+> greenfield — ignore this file and run the normal phases.
+
+## The switched-up flow (referenced mode)
+1. **Confirm it's referenced.** Does anything already exist (a resource group/subscription, IaC/plan, or
+   a doc describing current resources)? If yes, use this flow.
+2. **Inventory the existing resources** from whatever was provided. Capture a COMPLETE inventory — every
+   resource type, plus topology/relationships (VNet/subnet, private endpoints, identity bindings) and key
+   configurations (SKU/tier, TLS version, public-access setting, region). Do not omit resources or invent
+   ones that are not present:
+   - **Resource group / subscription** → introspect (`az resource list` / `az graph query`) → real
+     resources **with resource IDs**.
+   - **IaC / infra plan** (Bicep/Terraform/ARM, `infrastructure-plan.json`, `terraform show -json`) →
+     parse `resource` / `existing` / `data` blocks → logical resources.
+   - **General doc** → extract any existing resources it mentions.
+3. **Gather insights from ALL provided context.** Mine every input the user gave — docs, IaC comments,
+   resource tags, requirements, naming conventions, region, resiliency tier, PADU/preferences, cost and
+   compliance constraints — and record them as insights (the same channel Phase 3 already applies).
+   These shape the new workload just like tenant insights do.
+4. **Surface them and ask which to incorporate.** Present the existing resources you found and ask which
+   ones to **incorporate** (reference + wire) into the new workload. Recommend a sensible default —
+   incorporate the ones the new workload clearly depends on; never recreate them.
+5. **Generate the complete IaC** incorporating the chosen (or recommended-default) existing resources:
+   reference them (`existing` / `data`, real ID for live, a `param` otherwise) and **wire** the new
+   resources to them, honoring the gathered insights. Never emit a new `resource` for something that
+   already exists.
+
+## Answer-first (ask AND generate — never stall)
+Open with a **plain-language summary of the existing infrastructure** you inventoried and the additive
+change you understood, then an **explicit confirmation checkpoint** ("Confirm this understanding before I
+proceed to deploy"), and **then** generate the complete, deployable IaC in the SAME response using the
+recommended default. Order within the turn: (1) summary of what exists + what you'll add, (2) explicit
+"confirm before I proceed" gate, (3) the generated IaC, (4) the "which to incorporate?" choice and any
+assumptions. Never end a turn with only a summary or a question, and never deploy before the user
+confirms. If you lack a value (region, an existing resource's ID/name), **declare a parameter and
+proceed.** The confirmation gate governs deployment (Phase 7), not whether you generate the plan/IaC —
+you always generate; you never deploy without an explicit, risk-acknowledged go-ahead.
+
+## Inputs (three shapes → one normalized inventory)
+| Shape | Inputs | Referencing precision |
+|---|---|---|
+| **Actual state** | a live Azure resource, resource group, or subscription | real resource **IDs** → reference exactly (`existing`/`data`) |
+| **Declared state** | Bicep / Terraform / ARM, or an infra plan (`infrastructure-plan.json`, `terraform show -json`) | logical → reference by **parameter** (or build, if it's a spec) |
+| **Requirements/context** | any general doc with info/requirements the user wants | mine for requirements + any existing-resource mentions |
+
+Inputs can combine (e.g. a resource group + a requirements doc). If a declared file is ambiguous
+("reference existing vs. build new?"), make the most likely assumption, state it, and generate — ask at
+most one question, after the code.
+
+## For each existing resource, assign a ROLE (the "if needed" filter)
+- **Reference + integrate** — the new workload depends on it → reference it AND **wire it in**:
+  RBAC role assignment, diagnostics → existing Log Analytics, private endpoints into the existing
+  VNet/subnet, secrets from the existing Key Vault, connection to the existing Event Hubs, use the
+  existing managed identity, etc.
+- **Retain** — keep, must not recreate, nothing new connects → leave it; note "retained, out of scope".
+- **Ignore** — irrelevant → omit.
+
+**Never emit a new `resource` for a resource that already exists.** Reference it.
+
+## Deploy (referenced mode)
+Referenced mode **does not skip Phase 7** — the deliverable is deployed new infrastructure that
+integrates with what already exists. Run [phases/7-deploy.md](phases/7-deploy.md) with these guardrails:
+
+- **Same destructive-action gate.** Present the risks and require an explicit, risk-acknowledged
+  "deploy" reply sent *after* the risks are shown. The original prompt never satisfies the gate.
+- **Additive only.** The deployment must *add* the new resources and their wiring. The referenced
+  resources are declared as `existing`/`data` (not `resource`), so a normal deploy never touches them.
+- **Incremental mode, never Complete.** For Bicep use the default **incremental** mode — never
+  `--mode Complete` (it would delete resources absent from the template, including the referenced ones).
+  For Terraform, the referenced resources are `data` sources / `import`ed, so `apply` must show **no
+  destroy** against them — abort if the plan proposes destroying or replacing a referenced resource.
+- **Preview first.** Always run `az deployment ... --what-if` (Bicep) or `terraform plan` (Terraform)
+  and confirm the diff only *creates* new resources and *modifies nothing* on the referenced ones before
+  applying.
+- **Deploy into the existing scope when integrating.** Target the referenced resource group/subscription
+  so RBAC, private endpoints, and diagnostics wire into the existing resources.
+
+
+## How this rides the existing phases
+- **Phase 1:** normalize the reference into `insights.json` — existing resources (real ID or param),
+  `must_not_recreate`, integration points, requirements, tier.
+- **Phase 3:** existing "apply insights" logic assigns roles and picks references over new resources.
+- **Phase 5:** verify — (a) no duplicate of an existing resource; (b) **every declared dependency on an
+  existing resource is actually wired**; (c) cross-module `outputs.X` you consume is declared by that
+  module (prevents `BCP053`); (d) source unmodified.
+- **Phase 6:** emit new resources (secure-by-default) + `existing`/`data` references + the wiring.
+  Real ID inline for actual-state; a `param` for declared/doc inputs.
+- **Phase 7:** DO NOT skip deploy — run Phase 7 like greenfield, honoring the destructive-action gate.
+  The difference is scope: deploy **only the new resources and their wiring**; never modify, recreate,
+  or destroy the referenced/existing resources. See "Deploy (referenced mode)" below.
+
+## Secure-by-default (Phase 6)
+Private endpoints + `publicNetworkAccess: Disabled` on data services; managed identity over keys;
+storage `allowSharedKeyAccess: false`; Key Vault soft-delete + purge protection; AKS managed identity +
+disable local accounts; minimum TLS 1.2.

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/schema.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/schema.md
@@ -44,9 +44,35 @@
 ## Insights Schema
 
 ```ts
-{
-  id: string // Stable identifier (e.g., "insight-001"); cited from inputs.insightsApplied
-  pattern: string // Observed fact from the tenant scan (what is true today)
-  implication: string // Recommended planning action derived from the pattern
-}[]
+type ExistingResource = {
+  id: string // Full ARM ID for actual state; logical or parameter reference otherwise
+  type: string // ARM resource type (e.g., "Microsoft.Network/virtualNetworks")
+  name: string
+  role: "reference-and-integrate" | "retain" | "ignore"
+  must_not_recreate: true
+  integrationPoints: string[] // Connections or dependencies involving the new workload
+}
+
+type Insight =
+  | {
+      id: string // Stable identifier (e.g., "insight-001"); cited from inputs.insightsApplied
+      pattern: string // Observed fact from the tenant scan or referenced workload
+      implication: string // Recommended planning action derived from the pattern
+      existingResource?: ExistingResource
+    }
+  | {
+      id: string // Stable identifier for a resource-only entry
+      existingResource: ExistingResource
+      pattern?: string // Include with implication when the resource produces a broader insight
+      implication?: string
+    }
+
+type Insights = Insight[]
 ```
+
+In referenced mode:
+
+- Include exactly one entry for every inventoried existing resource, uniquely identified by `existingResource.id`.
+- Preserve the full ARM ID in `existingResource.id` for actual-state resources.
+- Use an empty `integrationPoints` array when the resource has no integration points.
+- A resource-only entry may omit `pattern` and `implication`; when recording a broader insight, include both.

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/terraform-generation.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/terraform-generation.md
@@ -85,3 +85,27 @@ Deploy with: `terraform apply -var-file=prod.tfvars`
 ## Validation Before Deployment
 
 Run `terraform validate` and `terraform plan` to verify before applying.
+
+## Correctness Checklist (must pass `terraform validate` with zero errors)
+
+Generate against these rules, then run `terraform init -backend=false` + `terraform validate` and fix
+in-place until clean. These are the failures that most often break validation:
+
+1. **Every referenced value is declared.** Each `var.X` has a `variable "X"` block; each `local.X` is
+   defined; each `module.X`/`azurerm_*.X` reference exists. No references to undeclared symbols.
+2. **Module wiring is complete.** Values passed into a child module map to declared `variable` blocks in
+   that module; values read as `module.X.Y` map to declared `output "Y"` in that child module.
+3. **Existing resources use `data`/`import`, not new `resource`.** Reference pre-existing infra via
+   `data` sources (or `import`), and wire new resources to them — never recreate them.
+4. **Valid provider + required attributes.** `required_providers` pins `azurerm` (`~> 4.0`), the
+   `provider "azurerm"` block has `features {}`, and every resource sets its required arguments with
+   valid enum values and correctly-typed attributes.
+5. **Correct block vs. attribute syntax.** Nested blocks (e.g. `identity`, `site_config`,
+   `ip_configuration`) use block syntax; scalars use `=`. No unsupported/renamed arguments for the
+   pinned provider version.
+6. **`tfvars` match variables.** Every value in `terraform.tfvars`/`*.tfvars` corresponds to a declared
+   `variable`; every variable without a default is supplied.
+7. **No secrets in code.** Secrets come from variables (`sensitive = true`) or Key Vault data sources,
+   never hardcoded literals.
+
+If `terraform` is unavailable, self-review every item above before presenting.

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/workflow.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/workflow.md
@@ -5,12 +5,25 @@
 - You must execute the seven phases in sequential order. Follow the instructions precisely as defined. Do not continue to the next phase until the current phase is complete.
 - You must stop on all "gate" conditions and only continue when the conditions have been met.
 - Destructive actions require explicit user confirmation.
+- **Confirmation gate vs. answer-first.** Always present a plain-language summary of your understanding plus an explicit "confirm before I proceed" checkpoint *before deploying* (Phase 7). In referenced mode you still generate the plan and IaC in the same turn (answer-first) — the gate governs *deployment*, not whether you produce the artifacts. Never end a turn with only a question, and never deploy without an explicit, risk-acknowledged go-ahead.
+- **Never claim a gate passed without proof.** When a phase gate depends on a command (validation, security scan), run it and show its actual output/exit status; do not assert success from memory.
 - You must read each phase's reference file in full before executing it.
 - Never assume knowledge and cut corners or skip research steps.
 
 ## Overview
 
 Starting from Phase 1, execute all phases in sequential order. Do not advance to the next phase until the current phase is complete and all of its gate conditions have been met.
+
+## Phase 6 — hardened generation gate (apply inline)
+
+The detailed generation reference files may not be loaded in every environment, so the Phase 6 gate is restated here and is mandatory. After generating the IaC, and **before** offering it or advancing to deploy:
+
+1. **Secure-by-default.** Every resource: private endpoints + public network access disabled on data/PaaS services; managed identity + RBAC (never keys/connection strings); no secrets in code; storage shared-key access disabled; Key Vault soft-delete + purge protection; AKS managed identity with local accounts disabled; TLS 1.2 minimum.
+2. **Validate + security-scan, fix until clean.** Bicep: `az bicep build --file infra/main.bicep`. Terraform: `terraform init -backend=false` then `terraform validate`. Then `checkov -d infra/`. Fix in-place and re-run until every command passes. **Paste the actual command output / exit status into your response** — never claim the gate passed without showing it. If a tool is genuinely unavailable, say so and self-review against the secure-by-default list.
+3. **Completion self-check.** End Phase 6 with a checklist, each line marked pass/fail: validation clean (output shown); `checkov` no unresolved high/critical; secure-by-default applied; referenced resources wired and none recreated (referenced mode); files under `infra/` with original sources untouched.
+
+
+> **Referenced workload?** If the user supplies something existing to reference or integrate with — a live Azure resource/resource group/subscription, a Bicep/Terraform/ARM file or infra plan, or a general doc of requirements/context — also read [referenced-workload.md](referenced-workload.md) and apply it alongside these phases. If not, run greenfield exactly as below.
 
 | Phase | Action | Reference | Key Gate |
 |-------|--------|-----------|----------|
@@ -44,3 +57,10 @@ Before writing any `.bicep` or `.tf` files in Phase 6:
 1. Create the `infra/` directory at `<project-root>/infra/`.
 2. Create `infra/modules/` for child modules.
 3. Write `main.bicep` (or `main.tf`) inside `infra/`, not in the project root or `.azure/`.
+
+
+// look into bicep and terraform for referenced resources
+// look into infra plans
+// look into deployment - 
+// add referenced workloads to golden dataset
+

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/workflow.md
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/references/workflow.md
@@ -59,8 +59,4 @@ Before writing any `.bicep` or `.tf` files in Phase 6:
 3. Write `main.bicep` (or `main.tf`) inside `infra/`, not in the project root or `.azure/`.
 
 
-// look into bicep and terraform for referenced resources
-// look into infra plans
-// look into deployment - 
-// add referenced workloads to golden dataset
 

--- a/plugins/azure-skills/skills/azure-enterprise-infra-planner/version.json
+++ b/plugins/azure-skills/skills/azure-enterprise-infra-planner/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.3",
+  "version": "1.4",
   "pathFilters": [
     "."
   ]


### PR DESCRIPTION
## Description

Added Referenced Workloads Updated to Azure Enterprise Infra Planner Skills. Now, it can handle brownfield and greenfield scenarios. 

## Checklist

- [Yes] Tests pass locally (`cd tests && npm test`)
- [Yes] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [Yes] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)
