### PR TITLE
chore: log plugin version

### DIFF
--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -333,7 +333,6 @@ $shouldTrack = $false
 $eventType = $null
 $skillName = $null
 $skillVersion = $null
-$pluginVersion = Get-PluginVersion
 $azureToolName = $null
 $filePath = $null
 
@@ -432,6 +431,8 @@ if (-not $filePath -and -not $skillName) {
 # === STEP 3: Publish event ===
 
 if ($shouldTrack) {
+    $pluginVersion = Get-PluginVersion
+
     # Build MCP command arguments
     $mcpArgs = @(
         "server", "plugin-telemetry",

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -182,6 +182,20 @@ function Get-SkillVersion {
     return $null
 }
 
+# Extract the plugin version from the top-level .plugin/plugin.json manifest.
+# Returns $null if the file or expected JSON value cannot be read.
+function Get-PluginVersion {
+    $pluginManifestPath = Join-Path (Split-Path -Parent $skillsDir) '.plugin/plugin.json'
+    if (-not (Test-Path -LiteralPath $pluginManifestPath)) { return $null }
+    try {
+        $manifest = Get-Content -LiteralPath $pluginManifestPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        if ($manifest.version -is [string] -and -not [string]::IsNullOrWhiteSpace($manifest.version)) {
+            return $manifest.version
+        }
+    } catch { }
+    return $null
+}
+
 # === Main Processing ===
 
 # Read entire stdin at once - hooks send one complete JSON per invocation
@@ -319,6 +333,7 @@ $shouldTrack = $false
 $eventType = $null
 $skillName = $null
 $skillVersion = $null
+$pluginVersion = Get-PluginVersion
 $azureToolName = $null
 $filePath = $null
 
@@ -428,6 +443,7 @@ if ($shouldTrack) {
     if ($sessionId) { $mcpArgs += "--session-id"; $mcpArgs += $sessionId }
     if ($skillName) { $mcpArgs += "--skill-name"; $mcpArgs += $skillName }
     if ($skillVersion) { $mcpArgs += "--skill-version"; $mcpArgs += $skillVersion }
+    if ($pluginVersion) { $mcpArgs += "--plugin-version"; $mcpArgs += $pluginVersion }
     if ($azureToolName) { $mcpArgs += "--tool-name"; $mcpArgs += $azureToolName }
     # Convert forward slashes to backslashes for azmcp allowlist compatibility
     if ($filePath) { $mcpArgs += "--file-reference"; $mcpArgs += ($filePath -replace '/', '\') }

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -164,6 +164,20 @@ get_skill_version() {
         | sed -E 's/^[[:space:]]*version:[[:space:]]*//; s/^["'"'"']//; s/["'"'"'][[:space:]]*$//; s/[[:space:]]*$//'
 }
 
+# Extract the plugin version from the top-level .plugin/plugin.json manifest.
+# Prints nothing if the file or expected JSON value cannot be read.
+get_plugin_version() {
+    local pluginManifestPath
+    pluginManifestPath="$(dirname "$SKILLS_DIR")/.plugin/plugin.json"
+    [ -f "$pluginManifestPath" ] || return 0
+    node -e '
+        try {
+            const manifest = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
+            if (typeof manifest.version === "string" && manifest.version) process.stdout.write(manifest.version);
+        } catch { }
+    ' "$pluginManifestPath" 2>/dev/null
+}
+
 # === JSON Parsing Functions (using sed - portable across platforms) ===
 
 # Extract simple string field from JSON
@@ -326,6 +340,7 @@ shouldTrack=false
 eventType=""
 skillName=""
 skillVersion=""
+pluginVersion=$(get_plugin_version)
 azureToolName=""
 filePath=""
 
@@ -421,6 +436,7 @@ if [ "$shouldTrack" = true ]; then
     [ -n "$sessionId" ] && mcpArgs+=("--session-id" "$sessionId")
     [ -n "$skillName" ] && mcpArgs+=("--skill-name" "$skillName")
     [ -n "$skillVersion" ] && mcpArgs+=("--skill-version" "$skillVersion")
+    [ -n "$pluginVersion" ] && mcpArgs+=("--plugin-version" "$pluginVersion")
     [ -n "$azureToolName" ] && mcpArgs+=("--tool-name" "$azureToolName")
     # Convert forward slashes to backslashes for azmcp allowlist compatibility
     [ -n "$filePath" ] && mcpArgs+=("--file-reference" "$(echo "$filePath" | tr '/' '\\')")

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -340,7 +340,6 @@ shouldTrack=false
 eventType=""
 skillName=""
 skillVersion=""
-pluginVersion=$(get_plugin_version)
 azureToolName=""
 filePath=""
 
@@ -425,6 +424,8 @@ fi
 # === STEP 3: Publish event via azmcp ===
 
 if [ "$shouldTrack" = true ]; then
+    pluginVersion=$(get_plugin_version)
+
     # Build MCP command arguments (using array for proper quoting)
     mcpArgs=(
         "server" "plugin-telemetry"


### PR DESCRIPTION
## Description

Log plugin version from track-telemetry hooks. They would help us catch bugs in the script that blocks sending telemetry.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:integration -- <skill>` or `npm run test:vally -- --skill <skill>`)

## Related Issues

semi-related to #2979.
