### PR TITLE
fix: remove azure-compliance skill triggers in skill body

### DIFF
--- a/plugins/azure-skills/skills/azure-compliance/SKILL.md
+++ b/plugins/azure-skills/skills/azure-compliance/SKILL.md
@@ -17,27 +17,6 @@ metadata:
 | Primary capabilities | Comprehensive Resources Assessment, Key Vault Expiration Monitoring |
 | MCP tools | azqr, subscription and resource group listing, Key Vault item inspection |
 
-## When to Use This Skill
-
-- Run azqr or Azure Quick Review for compliance assessment
-- Validate Azure resource configuration against best practices
-- Identify orphaned or misconfigured resources
-- Audit Key Vault keys, secrets, and certificates for expiration
-
-## Skill Activation Triggers
-
-Activate this skill when user wants to:
-- Check Azure compliance or best practices
-- Assess Azure resources for configuration issues
-- Run azqr or Azure Quick Review
-- Identify orphaned or misconfigured resources
-- Review Azure security posture
-- "Show me expired certificates/keys/secrets in my Key Vault"
-- "Check what's expiring in the next 30 days"
-- "Audit my Key Vault for compliance"
-- "Find secrets without expiration dates"
-- "Check certificate expiration dates"
-
 ## Prerequisites
 
 - Authentication: user is logged in to Azure via `az login`


### PR DESCRIPTION
## Description

Remove the redundant "When to Use This Skill" and "Skill Activation Triggers" sections from the Azure compliance skill. Trigger guidance remains in the skill frontmatter, reducing duplication and keeping the skill body focused on execution guidance.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

None.