### PR TITLE
feat: add Functions trigger and Durable troubleshooting

### DIFF
--- a/evals/azure-skills/azure-diagnostics/functions-troubleshooting.eval.yaml
+++ b/evals/azure-skills/azure-diagnostics/functions-troubleshooting.eval.yaml
@@ -1,0 +1,118 @@
+# Vally eval config for Function App trigger & Durable Functions troubleshooting
+# Added for issue #1615: trigger diagnostics (HTTP/Timer/Queue/Blob/Service Bus/Cosmos)
+# and Durable Functions diagnostics (stuck orchestrations, non-determinism, task hub
+# conflicts) added to azure-diagnostics/references/functions/{triggers,durable}.md.
+
+name: azure-diagnostics-functions-troubleshooting-eval
+description: |
+  Integration evaluation for the Function App trigger and Durable Functions
+  troubleshooting references added to azure-diagnostics. Covers queue poison-message
+  diagnosis, Cosmos trigger partial-document deserialization diagnosis, and stuck
+  Durable orchestration diagnosis, asserting correct skill routing and that the
+  response reflects the corrected guidance (not the incorrect fixes from the
+  abandoned prior attempt).
+
+tags:
+  type: integration
+  skill: azure-diagnostics
+
+defaults:
+  runs: 5
+  timeout: "10m"
+  executor: integration-test-agent-runner
+  model: claude-sonnet-4.6
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  # Queue poison-message diagnosis
+  - name: "Queue trigger poison message diagnosis"
+    prompt: "My Azure Function queue trigger keeps moving messages to the poison queue after 5 dequeue attempts. How do I diagnose why the messages are failing?"
+    config:
+      runs: 1
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: response-quality
+      requiredSkills:
+        - azure-diagnostics
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-diagnostics
+      - type: output-matches
+        config:
+          pattern: "(?i)maxDequeueCount|dequeue count|poison queue"
+      - type: completed
+      # Global: no_runtime_failure
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # Cosmos trigger partial-document diagnosis
+  # Regression guard for the corrected fix vs. abandoned PR #1641: the response
+  # must not claim StartFromBeginning/lease reset fixes partial document payloads.
+  - name: "Cosmos DB trigger partial document deserialization"
+    prompt: "My Cosmos DB trigger function is throwing deserialization errors because incoming documents are missing fields my POCO expects. Restarting the change feed from the beginning didn't help. How do I troubleshoot this?"
+    config:
+      runs: 1
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: response-quality
+      requiredSkills:
+        - azure-diagnostics
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-diagnostics
+      - type: output-matches
+        config:
+          pattern: "(?is)StartFromBeginning.{0,100}(does not|doesn't|cannot|can't|won't).{0,60}(fix|resolve|repair).{0,60}(deserializ|schema|payload|document)|(deserializ|schema|payload|document).{0,100}(is not|isn't|aren't|cannot|can't).{0,60}(fix|resolve|repair).{0,60}StartFromBeginning"
+      - type: output-matches
+        config:
+          pattern: "(?i)(schema|bound type|POCO|deserializ).*(raw|JsonElement|JObject|string)|(raw|JsonElement|JObject).*(schema|bound type|POCO|deserializ)"
+      - type: completed
+      # Global: no_runtime_failure
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  # Durable stuck-orchestration diagnosis
+  # Regression guard: the response should not present a bare Task.WhenAny timeout
+  # pattern without cancelling the losing operation (the bug fixed vs. PR #1641).
+  - name: "Durable Functions stuck orchestration diagnosis"
+    prompt: "One of my Durable Functions orchestrations has been stuck in the Running status for hours and never completes. How do I diagnose whether this is a non-determinism issue or something else, and how should I add a safe timeout?"
+    config:
+      runs: 1
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: response-quality
+      requiredSkills:
+        - azure-diagnostics
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-diagnostics
+      - type: output-matches
+        config:
+          pattern: "(?is)(cancel|CancellationToken).{0,100}timer|timer.{0,100}(cancel|CancellationToken)"
+      - type: output-matches
+        config:
+          pattern: "(?is)(TerminateAsync|TerminateInstanceAsync|external monitor|client-capable).{0,120}(child|sub-orchestration)|(?:child|sub-orchestration).{0,120}(TerminateAsync|TerminateInstanceAsync|external monitor|client-capable)"
+      - type: output-not-matches
+        config:
+          pattern: "(?is)((cancel(?:ing|lation)?|CancellationToken).{0,40}timer|timer.{0,20}cancel(?:s|ing|lation)?)(?!.{0,40}(does not|doesn't|cannot|can't|won't)).{0,60}(terminates?|cancels?|stops?).{0,40}(child|sub-orchestration|activity)"
+      - type: completed
+      # Global: no_runtime_failure
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"

--- a/evals/azure-skills/azure-diagnostics/functions-troubleshooting.eval.yaml
+++ b/evals/azure-skills/azure-diagnostics/functions-troubleshooting.eval.yaml
@@ -29,8 +29,6 @@ stimuli:
   # Queue poison-message diagnosis
   - name: "Queue trigger poison message diagnosis"
     prompt: "My Azure Function queue trigger keeps moving messages to the poison queue after 5 dequeue attempts. How do I diagnose why the messages are failing?"
-    config:
-      runs: 1
     tags:
       type: integration
       tier: full
@@ -57,8 +55,6 @@ stimuli:
   # must not claim StartFromBeginning/lease reset fixes partial document payloads.
   - name: "Cosmos DB trigger partial document deserialization"
     prompt: "My Cosmos DB trigger function is throwing deserialization errors because incoming documents are missing fields my POCO expects. Restarting the change feed from the beginning didn't help. How do I troubleshoot this?"
-    config:
-      runs: 1
     tags:
       type: integration
       tier: full
@@ -88,8 +84,6 @@ stimuli:
   # pattern without cancelling the losing operation (the bug fixed vs. PR #1641).
   - name: "Durable Functions stuck orchestration diagnosis"
     prompt: "One of my Durable Functions orchestrations has been stuck in the Running status for hours and never completes. How do I diagnose whether this is a non-determinism issue or something else, and how should I add a safe timeout?"
-    config:
-      runs: 1
     tags:
       type: integration
       tier: full

--- a/plugins/azure-skills/skills/azure-diagnostics/references/functions/README.md
+++ b/plugins/azure-skills/skills/azure-diagnostics/references/functions/README.md
@@ -78,3 +78,9 @@ az rest --method get \
 
 Compare deployment timestamps against when errors started appearing in App Insights to identify if a deployment caused the issue.
 
+---
+
+## Trigger & Durable Function Troubleshooting
+
+- [Trigger & Binding Troubleshooting](triggers.md) - HTTP, Timer, Queue, Blob, Service Bus, and Cosmos DB trigger diagnostics, plus Flex Consumption specifics and SDK conflicts.
+- [Durable Functions Troubleshooting](durable.md) - stuck orchestrations, non-determinism violations, timeout/cancellation patterns, and task hub conflicts.

--- a/plugins/azure-skills/skills/azure-diagnostics/references/functions/durable.md
+++ b/plugins/azure-skills/skills/azure-diagnostics/references/functions/durable.md
@@ -43,6 +43,7 @@ This in-process C# example cancels the timer and assigns a known child ID:
 
 ```csharp
 using var timeoutCts = new CancellationTokenSource();
+var deadline = context.CurrentUtcDateTime.AddMinutes(5);
 var childInstanceId = $"{context.InstanceId}:child";
 var subTask = context.CallSubOrchestratorAsync<Result>(
     "ChildOrchestrator", childInstanceId, input);

--- a/plugins/azure-skills/skills/azure-diagnostics/references/functions/durable.md
+++ b/plugins/azure-skills/skills/azure-diagnostics/references/functions/durable.md
@@ -1,0 +1,131 @@
+# Durable Functions Troubleshooting
+
+Diagnostics for stuck orchestrations, non-determinism, and task hub conflicts.
+
+## Stuck Orchestrations
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Orchestration stuck in `Running` indefinitely | An awaited durable timer/sub-orchestration/activity never completes, or completes but the orchestrator never observes it due to a non-determinism error breaking replay | Query instance status; check for `OrchestrationServiceException`/replay errors in App Insights `traces` for that `instanceId` |
+| Orchestration stuck in `Pending` | Task hub control-queue backlog, host-storage access failure, or the Durable extension isn't loading | Check control queue depth, `AzureWebJobsStorage`, extension startup logs, and scale-controller traces |
+| `Terminated`/`Failed` but activity output looks fine | Unhandled exception in the orchestrator itself (not an activity) | Orchestrator-level exceptions fail the whole instance; wrap sub-orchestrator/activity calls in `try/catch` if partial failure should be tolerated |
+
+```bash
+# Check one orchestration instance
+func durable get-runtime-status --connection-string-setting AzureWebJobsStorage \
+  --task-hub-name TASKHUB --id <instance-id> --show-output
+```
+
+## Non-Determinism Violations
+
+Orchestrator functions must produce the same durable operations in the same order on replay.
+Pure computation is safe; nondeterministic I/O, time, randomness, and unmanaged tasks aren't.
+
+| Anti-pattern | Why It Breaks | Fix |
+|--------------|----------------|-----|
+| `Thread.Sleep` / `Task.Delay` | Not replay-safe: uses a non-durable wait that isn't persisted, so it isn't recomputed identically on replay | `context.CreateTimer()` |
+| `DateTime.Now` / `DateTime.UtcNow` | Returns a different value on every replay | `context.CurrentUtcDateTime` |
+| `Guid.NewGuid()` | Generates a new value on every replay | `context.NewGuid()` |
+| Direct HTTP/DB calls in the orchestrator body | Side effects re-execute on every replay | Move to an activity function and call it via `context.CallActivityAsync` |
+| `async`/`await` on non-Durable-Task APIs (e.g. raw `Task.Run`, unmanaged threads) | Not tracked in the orchestration history, so it can't be replayed consistently | Only await `context.Call*Async`/`context.CreateTimer`/`context.WaitForExternalEvent` inside an orchestrator |
+
+> Search App Insights `exceptions` for `NonDeterministic` when an orchestration silently stalls. The extension logs `NonDeterministicWorkflowException`/replay errors when history and current execution diverge.
+
+## Timeout Patterns: Cancel the Loser, Don't Just Race
+
+A common but incomplete pattern uses `Task.WhenAny` to add a timeout to a
+sub-orchestration call, but `Task.WhenAny` only picks a winner. It doesn't cancel the
+loser. If the sub-orchestration wins, an outstanding durable timer keeps the parent
+instance's history growing until it fires. If the timer wins, the sub-orchestration keeps
+running with no caller waiting on it, which can duplicate side effects on retry.
+
+This in-process C# example cancels the timer and assigns a known child ID:
+
+```csharp
+using var timeoutCts = new CancellationTokenSource();
+var childInstanceId = $"{context.InstanceId}:child";
+var subTask = context.CallSubOrchestratorAsync<Result>(
+    "ChildOrchestrator", childInstanceId, input);
+var timeoutTask = context.CreateTimer(deadline, timeoutCts.Token);
+var winner = await Task.WhenAny(subTask, timeoutTask);
+
+if (winner == subTask)
+{
+    timeoutCts.Cancel(); // stop the outstanding timer from lingering in history
+    return await subTask;
+}
+
+// The child is still running. Include its ID so an external monitor can terminate it.
+throw new TimeoutException($"Child orchestration {childInstanceId} timed out.");
+```
+
+`context.CreateTimer` accepts a `CancellationToken`; canceling it on the success path
+allows the parent to complete without waiting for the timer. `Task.WhenAny` does not cancel
+an activity or sub-orchestration. If the child must stop, call `TerminateAsync` (in-process)
+or `TerminateInstanceAsync` (isolated worker) from a client-capable function using the known
+child ID. Do not inject or call a Durable client from orchestrator code. Termination also
+does not stop an activity already executing, so activity side effects must be idempotent or
+cooperatively cancellable.
+
+## Task Hub Conflicts
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Orchestrations from two apps interleave/corrupt each other's history | Two function apps configured with the same task hub name against the same storage backend | Assign each app a unique task hub name |
+| App fails to start after deployment, hub-name-related error | Task hub name isn't alphanumeric, or exceeds 45 characters | Task hub names must be alphanumeric only (letters and numbers, starting with a letter, 3-45 chars). The name prefixes storage artifacts that forbid special characters. `MyApp-TaskHub-Prod` is invalid; use `MyAppTaskHubProd` |
+| Duplicate/lost orchestration instances after a shared-storage migration | Multiple apps unintentionally sharing the same storage account and default task hub name | Give each app an explicit, unique `hubName` in `host.json` rather than relying on the default |
+
+```bash
+# Check whether a task hub name override is set via app settings
+az functionapp config appsettings list -n APP -g RG \
+  --query "[?name=='AzureFunctionsJobHost__extensions__durableTask__hubName']" -o table
+
+# If no override is set, the hub name comes from host.json:
+#   - Inspect host.json in your source repo, or
+#   - Use Kudu (Advanced Tools) / zip-deployed content to view host.json in the deployed app
+```
+
+```json
+{
+  "extensions": {
+    "durableTask": {
+      "hubName": "MyAppTaskHubProd"
+    }
+  }
+}
+```
+
+> **Tip:** For the Azure Storage provider, a task hub uses multiple tables, queues, and
+> blobs. See the [storage
+> providers docs](https://learn.microsoft.com/azure/azure-functions/durable/durable-functions-storage-providers#azure-storage)
+> for the full schema before assuming an artifact is missing.
+
+## Purging Old Instance History
+
+```bash
+# Compute a cutoff timestamp 7 days ago, portable across GNU (Linux) and BSD (macOS) date
+if CUTOFF=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null); then
+  :
+else
+  CUTOFF=$(date -u -v-7d +%Y-%m-%dT%H:%M:%SZ)
+fi
+
+func durable purge-history --connection-string-setting AzureWebJobsStorage \
+  --task-hub-name TASKHUB --created-before "$CUTOFF" \
+  --runtime-status completed failed terminated canceled
+```
+
+Always restrict purge operations to terminal statuses. Without `--runtime-status`, Core
+Tools also purges matching active instances.
+
+> ⚠️ **Growing history warning:** Orchestrations with >10,000 history events can hit
+> performance/storage limits. To check whether an instance's history is large, query the
+> History table for that instance's partition key and count rows. `--num-results 1` only
+> confirms the table has entries, it doesn't estimate row count.
+
+## Integration Testing Durable Failure Paths
+
+- **Stuck orchestration**: start an orchestration whose sub-orchestrator never completes; assert the instance stays `Running` and a timeout/terminate recovery path exists.
+- **Non-determinism**: introduce `DateTime.UtcNow` into an orchestrator, force a replay, and assert the extension surfaces a non-determinism error rather than silently diverging.
+- **Task hub conflict**: in Azurite or isolated test storage, run two apps with the same hub name and assert the collision is detected; never run this test against shared production storage.
+- **Timeout/cancellation**: assert that when the timer wins a `Task.WhenAny` race, the losing sub-orchestration is either explicitly terminated or documented as intentionally left running.

--- a/plugins/azure-skills/skills/azure-diagnostics/references/functions/triggers.md
+++ b/plugins/azure-skills/skills/azure-diagnostics/references/functions/triggers.md
@@ -1,0 +1,97 @@
+# Trigger & Binding Troubleshooting
+
+Diagnostics for HTTP, Timer, Queue, Blob, Service Bus, Cosmos DB, and Flex Consumption.
+
+## HTTP Trigger
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| 404 on known route | Route template mismatch or function not indexed | Check `route` in `function.json`/attribute; confirm the function loaded via `az functionapp function list` |
+| 500 on every request | Unhandled exception in the function | Query `exceptions` in App Insights for the stack trace |
+| 408 / timeout | Execution timeout or gateway idle timeout | `functionTimeout` controls execution, but HTTP responses still have a 230-second platform limit. For long work, return 202 with a status endpoint or use Durable HTTP APIs |
+| 401/403 unexpected | Function-level auth key mismatch, or Easy Auth intercepting the route | Verify `authLevel`; check `az webapp auth show` if App Service Authentication is enabled |
+
+```kusto
+requests
+| where toint(resultCode) >= 400
+| order by timestamp desc
+| take 50
+```
+
+## Timer Trigger
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Timer never fires | Invalid NCRONTAB expression | Validate the schedule with an NCRONTAB parser; check `TZ`/`WEBSITE_TIME_ZONE` if the schedule assumes a non-UTC zone |
+| Timer fires twice | `runOnStartup` adds invocations as hosts start, or another app/slot runs the schedule | Set `runOnStartup` to `false` in production and inventory deployments. Normal scale-out isn't the cause: a blob lease allows one scheduled invocation per app |
+| Timer never fires or runs late | Host storage is unavailable, the app is stopped/disabled, or the host ID collides with another app using the same storage | Check `AzureWebJobsStorage`, host storage permissions, `AzureFunctionsWebHost__hostid`, and `Host.Triggers.Timer` traces. Always On applies only to Dedicated plans; Consumption and Flex timers are designed to wake from zero |
+| Missed-run catch-up not happening | Schedule monitoring is disabled | Set `useMonitor` to `true` when catch-up is required. It defaults to `true` for intervals of at least one minute and `false` for more frequent schedules |
+
+## Queue Trigger
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Message never processed | Poison message after `maxDequeueCount` (default 5) retries | Message moved to `<queue>-poison`; inspect it to find the root cause |
+| Duplicate processing | Host stopped after side effects but before message deletion, or another consumer read the queue | The Functions host renews visibility during an invocation; `visibilityTimeout` controls retry delay after failure. Check host restarts and make side effects idempotent |
+| Function stops triggering | Storage authentication fails | Re-check `AzureWebJobsStorage` and `Host.Listener` traces for `StorageException` |
+
+```bash
+# Peek poison messages
+az storage message peek --queue-name "<queue>-poison" --account-name <account> --num-messages 32
+```
+
+## Blob Trigger
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Trigger delayed by minutes | Blob-trigger polling (non-Event Grid path) scans the container on a timer | Switch to the Event Grid-based blob trigger (`source: "EventGrid"`) for near-real-time triggering |
+| Trigger never fires for a version | A receipt already exists for that blob path and ETag | Overwriting the blob creates a new ETag and should trigger. To reprocess the same version, delete only its matching receipt after confirming duplicate side effects are safe |
+| Trigger fires for the wrong container | `path` pattern too broad or missing container scoping | Tighten the `path` binding expression (e.g. `samples-workitems/{name}`) |
+
+## Service Bus Trigger
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Message stuck retrying | `MaxDeliveryCount` exceeded, moved to dead-letter | Inspect the dead-letter sub-queue for the underlying exception |
+| `MessageLockLostException` | Execution exceeds lock renewal, or high prefetch lets locks age before processing | For single-message triggers, reduce work/prefetch or increase `maxAutoLockRenewalDuration` (default 5 minutes). It doesn't apply to batches; batch processing must finish within the entity's lock duration. Use manual renewal only with `autoCompleteMessages: false` and exposed message actions |
+| No messages arriving | SAS key rotated, or namespace network rules block the Functions host | Verify the connection app setting; check namespace firewall/VNet rules if not using a private endpoint |
+
+```text
+# View dead-letter message contents
+# Azure CLI does not support peeking Service Bus dead-letter message bodies directly.
+# Use one of the following instead:
+#   - Service Bus Explorer in the Azure portal (namespace -> Queues -> <queue> -> Dead-letter)
+#   - An Azure Service Bus SDK (.NET, Java, Python, or JavaScript) with a receiver scoped
+#     to "<queue>/$DeadLetterQueue", using a peek or receive operation.
+```
+
+## Cosmos DB Trigger
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Independent apps receive only part of the feed | Apps share a lease container and prefix, so they load-balance one logical processor | Give each independent workflow a unique `leaseContainerPrefix`, or use a dedicated lease container |
+| No changes delivered | Lease container missing, or `createLeaseContainerIfNotExists` is false without a pre-created container | Verify the lease container exists; grant the identity/connection write access to it |
+| Missing/default fields or deserialization failure | Bound model doesn't match document shape, casing, or schema version | `StartFromBeginning` only controls initial feed position and is ignored after checkpoints exist. Compare the document with the bound type, then inspect it through a supported raw JSON type (`JsonElement`, `string`, or `JObject`) |
+| Feed replays from the start unexpectedly | New lease container, or `StartFromBeginning: true` with no existing leases | Expected on first deployment; set `StartFromBeginning: false` (default) after backfill. It only affects lease creation with no prior checkpoint |
+
+For a manually created lease container, use partition key `/id`. The trigger identity needs
+read/write access to lease items. Multiple triggers can share that container only when each
+uses a unique `leaseContainerPrefix`.
+
+## Flex Consumption Specifics
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Cold start despite "always ready" expectation | No always-ready instance for the function's scale group | Configure `http`, `durable`, `blob`, or `function:<FUNCTION_NAME>` with `az functionapp scale config always-ready set` |
+| Can't reach a VNet-integrated resource | VNet integration not configured, or NSG/route table blocking egress | Confirm subnet delegation and outbound rules; enable VNet route-all if all egress must go through the VNet |
+| Deployment succeeds but scaling is capped | Maximum instance count or the regional subscription memory quota is exhausted | Inspect `az functionapp scale config show -g RG -n APP`; check **Usage + quotas** for the subscription and region |
+| Binding fails after dependency changes | Mixed Functions programming models or incompatible binding-extension versions | Use one programming model and align its binding packages. .NET isolated apps use `Microsoft.Azure.Functions.Worker.Extensions.*`; non-.NET apps using extension bundles should not also install the same binding extensions manually |
+
+## Integration Testing Trigger Failure Paths
+
+Assert the failure path, not just the happy path:
+
+- **Queue**: force failure; confirm the message reaches `<queue>-poison` after `maxDequeueCount`.
+- **Service Bus**: exceed lock renewal; confirm retries don't duplicate side effects.
+- **Cosmos DB**: omit a required field; assert a clear deserialization error.
+- **HTTP**: verify long work returns 202 instead of waiting past the gateway limit.


### PR DESCRIPTION
Closes #1615

## Summary

- add troubleshooting for HTTP, Timer, Queue, Blob, Service Bus, and Cosmos DB triggers
- add Flex Consumption and binding-package conflict guidance
- add Durable Functions diagnostics for stuck orchestrations, replay non-determinism, task hub conflicts, safe timeout handling, and history purging
- add Vally integration coverage for queue poison messages, Cosmos deserialization, and stuck Durable orchestrations

## Correctness fixes

- clarify that `StartFromBeginning` changes initial change-feed position and cannot repair payload deserialization
- cancel durable timers when child work wins and require external client termination when a timed-out child must stop
- restrict history purge examples to terminal orchestration states
- document runtime-managed timer locks, queue visibility renewal, and Service Bus lock renewal accurately

## Validation

- `npm run build`
- `npm test`
- `cd tests && npm test`
- `cd tests && npm run lint`
- `cd tests && npm run typecheck`
- `cd scripts && npm run vally validate-stimulus`
- `cd scripts && npm run references`
- changed markdown files pass token limits