### PR TITLE
feature: polish appinsights-instrumentation skill

### DIFF
--- a/plugins/azure-skills/skills/appinsights-instrumentation/SKILL.md
+++ b/plugins/azure-skills/skills/appinsights-instrumentation/SKILL.md
@@ -48,7 +48,7 @@ No matter which option you choose, recommend the user to create the App Insights
 - If the app is a Node.js app, see [NODEJS guide](references/nodejs.md) for how to modify the JavaScript/TypeScript code.
 - If the app is a Python app, see [PYTHON guide](references/python.md) for how to modify the Python code.
 
-If you have tools to edit code, make the changes and explain what they do. Otherwise, show what changes need to be made.
+For manual instrumentation, if you have tools to edit code, make the changes and explain what they do. Otherwise, show what changes need to be made.
 
 ## SDK Quick References
 

--- a/plugins/azure-skills/skills/appinsights-instrumentation/SKILL.md
+++ b/plugins/azure-skills/skills/appinsights-instrumentation/SKILL.md
@@ -11,31 +11,13 @@ metadata:
 
 This skill provides **guidance and reference material** for instrumenting webapps with Azure Application Insights.
 
-> **⛔ ADDING COMPONENTS?**
->
-> If the user wants to **add App Insights to their app**, invoke **azure-prepare** instead.
-> This skill provides reference material—azure-prepare orchestrates the actual changes.
-
-## When to Use This Skill
-
-- User asks **how** to instrument (guidance, patterns, examples)
-- User needs SDK setup instructions
-- azure-prepare invokes this skill during research phase
-- User wants to understand App Insights concepts
-
-## When to Use azure-prepare Instead
-
-- User says "add telemetry to my app"
-- User says "add App Insights" 
-- User wants to modify their project
-- Any request to change/add components
-
 ## Prerequisites
 
 The app in the workspace must be one of these kinds
 
 - An ASP.NET Core app hosted in Azure
 - A Node.js app hosted in Azure
+- A Python app hosted in Azure
 
 ## Guidelines
 
@@ -65,6 +47,8 @@ No matter which option you choose, recommend the user to create the App Insights
 - If the app is an ASP.NET Core app, see [ASPNETCORE guide](references/aspnetcore.md) for how to modify the C# code.
 - If the app is a Node.js app, see [NODEJS guide](references/nodejs.md) for how to modify the JavaScript/TypeScript code.
 - If the app is a Python app, see [PYTHON guide](references/python.md) for how to modify the Python code.
+
+If you have tools to edit code, make the changes and explain what they do. Otherwise, show what changes need to be made.
 
 ## SDK Quick References
 


### PR DESCRIPTION
## Description

Polish appinsights-instrumentation skill content:

- Removed content that aren't of much value. There is no point describing when to use the skill in the skill body since it doesn't help routing.
- Added a missing bullet point for python app
- Added an explicit instruction to persuade the LLM to make code changes 

## Additional note:

I ran a set of comparison tests for this skill using the comparison script. The result indicates the skill brings two differentiating benefits:

1. Consistently prevents the LLM from importing random 3rd party packages. Some no-skill runs end up suggesting a deprecated 3rd package "opencensus-ext-azure".
2. Recommends codeless auto-instrument approach for C# ASP.NET apps. No-skill runs frequently fail to mention it when it's available.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
