### PR TITLE
fix: out-of-date rbac info in foundry skill

### DIFF
--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/references/foundry-tool-catalog.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/create/references/foundry-tool-catalog.md
@@ -48,13 +48,13 @@ PUT https://management.azure.com/subscriptions/{sub}/resourceGroups/{rg}
 
 ### Preflight RBAC
 
-Caller needs **Azure AI Developer** or **Cognitive Services Contributor** on the project scope. Run this before the first PUT to surface 403s early:
+Caller needs **Foundry Project Manager** or **Cognitive Services Contributor** on the project scope. Run this before the first PUT to surface 403s early:
 
 ```pwsh
 $oid = az ad signed-in-user show --query id -o tsv
 $projId = "/subscriptions/$sub/resourceGroups/$rg/providers/Microsoft.CognitiveServices/accounts/$acct/projects/$proj"
-az role assignment list --assignee $oid --scope $projId --all `
-  --query "[?roleDefinitionName=='Azure AI Developer' || roleDefinitionName=='Cognitive Services Contributor'].roleDefinitionName" -o tsv
+az role assignment list --assignee $oid --scope $projId --include-inherited --all `
+  --query "[?roleDefinitionName=='Foundry Project Manager' || roleDefinitionName=='Cognitive Services Contributor'].roleDefinitionName" -o tsv
 ```
 
 Empty output → caller lacks the required role; expect `403 AuthorizationFailed` on PUT until granted.
@@ -674,7 +674,7 @@ The response body for `/mcp` is plain JSON (no SSE `data:` framing) despite the 
 
 | Operation | Role |
 |---|---|
-| PUT any connection above | **Azure AI Developer** on the project (or **Cognitive Services Contributor** on the account) |
+| PUT any connection above | **Foundry Project Manager** on the project (or **Cognitive Services Contributor** on the account) |
 | Drive OAuth consent (`gateway_connector`, `catalog_MCP` managed-OAuth) | The end-user themselves, signed in to the subscription's tenant |
 | `ProjectManagedIdentity` against a Cognitive Services upstream | Project MI needs the upstream's data-plane role (e.g. `Cognitive Services Language Owner` for `/language/mcp`) |
 

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/toolbox/references/mcp-protocol.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/toolbox/references/mcp-protocol.md
@@ -34,7 +34,8 @@ Verify the MCP endpoint end-to-end with a bearer token + raw `tools/list` / `too
 |---------|--------------|
 | `TOOLBOX_ENDPOINT` not set | Run `azd ai toolbox show` + `azd env set`. |
 | Env var missing in deployed agent | Add to the agent service's `environmentVariables` in `azure.yaml`, `azd deploy`. |
-| `403 Forbidden` (incl. `POST /toolboxes`, connection PUT) | Caller lacks `Foundry User` (or `Azure AI Developer`) on the project — grant at project scope. |
+| `403 Forbidden` on toolbox data-plane requests, including `POST /toolboxes` | Caller lacks `Foundry User` on the project — grant at project scope. |
+| `403 Forbidden` on connection PUT | Caller lacks `Foundry Project Manager` (or `Cognitive Services Contributor`) on the project — grant at project scope. |
 | 400 `Multiple tools without identifiers found` | Two unnamed tools (or duplicate `server_label`) — keep **at most one unnamed tool**; name each other. See [toolbox-azd.md § Multi-tool rule](toolbox-azd.md#multi-tool-rule). |
 | `tools/list` returns zero | Version still provisioning, or tool type unavailable in region — wait ~10s, retry, or try another region. |
 | `tools/list` zero for MCP/A2A only | Invalid/missing connection creds — verify `project_connection_id`; for MI auth, check RBAC on the target. |

--- a/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/toolbox/references/tool-mcp-managed-oauth.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/foundry-agent/toolbox/references/tool-mcp-managed-oauth.md
@@ -98,7 +98,8 @@ MCP-sourced tools surface as `{server_label}___{tool_name}` (three underscores).
 |---|---|
 | `tools/list` returns zero after consent | Wrong `--target` (not the MCP server URL), or the connector needs the `gateway_connector` two-PUT flow instead — see [foundry-tool-catalog.md](../../create/references/foundry-tool-catalog.md). |
 | `invalid_payload: unsupported authType` | API version drift — re-check allowed `authType` for `RemoteTool` in the [projects REST API](https://learn.microsoft.com/rest/api/aiservices/). |
-| `403 Forbidden` on connection PUT / toolbox POST | Caller lacks **Foundry User** / **Azure AI Developer** on the project — grant at project scope. |
+| `403 Forbidden` on connection PUT | Caller lacks **Foundry Project Manager** (or **Cognitive Services Contributor**) on the project — grant at project scope. |
+| `403 Forbidden` on toolbox data-plane POST | Caller lacks **Foundry User** on the project — grant at project scope. |
 
 ## References
 

--- a/plugins/azure-skills/skills/microsoft-foundry/rbac/rbac.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/rbac/rbac.md
@@ -23,6 +23,7 @@ Reference for managing RBAC for Microsoft Foundry resources: user permissions, m
 
 | Role | Create Projects | Data Actions | Role Assignments |
 |------|-----------------|--------------|------------------|
+| Foundry Agent Consumer | No | Invoke agents only | No |
 | Foundry User | No | Yes | No |
 | Foundry Project Manager | Yes | Yes | Yes (Foundry User only) |
 | Foundry Account Owner | Yes | No | Yes (Foundry User only) |
@@ -79,7 +80,7 @@ az role definition list --name "Foundry User" --query "[].permissions[].actions"
 
 | Action | Required Role(s) |
 |--------|------------------|
-| Deploy models | Foundry User, Foundry Project Manager, Foundry Owner |
+| Deploy models | Foundry Account Owner, Foundry Owner |
 | Create projects | Foundry Project Manager, Foundry Account Owner, Foundry Owner |
 | Assign Foundry User role | Foundry Project Manager, Foundry Account Owner, Foundry Owner |
 | Full data access | Foundry User, Foundry Project Manager, Foundry Owner |
@@ -124,7 +125,7 @@ az role assignment create --role "Contributor" --assignee "$SP_APP_ID" --scope "
 
 | CI/CD Scenario | Recommended Role | Additional Roles |
 |----------------|------------------|------------------|
-| Deploy models only | Foundry User | None |
+| Deploy models only | Foundry Account Owner | None |
 | Manage projects | Foundry Project Manager | None |
 | Full provisioning | Foundry Owner | Contributor (on RG) |
 | Read-only monitoring | Reader | Foundry User (for data) |
@@ -140,7 +141,7 @@ az account set --subscription "<subscription-id>"
 
 | Issue | Cause | Resolution |
 |-------|-------|------------|
-| "Authorization failed" when deploying | Missing Foundry User role | Assign Foundry User role at resource scope |
+| "Authorization failed" when deploying models | Missing Foundry Account Owner or Foundry Owner role | Assign Foundry Account Owner at account scope |
 | Cannot create projects | Missing Project Manager or Owner role | Assign Foundry Project Manager role |
 | "Access denied" on connected resources | Managed identity missing roles | Assign appropriate roles to MI on each resource |
 | Portal works but CLI fails | Portal auto-assigns roles, CLI doesn't | Explicitly assign Foundry User via CLI |

--- a/plugins/azure-skills/skills/microsoft-foundry/resource/private-network/references/post-deployment-validation.md
+++ b/plugins/azure-skills/skills/microsoft-foundry/resource/private-network/references/post-deployment-validation.md
@@ -62,11 +62,11 @@ Expect a self-referencing private endpoint to the account plus private endpoints
 
 The template does not assign data-plane roles automatically.
 
-Assign `Azure AI Developer` at the **account** scope (management-plane):
+Assign `Foundry Account Owner` at the **account** scope (management-plane):
 
 ```bash
 az role assignment create \
-  --role "Azure AI Developer" \
+  --role "Foundry Account Owner" \
   --assignee <your-object-id-or-email> \
   --scope /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.CognitiveServices/accounts/<ai-account-name>
 ```


### PR DESCRIPTION
## Description

Replace legacy `Azure AI Developer` guidance with operation-specific Microsoft Foundry roles:

- Use `Foundry User` for toolbox data-plane operations.
- Use `Foundry Project Manager` for project connection management, while preserving `Cognitive Services Contributor` as an alternative.
- Use `Foundry Account Owner` for model deployment.
- Add `Foundry Agent Consumer` to the RBAC reference.
- Correct existing model deployment role guidance.
- Include inherited role assignments in the connection RBAC preflight check.

The role mappings were verified against Microsoft Learn and Azure built-in role definitions.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

Fixes https://github.com/microsoft/GitHub-Copilot-for-Azure/issues/3098