### PR TITLE
fix: detect Cursor client in telemetry hook via cursor_version field

### DIFF
--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -227,12 +227,14 @@ $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
 # Detect client name based on input format
 # Copilot CLI (>=0.0.421): COPILOT_CLI env var is "1" — primary signal, checked first
 # Copilot CLI (<0.0.421):  has "toolArgs" field without "hook_event_name" — backward compat fallback
+# Cursor: has hook_event_name AND a "cursor_version" field
 # VS Code: has hook_event_name AND tool_use_id contains "__vscode" or transcript_path contains "Code"
 # Claude Code: has hook_event_name, tool_use_id does NOT contain "__vscode"
 $hasHookEventName = $inputData.PSObject.Properties.Name -contains "hook_event_name"
 $hasToolArgs = $inputData.PSObject.Properties.Name -contains "toolArgs"
 $toolUseId = $inputData.tool_use_id
 $transcriptPath = $inputData.transcript_path
+$cursorVersion = $inputData.cursor_version
 $isVscodeToolUseId = $toolUseId -and ($toolUseId -match '__vscode')
 # Match path separators around "Code" or "Code - Insiders" to avoid matching "Claude Code"
 $isVscodeTranscript = $transcriptPath -and ($transcriptPath -match '[/\\]Code( - Insiders)?[/\\]')
@@ -240,6 +242,8 @@ $isVscodeTranscript = $transcriptPath -and ($transcriptPath -match '[/\\]Code( -
 # Copilot CLI check first — env var available since v0.0.421
 if ($env:COPILOT_CLI -eq "1") {
     $clientName = "copilot-cli"
+} elseif ($hasHookEventName -and $cursorVersion) {
+    $clientName = "cursor"
 } elseif ($hasHookEventName -and ($isVscodeToolUseId -or $isVscodeTranscript)) {
     # Detect VS Code variant from transcript_path
     # Insiders: ...AppData\Roaming\Code - Insiders\User\...

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -245,6 +245,7 @@ timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Detect client name based on input format
 # Copilot CLI (>=0.0.421): COPILOT_CLI env var is "1" — primary signal, checked first
 # Copilot CLI (<0.0.421):  has "toolArgs" field without "hook_event_name" — backward compat fallback
+# Cursor: has hook_event_name AND a "cursor_version" field
 # VS Code: has hook_event_name AND tool_use_id contains "__vscode" or transcript_path contains "Code"
 # Claude Code: has hook_event_name, tool_use_id does NOT contain "__vscode"
 if [ "$COPILOT_CLI" = "1" ]; then
@@ -252,10 +253,13 @@ if [ "$COPILOT_CLI" = "1" ]; then
 elif echo "$rawInput" | grep -q '"hook_event_name"'; then
     toolUseId=$(extract_json_field "$rawInput" "tool_use_id")
     transcriptPath=$(extract_json_field "$rawInput" "transcript_path")
+    cursorVersion=$(extract_json_field "$rawInput" "cursor_version")
     # Normalize backslashes to forward slashes for consistent matching
     transcriptPathNorm=$(echo "$transcriptPath" | tr '\\' '/')
+    if [ -n "$cursorVersion" ]; then
+        clientName="cursor"
     # Match path separators around "Code" or "Code - Insiders" to avoid matching "Claude Code"
-    if [[ "$toolUseId" == *"__vscode"* ]] || [[ "$transcriptPathNorm" == */Code/* ]] || [[ "$transcriptPathNorm" == */Code\ -\ Insiders/* ]]; then
+    elif [[ "$toolUseId" == *"__vscode"* ]] || [[ "$transcriptPathNorm" == */Code/* ]] || [[ "$transcriptPathNorm" == */Code\ -\ Insiders/* ]]; then
         # Detect VS Code variant from transcript_path
         # Insiders: ...AppData/Roaming/Code - Insiders/User/...
         # Stable:   ...AppData/Roaming/Code/User/...


### PR DESCRIPTION
## Summary

The `track-telemetry.sh` / `track-telemetry.ps1` hook scripts detect the calling client based on the shape of the `postToolUse` payload. Cursor's payload includes `hook_event_name` but was previously indistinguishable from Claude Code's format, so Cursor telemetry was being misclassified as `claude-code`.

Cursor payloads include a `cursor_version` field. Both scripts now check for `cursor_version` (when `hook_event_name` is present) before falling through to the VS Code / Claude Code checks, and classify the client as `cursor`.

Fixes #3099

## Testing

Verified against a real Cursor `postToolUse` payload (with `COPILOT_CLI` unset, since it's normally `1` in dev shells and would otherwise short-circuit detection):

- `hooks/scripts/track-telemetry.ps1` → resolves `clientName=cursor`
- `hooks/scripts/track-telemetry.sh` → resolves `clientName=cursor`

Both scripts still exit cleanly with `{"continue":true}`, and existing VS Code / Claude Code / Copilot CLI detection branches are unchanged.
