### PR TITLE
feat: add Azure Functions hosting and cold-start guidance

### DIFF
--- a/plugins/azure-skills/skills/azure-prepare/SKILL.md
+++ b/plugins/azure-skills/skills/azure-prepare/SKILL.md
@@ -70,7 +70,7 @@ Activate this skill when user wants to:
 |----------------|-------------|
 | Python + App Service (e.g., "deploy Python to App Service", "Flask on Azure App Service", "publish Python web app to App Service") | **python-appservice-deploy** |
 | Lambda, AWS Lambda, migrate AWS, migrate GCP, Lambda to Functions, migrate from AWS, migrate from GCP | **azure-cloud-migrate** |
-| Azure Functions, function app, serverless function, timer trigger, HTTP trigger, func new | Stay in **azure-prepare** — prefer Azure Functions templates in Step 4 |
+| Azure Functions, function app, serverless function, timer trigger, HTTP trigger, func new | Stay in **azure-prepare** — prefer Azure Functions templates in Step 4; for plan choice/cold starts see [hosting-plans.md](references/services/functions/hosting-plans.md) and [cold-start.md](references/services/functions/cold-start.md) |
 | APIM, API Management, API gateway, deploy APIM | Stay in **azure-prepare** — see [APIM Deployment Guide](references/apim.md) |
 | AI gateway, AI gateway policy, AI gateway backend, AI gateway configuration | **azure-aigateway** |
 | workflow, orchestration, multi-step, pipeline, fan-out/fan-in, saga, long-running process, durable, order processing | Stay in **azure-prepare** — select **durable** recipe in Step 4. **MUST** load [durable.md](references/services/functions/durable.md), [DTS reference](references/services/durable-task-scheduler/README.md), and [DTS Bicep patterns](references/services/durable-task-scheduler/bicep.md). |

--- a/plugins/azure-skills/skills/azure-prepare/references/services/functions/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/functions/README.md
@@ -44,19 +44,7 @@ services:
 
 **Use Flex Consumption for new deployments** (all AZD templates default to Flex).
 
-| Plan | Use Case | Scaling | VNET | Slots |
-|------|----------|---------|------|-------|
-| **Flex Consumption** ⭐ | Default for new projects | Auto, pay-per-execution | ✅ | ❌ |
-| Consumption Windows (Y1) | Legacy/maintenance, Windows-only features | Auto, scale to zero | ❌ | ✅ 1 staging slot |
-| Consumption Linux (Y1) | Legacy/maintenance | Auto, scale to zero | ❌ | ❌ |
-| Premium (EP1-EP3) | No cold starts, longer execution, slots | Auto, min instances | ✅ | ✅ 20 slots |
-| Dedicated | Predictable load, existing App Service | Manual or auto | ✅ | ✅ varies by SKU |
-
-> ⚠️ **Deployment Slots Guidance:**
-> - **Windows Consumption (Y1)** supports 1 staging slot — valid for existing apps or specific Windows requirements.
->   Prefer **Elastic Premium (EP1)** or **Dedicated** for new apps requiring slots, as Consumption cold starts affect swap reliability.
-> - **Linux Consumption and Flex Consumption** do **not** support deployment slots.
-> - For new projects needing slots: use **Elastic Premium** or an **App Service Plan (Standard+)**.
+For the full comparison matrix (scale limits, instance sizing, deployment slots, cost model, and a decision tree), see **[hosting-plans.md](hosting-plans.md)**. For mitigating cold starts on any plan, see **[cold-start.md](cold-start.md)**.
 
 ## Runtime Stacks
 
@@ -94,3 +82,5 @@ services:
 - [Terraform Patterns](terraform.md)
 - [Durable Functions](durable.md)
 - [Aspire + Container Apps](aspire-containerapps.md)
+- [Hosting Plans Comparison](hosting-plans.md) — Consumption vs Flex vs Premium vs Dedicated vs Container Apps
+- [Cold Start Mitigation](cold-start.md) — Per-plan strategies and CLI/Bicep examples

--- a/plugins/azure-skills/skills/azure-prepare/references/services/functions/cold-start.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/functions/cold-start.md
@@ -50,7 +50,7 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
     functionAppConfig: {
       runtime: {
         name: 'node'
-        version: '22'
+        version: '<supported-major-version>'
       }
       scaleAndConcurrency: {
         alwaysReady: [
@@ -135,7 +135,7 @@ resource functionApp 'Microsoft.App/containerApps@2024-10-02-preview' = {
 | Language | Cold Start Tip |
 |----------|---------------|
 | .NET | Use ReadyToRun (or Native AOT where supported) compilation; avoid heavy DI registration in startup |
-| Node.js | Minimize `node_modules`; bundle with esbuild/webpack; use Node 22 (current LTS) |
+| Node.js | Minimize `node_modules`; bundle with esbuild/webpack; use the latest LTS version supported by Azure Functions |
 | Python | Reduce package count; avoid importing unused modules at the top of the file |
 | Java | Prefer the latest supported Java version on Functions v4; minimize static initialization and classpath size |
 | PowerShell | Minimize modules declared in `requirements.psd1` |

--- a/plugins/azure-skills/skills/azure-prepare/references/services/functions/cold-start.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/functions/cold-start.md
@@ -1,0 +1,136 @@
+# Azure Functions Cold Start Mitigation
+
+Cold starts occur when a function app must allocate infrastructure, load the runtime, and initialize your code before handling a request. Impact and mitigation options differ significantly by hosting plan.
+
+## Cold Start Impact by Plan
+
+| Plan | Typical Cold Start | Can Eliminate? |
+|------|--------------------|----------------|
+| Consumption (Y1) | Seconds, worse on Linux with large dependency trees | ❌ No built-in always-ready mechanism; timer warm-up is a workaround only |
+| Flex Consumption (FC1) | Near-zero with always-ready instances configured | ✅ Yes, via always-ready instance groups |
+| Premium (EP1–EP3) | Near-zero with minimum instances configured | ✅ Yes, via minimum instance count |
+| Dedicated | None while `Always On` is enabled | ✅ Yes, plan runs continuously |
+| Container Apps (Functions-on-ACA) | Depends on `minimumElasticInstanceCount` | ✅ Yes, set minimum instance count ≥ 1 |
+
+## Mitigation Strategies
+
+### Consumption Plan
+
+No built-in always-ready mechanism. Available workarounds:
+
+| Strategy | How | Trade-off |
+|----------|-----|-----------|
+| Timer trigger warm-up | Timer function every few minutes pings HTTP endpoints | Extra invocations; not guaranteed to prevent every cold start |
+| Reduce package size | Trim unused dependencies; use tree-shaking/bundling | Development effort |
+| Optimize startup code | Lazy-load heavy modules; defer non-critical connections | Code changes required |
+
+```jsonc
+// host.json — reduce extension bundle load time by pinning a narrower version range
+{
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}
+```
+
+> 💡 **Tip:** If cold starts are a consistent problem on Consumption, move to Flex Consumption or Premium — see [hosting-plans.md](hosting-plans.md) for the comparison.
+
+### Flex Consumption Plan
+
+Configure always-ready instances for a function group with the dedicated CLI command (do not hand-edit the `functionAppConfig` ARM array — indexing into it by position can silently overwrite other always-ready groups):
+
+```bash
+# Set 1 always-ready instance for the "http" function group
+az functionapp scale config always-ready set \
+  -g $RG -n $APP \
+  --settings http=1
+```
+
+#### Bicep — Always-Ready Configuration
+
+```bicep
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
+  name: appName
+  location: location
+  kind: 'functionapp,linux'
+  properties: {
+    serverFarmId: flexPlan.id
+    functionAppConfig: {
+      runtime: {
+        name: 'node'
+        version: '22'
+      }
+      scaleAndConcurrency: {
+        alwaysReady: [
+          { name: 'http', instanceCount: 1 }
+        ]
+        instanceMemoryMB: 2048
+        maximumInstanceCount: 100
+      }
+    }
+  }
+}
+```
+
+> ⚠️ **Warning:** Always-ready instances are billed continuously, separate from and in addition to on-demand instances (they don't count toward `maximumInstanceCount`). Start with 1 instance per group and scale based on observed traffic.
+
+### Premium Plan
+
+Premium plans support a configurable minimum instance count; the platform auto-calculates a floor from each app's always-ready requests, but you can raise it explicitly:
+
+```bash
+az functionapp plan update -g $RG -n $PLAN --min-instances 2
+az functionapp plan update -g $RG -n $PLAN --max-burst 20
+```
+
+> `--min-elastic-worker-count` is not a valid parameter for `az functionapp plan update` — use `--min-instances`.
+
+### Dedicated Plan
+
+Enable `Always On` so the app is never unloaded due to idle timeout:
+
+```bash
+az functionapp config set -g $RG -n $APP --always-on true
+```
+
+### Functions on Container Apps
+
+Functions running on Container Apps are deployed as a `Microsoft.Web/sites` resource pointed at a Container Apps managed environment — **not** a bare `Microsoft.App/containerApps` resource, which would produce a plain container app with no Functions host. Set the minimum instance count via `siteConfig.minimumElasticInstanceCount`:
+
+```bicep
+resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
+  name: appName
+  location: location
+  kind: 'functionapp,linux,container,azurecontainerapps'
+  properties: {
+    managedEnvironmentId: containerAppsEnvironment.id
+    siteConfig: {
+      minimumElasticInstanceCount: 1
+      linuxFxVersion: 'DOCKER|${containerImage}'
+    }
+  }
+}
+```
+
+> ⚠️ **Warning:** `minimumElasticInstanceCount: 0` allows scale-to-zero (cold starts return); set it to `1` or higher to keep at least one instance warm.
+
+## Language-Specific Optimization
+
+| Language | Cold Start Tip |
+|----------|---------------|
+| .NET | Use ReadyToRun (or Native AOT where supported) compilation; avoid heavy DI registration in startup |
+| Node.js | Minimize `node_modules`; bundle with esbuild/webpack; use Node 22 (current LTS) |
+| Python | Reduce package count; avoid importing unused modules at the top of the file |
+| Java | Prefer the latest supported Java version on Functions v4; minimize static initialization and classpath size |
+| PowerShell | Minimize modules declared in `requirements.psd1` |
+
+## Recommendation Summary
+
+| Scenario | Recommended Plan | Cold Start Strategy |
+|----------|-----------------|----------------------|
+| Cost-sensitive, tolerates latency | Consumption | Timer warm-up + small deployment package |
+| Low latency, Linux, bursty | Flex Consumption | 1-2 always-ready instances via `az functionapp scale config always-ready set` |
+| Enterprise, strict SLA, Windows or slots needed | Premium | `--min-instances` set to cover peak-adjacent baseline |
+| Shared App Service plan, always running | Dedicated | `Always On = true` |
+| Containerized Functions | Container Apps (Functions-on-ACA) | `siteConfig.minimumElasticInstanceCount ≥ 1` on a `Microsoft.Web/sites` resource |

--- a/plugins/azure-skills/skills/azure-prepare/references/services/functions/cold-start.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/functions/cold-start.md
@@ -2,39 +2,30 @@
 
 Cold starts occur when a function app must allocate infrastructure, load the runtime, and initialize your code before handling a request. Impact and mitigation options differ significantly by hosting plan.
 
-## Cold Start Impact by Plan
+## Cold Start Behavior by Plan
 
-| Plan | Typical Cold Start | Can Eliminate? |
-|------|--------------------|----------------|
-| Consumption (Y1) | Seconds, worse on Linux with large dependency trees | ❌ No built-in always-ready mechanism; timer warm-up is a workaround only |
-| Flex Consumption (FC1) | Near-zero with always-ready instances configured | ✅ Yes, via always-ready instance groups |
-| Premium (EP1–EP3) | Near-zero with minimum instances configured | ✅ Yes, via minimum instance count |
-| Dedicated | None while `Always On` is enabled | ✅ Yes, plan runs continuously |
-| Container Apps (Functions-on-ACA) | Depends on `minimumElasticInstanceCount` | ✅ Yes, set minimum instance count ≥ 1 |
+Cold-start duration depends on the runtime, dependencies, package size, and initialization work. Measure the latency of the deployed app instead of relying on a fixed estimate.
+
+| Plan | Platform behavior | Primary mitigation |
+|------|-------------------|--------------------|
+| Consumption (Y1) | Scales to zero; cold starts are expected | Reduce dependencies and startup work, or move to another plan |
+| Flex Consumption (FC1) | Improved scale-from-zero behavior | Configure always-ready instances per function or trigger group |
+| Premium (EP1-EP3) | Keeps app-level always-ready instances and an HTTP prewarmed buffer | Configure the app's always-ready instance count |
+| Dedicated | Host runs continuously when `Always On` is enabled | Enable `Always On` |
+| Container Apps (Functions-on-ACA) | Scales to zero when `minReplicas` is `0` | Set `minReplicas` to `1` or higher |
 
 ## Mitigation Strategies
 
 ### Consumption Plan
 
-No built-in always-ready mechanism. Available workarounds:
+Consumption has no built-in always-ready setting. Reduce the work required to specialize a new instance:
 
 | Strategy | How | Trade-off |
 |----------|-----|-----------|
-| Timer trigger warm-up | Timer function every few minutes pings HTTP endpoints | Extra invocations; not guaranteed to prevent every cold start |
 | Reduce package size | Trim unused dependencies; use tree-shaking/bundling | Development effort |
 | Optimize startup code | Lazy-load heavy modules; defer non-critical connections | Code changes required |
 
-```jsonc
-// host.json — reduce extension bundle load time by pinning a narrower version range
-{
-  "extensionBundle": {
-    "id": "Microsoft.Azure.Functions.ExtensionBundle",
-    "version": "[4.*, 5.0.0)"
-  }
-}
-```
-
-> 💡 **Tip:** If cold starts are a consistent problem on Consumption, move to Flex Consumption or Premium — see [hosting-plans.md](hosting-plans.md) for the comparison.
+> 💡 **Tip:** A timer-based keep-alive isn't a cold-start guarantee and creates extra executions. If cold starts are a consistent problem, move to Flex Consumption or Premium. See [hosting-plans.md](hosting-plans.md) for the comparison.
 
 ### Flex Consumption Plan
 
@@ -77,14 +68,21 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
 
 ### Premium Plan
 
-Premium plans support a configurable minimum instance count; the platform auto-calculates a floor from each app's always-ready requests, but you can raise it explicitly:
+Set the app-level always-ready count so this function app stays loaded. The HTTP prewarmed buffer defaults to one instance and usually shouldn't be changed:
+
+```bash
+az functionapp update -g $RG -n $APP \
+  --set siteConfig.minimumElasticInstanceCount=2
+```
+
+If you need to reserve plan capacity ahead of scale-out or change its burst ceiling, configure the plan separately:
 
 ```bash
 az functionapp plan update -g $RG -n $PLAN --min-instances 2
 az functionapp plan update -g $RG -n $PLAN --max-burst 20
 ```
 
-> `--min-elastic-worker-count` is not a valid parameter for `az functionapp plan update` — use `--min-instances`.
+> `--min-instances` reserves plan capacity. It doesn't replace the app-level `minimumElasticInstanceCount` setting that keeps a specific app always ready. `--min-elastic-worker-count` isn't a valid parameter for `az functionapp plan update`.
 
 ### Dedicated Plan
 
@@ -96,24 +94,41 @@ az functionapp config set -g $RG -n $APP --always-on true
 
 ### Functions on Container Apps
 
-Functions running on Container Apps are deployed as a `Microsoft.Web/sites` resource pointed at a Container Apps managed environment — **not** a bare `Microsoft.App/containerApps` resource, which would produce a plain container app with no Functions host. Set the minimum instance count via `siteConfig.minimumElasticInstanceCount`:
+For new deployments, use the native `Microsoft.App/containerApps` integration and set `kind: 'functionapp'`. A generic container app without this kind doesn't enable the Functions integration. The older `Microsoft.Web/sites` integration is legacy and planned for future deprecation.
 
 ```bicep
-resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
+resource functionApp 'Microsoft.App/containerApps@2024-10-02-preview' = {
   name: appName
   location: location
-  kind: 'functionapp,linux,container,azurecontainerapps'
+  kind: 'functionapp'
   properties: {
     managedEnvironmentId: containerAppsEnvironment.id
-    siteConfig: {
-      minimumElasticInstanceCount: 1
-      linuxFxVersion: 'DOCKER|${containerImage}'
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 80
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: appName
+          image: containerImage
+          resources: {
+            cpu: json('0.5')
+            memory: '1Gi'
+          }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+      }
     }
   }
 }
 ```
 
-> ⚠️ **Warning:** `minimumElasticInstanceCount: 0` allows scale-to-zero (cold starts return); set it to `1` or higher to keep at least one instance warm.
+> ⚠️ **Warning:** `minReplicas: 0` allows scale-to-zero; set it to `1` or higher to keep at least one replica running. Configure required Functions settings such as `AzureWebJobsStorage` through secrets or managed identity.
 
 ## Language-Specific Optimization
 
@@ -129,8 +144,8 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
 
 | Scenario | Recommended Plan | Cold Start Strategy |
 |----------|-----------------|----------------------|
-| Cost-sensitive, tolerates latency | Consumption | Timer warm-up + small deployment package |
+| Cost-sensitive, tolerates latency | Consumption | Small deployment package + minimal startup work |
 | Low latency, Linux, bursty | Flex Consumption | 1-2 always-ready instances via `az functionapp scale config always-ready set` |
-| Enterprise, strict SLA, Windows or slots needed | Premium | `--min-instances` set to cover peak-adjacent baseline |
+| Enterprise, strict SLA, Windows or slots needed | Premium | App-level `minimumElasticInstanceCount` + default prewarmed buffer |
 | Shared App Service plan, always running | Dedicated | `Always On = true` |
-| Containerized Functions | Container Apps (Functions-on-ACA) | `siteConfig.minimumElasticInstanceCount ≥ 1` on a `Microsoft.Web/sites` resource |
+| Containerized Functions | Container Apps (Functions-on-ACA) | `minReplicas` set to `1` or higher on a `Microsoft.App/containerApps` resource with `kind: 'functionapp'` |

--- a/plugins/azure-skills/skills/azure-prepare/references/services/functions/hosting-plans.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/functions/hosting-plans.md
@@ -9,7 +9,7 @@
 | **Always-ready / min instances** | ❌ | ✅ (always-ready groups) | ✅ (min instances) | ✅ (Always On) | ✅ (min replicas) |
 | **Scale to zero** | ✅ | ✅ | ❌ (min 1 instance) | ❌ | ✅ (`minReplicas: 0`) |
 | **VNet integration (outbound)** | ❌ | ✅ | ✅ | ✅ | ✅ |
-| **Private endpoints (inbound)** | ❌ | ✅ | ✅ | ✅ | ❌ |
+| **Private endpoints (inbound)** | ❌ | ✅ | ✅ | ✅ | ✅ (environment-level) |
 | **Deployment slots (incl. production)** | 2 | ❌ Not supported | 3 | 1-20 (tier-dependent) | Via [revisions](https://learn.microsoft.com/azure/container-apps/revisions) |
 | **Function timeout — default / max** | 5 min / 10 min | 30 min / unbounded | 30 min / unbounded | 30 min / unbounded (requires Always On) | 30 min / unbounded |
 | **OS support** | Windows + Linux | Linux only | Windows + Linux | Windows + Linux | Linux only |
@@ -87,8 +87,8 @@ Need per-function scaling, Linux, and fast/large scale-out?
 ### Container Apps (Functions-on-ACA)
 
 - Best for: teams standardizing on Container Apps/Dapr/microservices, or needing a custom container image for Functions.
-- Deployed as a `Microsoft.Web/sites` resource (kind `functionapp,linux,container,azurecontainerapps`) pointed at a Container Apps managed environment — **not** a bare `Microsoft.App/containerApps` resource. See [cold-start.md](cold-start.md#functions-on-container-apps) for the correct Bicep shape.
-- Scale-to-zero via `minimumElasticInstanceCount: 0`; revisions replace deployment slots for staged rollout.
+- For new deployments, use the native `Microsoft.App/containerApps` integration with `kind: 'functionapp'`. The older `Microsoft.Web/sites` integration is legacy and planned for future deprecation. See [cold-start.md](cold-start.md#functions-on-container-apps) for the current Bicep shape.
+- Scale-to-zero via `minReplicas: 0`; revisions replace deployment slots for staged rollout.
 
 ## Migration Notes
 

--- a/plugins/azure-skills/skills/azure-prepare/references/services/functions/hosting-plans.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/functions/hosting-plans.md
@@ -1,0 +1,95 @@
+# Azure Functions Hosting Plans
+
+## Plan Comparison Matrix
+
+| Feature | Consumption (Y1) | Flex Consumption (FC1) | Premium (EP1-EP3) | Dedicated (App Service) | Container Apps |
+|---------|:-:|:-:|:-:|:-:|:-:|
+| **Max scale-out (instances)** | 200 | 1,000 | Plan-dependent (up to ~100) | Manual, per plan SKU | Up to 1,000 |
+| **Per-function scaling** | ❌ | ✅ | ❌ | ❌ | ❌ |
+| **Always-ready / min instances** | ❌ | ✅ (always-ready groups) | ✅ (min instances) | ✅ (Always On) | ✅ (min replicas) |
+| **Scale to zero** | ✅ | ✅ | ❌ (min 1 instance) | ❌ | ✅ (`minReplicas: 0`) |
+| **VNet integration (outbound)** | ❌ | ✅ | ✅ | ✅ | ✅ |
+| **Private endpoints (inbound)** | ❌ | ✅ | ✅ | ✅ | ❌ |
+| **Deployment slots (incl. production)** | 2 | ❌ Not supported | 3 | 1-20 (tier-dependent) | Via [revisions](https://learn.microsoft.com/azure/container-apps/revisions) |
+| **Function timeout — default / max** | 5 min / 10 min | 30 min / unbounded | 30 min / unbounded | 30 min / unbounded (requires Always On) | 30 min / unbounded |
+| **OS support** | Windows + Linux | Linux only | Windows + Linux | Windows + Linux | Linux only |
+
+> ⚠️ **"Unbounded" timeout caveat:** Flex Consumption, Premium, Dedicated, and Container Apps allow `functionTimeout` in `host.json` to be set unbounded, but the platform can still recycle a worker: a 60-minute idle timer, up to a 60-minute scale-in grace period, and a 10-minute grace period during platform upgrades. Design long-running work to be resumable (e.g., Durable Functions) rather than relying on a single uninterrupted execution.
+
+## Instance Sizing
+
+| Plan | SKU | vCPU | Memory |
+|------|-----|------|--------|
+| Consumption | Y1 | Shared/dynamic | 1.5 GB |
+| Flex Consumption | FC1 | 0.25 / 1 / 2 (selectable) | 512 MB / 2,048 MB / 4,096 MB (selectable) |
+| Premium | EP1 | 1 | 3.5 GB |
+| Premium | EP2 | 2 | 7 GB |
+| Premium | EP3 | 4 | 14 GB |
+| Dedicated | B1/S1 | 1 | 1.75 GB |
+| Dedicated | P1v3 | 2 | 8 GB |
+
+> 💡 Flex Consumption instance memory is user-selectable per app (512 MB, 2,048 MB, or 4,096 MB), each mapping to a fixed vCPU allocation. Use 2,048 MB as the default; go smaller for high fan-out/low-per-invocation-cost workloads, larger for CPU- or memory-intensive functions. Each region has a default 250-core (512,000 MB) Flex quota shared across all Flex apps in that subscription/region — request an increase for large-scale deployments.
+
+## Cost Models
+
+| Plan | Pricing Model | Notes |
+|------|--------------|-------|
+| Consumption | Per-execution + GB-s; free monthly grant | Lowest cost for spiky, low-volume workloads; no charge while idle |
+| Flex Consumption | Per-execution + GB-s; optional always-ready instances billed continuously | Scale-to-zero like Consumption, with opt-in always-ready base cost for latency-sensitive paths |
+| Premium (EP1) | Per-instance-hour; at least 1 instance always allocated | Fixed minimum cost even at zero traffic (no scale-to-zero) |
+| Dedicated (B1) | Per-instance-hour; plan runs continuously | Cost-effective when Functions co-locate with existing App Service Plan capacity |
+| Container Apps | Per-vCPU-second + per-GiB-second; can scale to zero | Pay only while replicas run when `minReplicas: 0` |
+
+## Decision Criteria
+
+```
+Need per-function scaling, Linux, and fast/large scale-out?
+├─ Yes → Flex Consumption
+└─ No
+   Need VNet integration or private endpoints?
+   ├─ No → Consumption (lowest cost, simplest)
+   └─ Yes
+      Already running other apps on an App Service Plan, or need Windows + slots + long history of App Service features?
+      ├─ Yes → Dedicated (App Service Plan)
+      └─ No
+         Budget-sensitive with bursty traffic?
+         ├─ Yes + Linux → Flex Consumption
+         ├─ Yes + Windows → Premium (EP1, cheapest always-on with VNet)
+         └─ No → Premium (predictable pre-warmed latency, deployment slots)
+```
+
+## Plan-Specific Considerations
+
+### Consumption (Y1)
+
+- Best for: low-traffic, event-driven workloads that tolerate occasional cold starts.
+- Limits: 10-minute max execution, no VNet integration, no per-function scaling.
+- Slots: 2 total (production + 1 staging) on Windows and Linux.
+
+### Flex Consumption (FC1)
+
+- **Recommended default for new Functions apps.** Best for Linux workloads needing fast/large scale-out, VNet, per-function scaling, and configurable instance memory.
+- Limits: Linux only, **no deployment slots** (use [rolling/blue-green site update strategies](https://learn.microsoft.com/azure/azure-functions/flex-consumption-site-updates) instead for zero-downtime deploys).
+- Always-ready instances bypass the max-instance-count ceiling and are billed continuously — start small and measure.
+
+### Premium (EP1–EP3)
+
+- Best for: latency-sensitive workloads, longer executions, VNet + private endpoints on Windows, or apps needing 3 deployment slots.
+- Always allocates at least 1 instance (no scale-to-zero); minimum instance count and maximum burst are both configurable.
+- Migrating an existing app between Consumption and Premium **on Windows** is supported in place via CLI/PowerShell (no new app required). This migration path is **not supported on Linux** — Linux apps require a new function app on the target plan.
+
+### Dedicated (App Service Plan)
+
+- Best for: consolidating Functions onto App Service Plan capacity you already run, or workloads needing the broadest App Service feature set (Hybrid Connections, custom domains, `Always On`).
+- Slot count depends on the underlying App Service Plan tier (Basic = 1, Standard = 5, Premium = 20; see [App Service limits](https://learn.microsoft.com/azure/azure-resource-manager/management/azure-subscription-service-limits#azure-app-service-limits)).
+- No automatic scale-to-zero; the plan runs (and is billed) continuously unless you scale it down manually.
+
+### Container Apps (Functions-on-ACA)
+
+- Best for: teams standardizing on Container Apps/Dapr/microservices, or needing a custom container image for Functions.
+- Deployed as a `Microsoft.Web/sites` resource (kind `functionapp,linux,container,azurecontainerapps`) pointed at a Container Apps managed environment — **not** a bare `Microsoft.App/containerApps` resource. See [cold-start.md](cold-start.md#functions-on-container-apps) for the correct Bicep shape.
+- Scale-to-zero via `minimumElasticInstanceCount: 0`; revisions replace deployment slots for staged rollout.
+
+## Migration Notes
+
+Switching hosting plans generally requires creating a new function app, **except**: Consumption ↔ Premium migration **on Windows** is supported in place via `az functionapp update` (see [Plan migration](https://learn.microsoft.com/azure/azure-functions/functions-how-to-use-azure-function-app-settings#plan-migration)). All Linux plan changes, and any move to/from Flex Consumption, require redeploying to a new app on the target plan. See `azure-upgrade` skill for Consumption→Flex migration guidance.


### PR DESCRIPTION
## Description

Adds Azure Functions hosting-plan comparison and cold-start guidance to `azure-prepare`. The references cover Consumption, Flex Consumption, Premium, Dedicated, and native Functions on Azure Container Apps, with current scaling limits, app-level cold-start controls, supported CLI commands, and plan selection guidance.

Updates the Functions reference index and skill routing so plan and cold-start questions load the new guidance.

## Checklist

- [x] Tests pass locally (`cd tests && npm test`)
- [x] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [x] **If modifying skill descriptions:** not applicable, frontmatter descriptions are unchanged

## Related Issues

Partially addresses #1612