### PR TITLE
misc: revert additional path pattern for kusto graph plugin

### DIFF
--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -74,8 +74,7 @@
 #     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
 #     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
 #
-#   Recognized install paths (one set per plugin, see $pathPatterns below):
-#     azure-skills:
+#   Recognized azure-skills install paths:
 #     - .copilot/installed-plugins/<catalog-name>/azure/skills/...
 #       (<catalog-name> is the marketplace/catalog folder the plugin was
 #       installed under, e.g. "awesome-copilot" — it does not necessarily
@@ -83,11 +82,6 @@
 #     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
 #     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
 #     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
-#     azure-kusto-graph-skills:
-#     - .copilot/installed-plugins/<catalog-name>/azure-kusto-graph-skills/skills/...
-#     - .claude/plugins/cache/azure-skills/azure-kusto-graph-skills/<version>/skills/...
-#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/...
-#     shared:
 #     - .agents/skills/...
 #
 #   If the path matches AND is not a SKILL.md file, the relative path after
@@ -295,32 +289,14 @@ function Get-ToolInputPath {
 
 # === STEP 2: Determine what to track for azmcp ===
 
-# Path patterns per client, one block per plugin (used for SKILL.md and
-# file-reference matching). Add a new block (with the "azure-skills"
-# segments swapped for the new plugin's name) when onboarding another plugin.
-
-# --- azure-skills plugin ---
-# The Copilot CLI pattern wildcards the catalog/marketplace folder name
-# (e.g. "awesome-copilot") since it does not necessarily match the plugin's
-# own name ("azure").
+# Azure-skills path patterns per client (used for SKILL.md and file-reference matching)
 $pathPatternCopilot = '\.copilot/installed-plugins/[^/]+/azure/skills/'
 $pathPatternClaude = '\.claude/plugins/cache/(azure-skills|claude-plugins-official)/azure/[0-9.]+/skills/'
 $pathPatternVscodeAgentPlugins = 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-skills/skills/'
-
-# --- azure-kusto-graph-skills plugin ---
-$pathPatternCopilotKustoGraph = '\.copilot/installed-plugins/[^/]+/azure-kusto-graph-skills/skills/'
-$pathPatternClaudeKustoGraph = '\.claude/plugins/cache/azure-skills/azure-kusto-graph-skills/[0-9.]+/skills/'
-$pathPatternVscodeAgentPluginsKustoGraph = 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-kusto-graph-skills/skills/'
-
-# --- shared across all plugins ---
 $pathPatternAgentsSkills = '\.agents/skills/'
 
 # Put the path patterns into an array for easier iteration
-$pathPatterns = @(
-    $pathPatternCopilot, $pathPatternClaude, $pathPatternVscodeAgentPlugins,
-    $pathPatternCopilotKustoGraph, $pathPatternClaudeKustoGraph, $pathPatternVscodeAgentPluginsKustoGraph,
-    $pathPatternAgentsSkills
-)
+$pathPatterns = @($pathPatternCopilot, $pathPatternClaude, $pathPatternVscodeAgentPlugins, $pathPatternAgentsSkills)
 
 # If $env:AZURE_SKILLS_PLUGIN_ROOT is set, add it to the path patterns for local skill development
 if ($env:AZURE_SKILLS_PLUGIN_ROOT) {

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -76,8 +76,7 @@
 #     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
 #     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
 #
-#   Recognized install paths (one set per plugin, see is_azure_skills_path):
-#     azure-skills:
+#   Recognized azure-skills install paths:
 #     - .copilot/installed-plugins/<catalog-name>/azure/skills/...
 #       (<catalog-name> is the marketplace/catalog folder the plugin was
 #       installed under, e.g. "awesome-copilot" — it does not necessarily
@@ -85,11 +84,6 @@
 #     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
 #     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
 #     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
-#     azure-kusto-graph-skills:
-#     - .copilot/installed-plugins/<catalog-name>/azure-kusto-graph-skills/skills/...
-#     - .claude/plugins/cache/azure-skills/azure-kusto-graph-skills/<version>/skills/...
-#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/...
-#     shared:
 #     - .agents/skills/...
 #
 #   If the path matches AND is not a SKILL.md file, the relative path after
@@ -302,30 +296,15 @@ fi
 
 # === STEP 2: Determine what to track for azmcp ===
 
-# Check if a path matches any known plugin skills folder structure.
-# Each plugin has its own block below — add a new block (with the
-# "azure-skills" segments swapped for the new plugin's name) when onboarding
-# another plugin. Returns 0 (true) if matched, 1 (false) otherwise.
+# Check if a path matches any known azure-skills folder structure
+# Returns 0 (true) if matched, 1 (false) otherwise
 is_azure_skills_path() {
     local p="$1"
-
-    # --- azure-skills plugin ---
-    # The Copilot CLI pattern wildcards the catalog/marketplace folder name
-    # (e.g. "awesome-copilot") since it does not necessarily match the
-    # plugin's own name ("azure").
     [[ "$p" == *".copilot/installed-plugins/"*"/azure/skills/"* ]] && return 0
     [[ "$p" == *".claude/plugins/cache/azure-skills/azure/"*"/skills/"* ]] && return 0
     [[ "$p" == *".claude/plugins/cache/claude-plugins-official/azure/"*"/skills/"* ]] && return 0
     [[ "$p" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/"* ]] && return 0
-
-    # --- azure-kusto-graph-skills plugin ---
-    [[ "$p" == *".copilot/installed-plugins/"*"/azure-kusto-graph-skills/skills/"* ]] && return 0
-    [[ "$p" == *".claude/plugins/cache/azure-skills/azure-kusto-graph-skills/"*"/skills/"* ]] && return 0
-    [[ "$p" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/"* ]] && return 0
-
-    # --- shared across all plugins ---
     [[ "$p" == *".agents/skills/"* ]] && return 0
-
     # Local plugin development: match paths under AZURE_SKILLS_PLUGIN_ROOT/skills/
     # (e.g. when loading a local plugin via `--plugin-dir`)
     if [ -n "$AZURE_SKILLS_PLUGIN_ROOT" ]; then
@@ -452,4 +431,3 @@ fi
 
 # Output success to stdout (required by hooks)
 return_success
-


### PR DESCRIPTION
## Description

Revert expanded reference file path filter to help troubleshoot telemetry drop.

Telemetry data dropped significantly since the expanded reference file path filter was merged. Although there is no clear evidence that these changes caused it, I would like to revert them for now and see if the event count recovers. This could help us further confirm if the root cause of the drop is these changes.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
