### PR TITLE
feat: add Container Apps development capability

### DIFF
--- a/plugins/azure-skills/skills/azure-prepare/references/analyze.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/analyze.md
@@ -102,8 +102,8 @@ Converting an existing application to run on Azure.
 **If the target compute is Azure Container Apps**, you MUST load the composition algorithm before generating ANY infrastructure:
 
 1. Load `services/container-apps/templates/selection.md` — decision tree for base template (web-app, api, microservice, worker, job, functions-on-aca) + recipe layering (Dapr, Cosmos DB, Service Bus, Redis, ACR, PostgreSQL)
-2. Load `services/container-apps/templates/recipes/composition.md` — the exact algorithm to follow
-3. Compose the selected base template with each required recipe — NEVER hand-write Bicep/Terraform from scratch; use `azd init -t <template>` as the starting point
+2. Load `services/container-apps/templates/composition.md` — the exact algorithm to follow
+3. Generate from the selected base guide and compose each required recipe; these Markdown files are not valid `azd init -t` identifiers
 
 > ⚠️ **Critical**: The Container Apps `bicep.md` and `terraform.md` files are **REFERENCE DOCUMENTATION**, not templates to copy. Hand-writing infrastructure from these patterns results in missing RBAC, incorrect managed identity configuration, and security vulnerabilities.
 

--- a/plugins/azure-skills/skills/azure-prepare/references/analyze.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/analyze.md
@@ -10,6 +10,7 @@ If matched, invoke the corresponding skill **immediately** — it has tested tem
 | User prompt mentions | Action |
 |---------------------|--------|
 | Azure Functions, function app, serverless function, timer trigger, func new | Stay in **azure-prepare**. When selecting compute, **prefer Azure Functions** templates and best practices, then continue from Step 4. |
+| Container Apps, microservice, Dapr, KEDA, containerized worker/job | Stay in **azure-prepare**. When selecting compute, **prefer Container Apps** base templates + recipes, then continue from Step 4. |
 
 > ⚠️ Check the user's **prompt text** — not just existing code. This is critical for greenfield projects with no codebase. See [full routing table](specialized-routing.md).
 
@@ -96,4 +97,14 @@ Converting an existing application to run on Azure.
 
 > ⚠️ **Critical**: The Functions `bicep.md` and `terraform.md` files are **REFERENCE DOCUMENTATION**, not templates to copy. Hand-writing infrastructure from these patterns results in missing RBAC, incorrect managed identity configuration, and security vulnerabilities.
 
-For other compute targets (Container Apps, App Service, Static Web Apps), load their respective README files in `services/` for guidance.
+## ⛔ MANDATORY for Container Apps: Load Composition Rules BEFORE Execution
+
+**If the target compute is Azure Container Apps**, you MUST load the composition algorithm before generating ANY infrastructure:
+
+1. Load `services/container-apps/templates/selection.md` — decision tree for base template (web-app, api, microservice, worker, job, functions-on-aca) + recipe layering (Dapr, Cosmos DB, Service Bus, Redis, ACR, PostgreSQL)
+2. Load `services/container-apps/templates/recipes/composition.md` — the exact algorithm to follow
+3. Compose the selected base template with each required recipe — NEVER hand-write Bicep/Terraform from scratch; use `azd init -t <template>` as the starting point
+
+> ⚠️ **Critical**: The Container Apps `bicep.md` and `terraform.md` files are **REFERENCE DOCUMENTATION**, not templates to copy. Hand-writing infrastructure from these patterns results in missing RBAC, incorrect managed identity configuration, and security vulnerabilities.
+
+For other compute targets (App Service, Static Web Apps), load their respective README files in `services/` for guidance.

--- a/plugins/azure-skills/skills/azure-prepare/references/research.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/research.md
@@ -79,27 +79,12 @@ Invoke related skills for specialized scenarios:
 | Scenario | Action |
 |----------|--------|
 | Using Azure Functions | Stay in **azure-prepare** — load [selection.md](services/functions/templates/selection.md) → Follow [composition.md](services/functions/templates/recipes/composition.md) algorithm |
-| Using Container Apps with Dapr/recipes (Cosmos, Service Bus, Redis, ACR, PostgreSQL) | Stay in **azure-prepare** — load [selection.md](services/container-apps/templates/selection.md) → Follow [composition.md](services/container-apps/templates/recipes/composition.md) algorithm |
+| Using Container Apps with Dapr/recipes (Cosmos, messaging, Redis, ACR, PostgreSQL) | Stay in **azure-prepare** — load [selection.md](services/container-apps/templates/selection.md) → Follow [composition.md](services/container-apps/templates/composition.md) algorithm |
 | PostgreSQL with passwordless auth | Handle directly without a separate skill |
 | Need detailed security hardening | Handle directly with service-specific security guidance and platform best practices |
 | Setting up App Insights instrumentation | `appinsights-instrumentation` |
 | Building AI applications | `microsoft-foundry` |
 | Cost-sensitive deployment | `azure-cost` |
-
-**Skill/Reference Invocation Pattern:**
-
-For **Azure Functions**:
-1. Load: [selection.md](services/functions/templates/selection.md) (decision tree)
-2. Follow: [composition.md](services/functions/templates/recipes/composition.md) (algorithm)
-3. Result: Base template + recipe composition (never synthesize IaC)
-
-For **PostgreSQL**:
-1. Handle passwordless auth patterns directly without a separate skill
-
-For **Container Apps** (with Dapr or other recipes):
-1. Load: [selection.md](services/container-apps/templates/selection.md) (base template + recipe decision tree)
-2. Follow: [composition.md](services/container-apps/templates/recipes/composition.md) (algorithm)
-3. Result: Base template (web-app, api, microservice, worker, job, functions-on-aca) + recipe composition (never synthesize IaC)
 
 ### Step 3: Document in Plan
 
@@ -107,42 +92,12 @@ Add research findings to `.azure/deployment-plan.md` under a `## Research Summar
 
 ## Common Research Patterns
 
-### Web Application + API + Database (Cosmos DB)
+| Scenario | Load or invoke |
+|----------|----------------|
+| Web/API + Cosmos DB | [Container Apps](services/container-apps/README.md), [Cosmos DB](services/cosmos-db/README.md), [partitioning](services/cosmos-db/partitioning.md), [Key Vault](services/key-vault/README.md), `azure-observability` |
+| Container Apps + SQL | [Container Apps selection](services/container-apps/templates/selection.md), [composition](services/container-apps/templates/composition.md), [SQL Bicep](services/sql-database/bicep.md), [SQL auth](services/sql-database/auth.md), [Key Vault](services/key-vault/README.md) |
+| App Service + SQL | [App Service Bicep](services/app-service/bicep.md), [SQL Bicep](services/sql-database/bicep.md), [SQL auth](services/sql-database/auth.md), [Key Vault](services/key-vault/README.md) |
+| Serverless events | [Functions](services/functions/README.md), [Event Grid](services/event-grid/README.md) or [Service Bus](services/service-bus/README.md), [Storage](services/storage/README.md), `azure-observability` |
+| AI application | `microsoft-foundry`, [Container Apps](services/container-apps/README.md), [Cosmos DB partitioning](services/cosmos-db/partitioning.md), [Key Vault](services/key-vault/README.md) |
 
-1. Load: [services/container-apps/README.md](services/container-apps/README.md) → [bicep.md](services/container-apps/bicep.md) or [terraform.md](services/container-apps/terraform.md), [scaling.md](services/container-apps/scaling.md)
-2. Load: [services/cosmos-db/README.md](services/cosmos-db/README.md) → [partitioning.md](services/cosmos-db/partitioning.md)
-3. Load: [services/key-vault/README.md](services/key-vault/README.md)
-4. Invoke: `azure-observability` (monitoring setup)
-5. Review service-specific security guidance directly before generation
-
-### Container Apps + API + SQL Database
-
-1. Load: [services/container-apps/README.md](services/container-apps/README.md) → [templates/selection.md](services/container-apps/templates/selection.md) → [templates/recipes/composition.md](services/container-apps/templates/recipes/composition.md)
-2. Load: [services/sql-database/README.md](services/sql-database/README.md) → [bicep.md](services/sql-database/bicep.md), [auth.md](services/sql-database/auth.md)
-3. Load: [services/key-vault/README.md](services/key-vault/README.md)
-4. Review [auth.md](services/sql-database/auth.md) directly for Entra-only auth configuration
-
-### App Service + API + SQL Database
-
-1. Load: [services/app-service/README.md](services/app-service/README.md) → [bicep.md](services/app-service/bicep.md)
-2. Load: [services/sql-database/README.md](services/sql-database/README.md) → [bicep.md](services/sql-database/bicep.md), [auth.md](services/sql-database/auth.md)
-3. Load: [services/key-vault/README.md](services/key-vault/README.md)
-4. Review [auth.md](services/sql-database/auth.md) directly for Entra-only auth configuration
-
-### Serverless Event-Driven
-
-1. Load: [services/functions/README.md](services/functions/README.md) (contains mandatory composition workflow)
-2. Load: [services/event-grid/README.md](services/event-grid/README.md) or [services/service-bus/README.md](services/service-bus/README.md) (if using messaging)
-3. Load: [services/storage/README.md](services/storage/README.md) (if using queues/blobs)
-4. Invoke: `azure-observability` (distributed tracing)
-
-### AI Application
-
-1. Invoke: `microsoft-foundry` (AI patterns and best practices)
-2. Load: [services/container-apps/README.md](services/container-apps/README.md) → [bicep.md](services/container-apps/bicep.md) or [terraform.md](services/container-apps/terraform.md)
-3. Load: [services/cosmos-db/README.md](services/cosmos-db/README.md) → [partitioning.md](services/cosmos-db/partitioning.md) (vector storage)
-4. Review Key Vault and Foundry references directly for API key management
-
-## After Research
-
-Proceed to **Generate Artifacts** step with research findings applied.
+Apply the findings during **Generate Artifacts**.

--- a/plugins/azure-skills/skills/azure-prepare/references/research.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/research.md
@@ -79,6 +79,7 @@ Invoke related skills for specialized scenarios:
 | Scenario | Action |
 |----------|--------|
 | Using Azure Functions | Stay in **azure-prepare** — load [selection.md](services/functions/templates/selection.md) → Follow [composition.md](services/functions/templates/recipes/composition.md) algorithm |
+| Using Container Apps with Dapr/recipes (Cosmos, Service Bus, Redis, ACR, PostgreSQL) | Stay in **azure-prepare** — load [selection.md](services/container-apps/templates/selection.md) → Follow [composition.md](services/container-apps/templates/recipes/composition.md) algorithm |
 | PostgreSQL with passwordless auth | Handle directly without a separate skill |
 | Need detailed security hardening | Handle directly with service-specific security guidance and platform best practices |
 | Setting up App Insights instrumentation | `appinsights-instrumentation` |
@@ -94,6 +95,11 @@ For **Azure Functions**:
 
 For **PostgreSQL**:
 1. Handle passwordless auth patterns directly without a separate skill
+
+For **Container Apps** (with Dapr or other recipes):
+1. Load: [selection.md](services/container-apps/templates/selection.md) (base template + recipe decision tree)
+2. Follow: [composition.md](services/container-apps/templates/recipes/composition.md) (algorithm)
+3. Result: Base template (web-app, api, microservice, worker, job, functions-on-aca) + recipe composition (never synthesize IaC)
 
 ### Step 3: Document in Plan
 
@@ -111,7 +117,7 @@ Add research findings to `.azure/deployment-plan.md` under a `## Research Summar
 
 ### Container Apps + API + SQL Database
 
-1. Load: [services/container-apps/README.md](services/container-apps/README.md) → [bicep.md](services/container-apps/bicep.md) or [terraform.md](services/container-apps/terraform.md), [scaling.md](services/container-apps/scaling.md)
+1. Load: [services/container-apps/README.md](services/container-apps/README.md) → [templates/selection.md](services/container-apps/templates/selection.md) → [templates/recipes/composition.md](services/container-apps/templates/recipes/composition.md)
 2. Load: [services/sql-database/README.md](services/sql-database/README.md) → [bicep.md](services/sql-database/bicep.md), [auth.md](services/sql-database/auth.md)
 3. Load: [services/key-vault/README.md](services/key-vault/README.md)
 4. Review [auth.md](services/sql-database/auth.md) directly for Entra-only auth configuration

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/README.md
@@ -38,6 +38,30 @@ services:
 | Background Worker | None | 0 (scale to zero) | Queue-based |
 | Web Application | External | 1 | HTTP-based |
 
+## Templates & Recipes
+
+> ⚠️ **Before generating IaC**, load [templates/selection.md](templates/selection.md) for the base
+> template decision tree, then follow [templates/recipes/composition.md](templates/recipes/composition.md)
+> to compose the base template with any required recipes. Never hand-write Container Apps IaC from scratch.
+
+| Base Template | Use Case |
+|---------------|----------|
+| [web-app](templates/web-app.md) | High-scale serverless web application |
+| [api](templates/api.md) | REST/gRPC API service |
+| [microservice](templates/microservice.md) | Multi-service app with Dapr service discovery |
+| [worker](templates/worker.md) | Background/queue-driven worker |
+| [job](templates/job.md) | Scheduled/event/manual-trigger Container Apps Job |
+| [functions-on-aca](templates/functions-on-aca.md) | Azure Functions hosted on Container Apps |
+
+| Recipe | Adds |
+|--------|------|
+| [dapr](templates/recipes/dapr/README.md) | Service invocation, pub/sub, state, secrets |
+| [cosmos](templates/recipes/cosmos/README.md) | Cosmos DB NoSQL |
+| [servicebus](templates/recipes/servicebus/README.md) | Service Bus messaging + KEDA scaling |
+| [redis](templates/recipes/redis/README.md) | Redis cache / state store |
+| [acr](templates/recipes/acr/README.md) | Container Registry build/push |
+| [postgres](templates/recipes/postgres/README.md) | PostgreSQL Flexible Server |
+
 ## References
 
 - [Bicep Patterns](bicep.md)

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/README.md
@@ -41,8 +41,8 @@ services:
 ## Templates & Recipes
 
 > ⚠️ **Before generating IaC**, load [templates/selection.md](templates/selection.md) for the base
-> template decision tree, then follow [templates/recipes/composition.md](templates/recipes/composition.md)
-> to compose the base template with any required recipes. Never hand-write Container Apps IaC from scratch.
+> template decision tree, then follow [templates/composition.md](templates/composition.md)
+> to generate the base and compose required recipes.
 
 | Base Template | Use Case |
 |---------------|----------|
@@ -58,9 +58,12 @@ services:
 | [dapr](templates/recipes/dapr/README.md) | Service invocation, pub/sub, state, secrets |
 | [cosmos](templates/recipes/cosmos/README.md) | Cosmos DB NoSQL |
 | [servicebus](templates/recipes/servicebus/README.md) | Service Bus messaging + KEDA scaling |
+| [eventhubs](templates/recipes/eventhubs/README.md) | Event Hubs streaming + KEDA scaling |
 | [redis](templates/recipes/redis/README.md) | Redis cache / state store |
 | [acr](templates/recipes/acr/README.md) | Container Registry build/push |
 | [postgres](templates/recipes/postgres/README.md) | PostgreSQL Flexible Server |
+
+Choose a runtime from [multi-stage Dockerfiles](templates/dockerfiles/README.md).
 
 ## References
 

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/api.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/api.md
@@ -1,0 +1,161 @@
+# API Template — REFERENCE ONLY
+
+REST and gRPC API services on Azure Container Apps with ingress configuration.
+
+## When to Use
+
+- REST API with OpenAPI/Swagger
+- gRPC service
+- API gateway backend
+- Backend-for-frontend (BFF) pattern
+
+## Project Structure
+
+```
+project-root/
+├── azure.yaml
+├── Dockerfile
+├── src/
+│   └── (API code)
+└── infra/
+    ├── main.bicep
+    └── app/
+        └── api.bicep
+```
+
+## azure.yaml
+
+```yaml
+name: my-api
+metadata:
+  template: container-apps-api
+services:
+  api:
+    host: containerapp
+    project: .
+    language: <js|ts|python|csharp|java|go>
+```
+
+## Bicep — API Container App
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param envId string
+param containerRegistryName string
+param imageName string
+param userAssignedIdentityId string
+param isGrpc bool = false
+param allowedOrigins array = ['https://example.com']
+
+resource api 'Microsoft.App/containerApps@2024-03-01' = {
+  name: name
+  location: location
+  tags: union(tags, { 'azd-service-name': 'api' })
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${userAssignedIdentityId}': {} }
+  }
+  properties: {
+    managedEnvironmentId: envId
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 8080
+        transport: isGrpc ? 'http2' : 'auto'
+        corsPolicy: {
+          allowedOrigins: allowedOrigins
+          allowedMethods: ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS']
+          allowedHeaders: ['*']
+        }
+        // Use ['*'] only for local/dev smoke tests; set explicit origins for production.
+      }
+      registries: [
+        {
+          server: '${containerRegistryName}.azurecr.io'
+          identity: userAssignedIdentityId
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'api'
+          image: imageName
+          resources: { cpu: json('0.5'), memory: '1Gi' }
+          env: [
+            { name: 'PORT', value: '8080' }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 20
+        rules: [
+          {
+            name: 'http-scale'
+            http: { metadata: { concurrentRequests: '50' } }
+          }
+        ]
+      }
+    }
+  }
+}
+
+output fqdn string = api.properties.configuration.ingress.fqdn
+output name string = api.name
+```
+
+## REST vs gRPC
+
+| Setting | REST | gRPC |
+|---------|------|------|
+| `transport` | `auto` | `http2` |
+| `targetPort` | 8080 | 8080 |
+| Ingress | External or internal | External or internal |
+
+> ⚠️ **gRPC requires `transport: 'http2'`** — without it, gRPC calls fail.
+
+## Internal API (No External Ingress)
+
+For backend APIs only consumed by other Container Apps:
+
+```bicep
+ingress: {
+  external: false        // internal only
+  targetPort: 8080
+  transport: 'auto'
+}
+```
+
+Internal APIs are reachable at `https://<app-name>.internal.<env-domain>`.
+
+## API with Authentication
+
+Use Easy Auth or integrate with Microsoft Entra ID:
+
+```bicep
+configuration: {
+  ingress: {
+    external: true
+    targetPort: 8080
+  }
+}
+```
+
+> 💡 **Tip:** For API authentication, consider using the built-in authentication
+> feature of Container Apps (Easy Auth) or validating JWT tokens in your application code.
+
+## CORS Configuration
+
+Restrict `allowedOrigins` for production:
+
+```bicep
+corsPolicy: {
+  allowedOrigins: ['https://myapp.example.com']
+  allowedMethods: ['GET', 'POST', 'PUT', 'DELETE']
+  allowedHeaders: ['Authorization', 'Content-Type']
+  maxAge: 3600
+}
+```

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/api.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/api.md
@@ -105,6 +105,7 @@ resource api 'Microsoft.App/containerApps@2024-03-01' = {
 
 output fqdn string = api.properties.configuration.ingress.fqdn
 output name string = api.name
+output principalId string = api.identity.userAssignedIdentities[userAssignedIdentityId].principalId
 ```
 
 ## REST vs gRPC

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/composition.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/composition.md
@@ -9,8 +9,7 @@ Step-by-step algorithm for composing a Container Apps base template with integra
 ```
 INPUT:
   - base:        web-app | api | microservice | worker | job | functions-on-aca
-  - recipes:     dapr | cosmos | servicebus | redis | acr | postgres (zero or more)
-  - iac:         bicep | terraform
+  - recipes:     dapr | cosmos | servicebus | eventhubs | redis | acr | postgres
 
 OUTPUT:
   - Complete project directory ready for `azd up`
@@ -18,13 +17,16 @@ OUTPUT:
 
 ### Step 1: Select Base Template
 
-Choose the base template from [selection.md](../selection.md) based on the workload type.
-Use `-t <template-name>` when initializing new projects so the project starts from proven IaC. Only omit `-t` if you are inside an existing template directory.
+Choose one base guide from [selection.md](selection.md). These files are generation
+guidance, not published AZD template identifiers.
 
 ```bash
 ENV_NAME="$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')-dev"
-azd init -t "<template-name-from-selection.md>" -e "$ENV_NAME" --no-prompt
+azd init -e "$ENV_NAME" --no-prompt
 ```
+
+Generate the application, multi-stage [Dockerfile](dockerfiles/README.md), `azure.yaml`,
+and base infrastructure from the selected guide. Preserve existing project files in MODIFY mode.
 
 ### Step 2: Check if Recipes Needed
 
@@ -40,12 +42,13 @@ IF recipes detected:
 
 Read the recipe's README for IaC patterns, env vars, RBAC roles, and scaling rules:
 
-- [recipes/acr/README.md](acr/README.md) — Container Registry build + push
-- [recipes/cosmos/README.md](cosmos/README.md) — Cosmos DB NoSQL
-- [recipes/dapr/README.md](dapr/README.md) — Dapr components (state, pub/sub, invocation, secrets)
-- [recipes/postgres/README.md](postgres/README.md) — PostgreSQL Flexible Server
-- [recipes/redis/README.md](redis/README.md) — Redis cache / state store
-- [recipes/servicebus/README.md](servicebus/README.md) — Service Bus messaging + KEDA scaling
+- [ACR](recipes/acr/README.md) — Container Registry build + push
+- [Cosmos DB](recipes/cosmos/README.md) — Cosmos DB NoSQL
+- [Dapr](recipes/dapr/README.md) — state, pub/sub, invocation, secrets
+- [Event Hubs](recipes/eventhubs/README.md) — streaming + KEDA scaling
+- [PostgreSQL](recipes/postgres/README.md) — PostgreSQL Flexible Server
+- [Redis](recipes/redis/README.md) — cache / state store
+- [Service Bus](recipes/servicebus/README.md) — messaging + KEDA scaling
 
 **Bicep:**
 1. Create recipe Bicep module in `infra/app/` based on the recipe's documented patterns
@@ -62,10 +65,6 @@ Read the recipe's README for IaC patterns, env vars, RBAC roles, and scaling rul
      }
    }
    ```
-
-**Terraform:**
-1. Copy recipe `.tf` file into `infra/`
-2. Merge recipe app settings into container app environment variables
 
 ### Step 4: Add Environment Variables
 
@@ -137,8 +136,8 @@ Base (web-app)
 
 ## Critical Rules
 
-1. **Never synthesize IaC from scratch** — always extend base template
-2. **Don't replace or remove base IaC resources** — extend base files only by adding module references and additive resources
+1. **Generate from the selected base guide** — do not pass Markdown filenames to `azd init -t`
+2. **Don't replace or remove existing IaC resources** — merge additive modules in MODIFY mode
 3. **Always use recipe RBAC role GUIDs** — never let the LLM guess role IDs
 4. **Always use UAMI** — never use connection strings or access keys
 5. **Always use `--no-prompt`** with azd commands

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/README.md
@@ -1,0 +1,14 @@
+# Multi-stage Dockerfiles
+
+Choose the runtime used by the selected base guide.
+
+| Runtime | Template | Default port |
+|---|---|---:|
+| Node.js/TypeScript | [node.md](node.md) | 3000 |
+| Python | [python.md](python.md) | 8000 |
+| .NET | [dotnet.md](dotnet.md) | 8080 |
+| Java | [java.md](java.md) | 8080 |
+| Go | [go.md](go.md) | 8080 |
+
+Pin base images to an approved digest in production. Run as a non-root user, expose only
+the application port, keep build tools out of the runtime stage, and add a `.dockerignore`.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/dotnet.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/dotnet.md
@@ -1,0 +1,21 @@
+# .NET Dockerfile
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+COPY *.csproj ./
+RUN dotnet restore
+COPY . .
+RUN dotnet publish -c Release -o /app --no-restore
+
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
+WORKDIR /app
+COPY --from=build /app .
+USER $APP_UID
+EXPOSE 8080
+ENV ASPNETCORE_HTTP_PORTS=8080
+ENTRYPOINT ["dotnet", "App.dll"]
+```
+
+Replace `App.dll` with the published assembly name. The .NET 8 Linux images provide
+`APP_UID` for non-root execution.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/go.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/go.md
@@ -1,0 +1,19 @@
+# Go Dockerfile
+
+```dockerfile
+FROM golang:1.24-bookworm AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/app ./cmd/app
+
+FROM gcr.io/distroless/static-debian12:nonroot AS runtime
+COPY --from=build /out/app /app
+USER nonroot:nonroot
+EXPOSE 8080
+ENTRYPOINT ["/app"]
+```
+
+Change `./cmd/app` to the repository's main package. The static runtime has no shell, which
+reduces image size and attack surface.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/java.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/java.md
@@ -1,0 +1,21 @@
+# Java Dockerfile
+
+```dockerfile
+FROM maven:3.9-eclipse-temurin-21 AS build
+WORKDIR /src
+COPY pom.xml .
+RUN mvn -B dependency:go-offline
+COPY src ./src
+RUN mvn -B package -DskipTests
+
+FROM eclipse-temurin:21-jre AS runtime
+RUN useradd --create-home app
+WORKDIR /app
+COPY --from=build --chown=app:app /src/target/*.jar app.jar
+USER app
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]
+```
+
+Use Gradle equivalents when the project has `build.gradle`. Align the application server
+port and Container App `targetPort` with `8080`.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/node.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/node.md
@@ -1,0 +1,23 @@
+# Node.js / TypeScript Dockerfile
+
+```dockerfile
+FROM node:22-bookworm-slim AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build && npm prune --omit=dev
+
+FROM node:22-bookworm-slim AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+COPY --from=build --chown=node:node /app/node_modules ./node_modules
+COPY --from=build --chown=node:node /app/dist ./dist
+COPY --chown=node:node package.json ./
+USER node
+EXPOSE 3000
+CMD ["node", "dist/index.js"]
+```
+
+Set the Container App `targetPort` to `3000`. For JavaScript without a build step, copy the
+source directory instead of `dist`.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/python.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/dockerfiles/python.md
@@ -1,0 +1,21 @@
+# Python Dockerfile
+
+```dockerfile
+FROM python:3.13-slim AS build
+WORKDIR /build
+COPY requirements.txt .
+RUN python -m venv /venv && /venv/bin/pip install --no-cache-dir -r requirements.txt
+
+FROM python:3.13-slim AS runtime
+ENV PATH="/venv/bin:$PATH" PYTHONUNBUFFERED=1
+RUN useradd --create-home app
+WORKDIR /app
+COPY --from=build /venv /venv
+COPY --chown=app:app . .
+USER app
+EXPOSE 8000
+CMD ["gunicorn", "--bind", "0.0.0.0:8000", "main:app"]
+```
+
+Use an ASGI worker for FastAPI, for example
+`gunicorn -k uvicorn.workers.UvicornWorker`, and align `targetPort` with `8000`.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/functions-on-aca.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/functions-on-aca.md
@@ -1,0 +1,180 @@
+# Functions on Container Apps — REFERENCE ONLY
+
+Azure Functions hosted on Container Apps for event-driven triggers and bindings
+with Container Apps scaling and networking.
+
+## When to Use
+
+- Event-driven processing requiring Functions triggers/bindings
+- Need KEDA-based scaling with Functions programming model
+- Want Container Apps networking (VNet, private endpoints) with Functions
+- Migrating from Functions Consumption/Premium to Container Apps
+
+## Why Functions on Container Apps?
+
+| Feature | Functions (Flex) | Functions on ACA |
+|---------|-----------------|------------------|
+| Programming model | Functions v4 | Functions v4 |
+| Triggers/bindings | ✅ Full support | ✅ Full support |
+| Scaling | Flex Consumption | KEDA (Container Apps) |
+| Networking | VNet integration | Container Apps VNet |
+| Container support | Managed | Full Dockerfile control |
+| Dapr integration | ❌ | ✅ |
+| Side-cars | ❌ | ✅ |
+
+## Project Structure
+
+```
+project-root/
+├── azure.yaml
+├── Dockerfile
+├── host.json
+├── src/
+│   └── (Functions code)
+└── infra/
+    ├── main.bicep
+    └── app/
+        └── functions-app.bicep
+```
+
+## Dockerfile
+
+```dockerfile
+# Example: Node.js Functions on ACA
+FROM mcr.microsoft.com/azure-functions/node:4-node20
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot
+COPY . /home/site/wwwroot
+RUN cd /home/site/wwwroot && npm install --production
+```
+
+## azure.yaml
+
+```yaml
+name: my-functions-aca
+metadata:
+  template: container-apps-functions
+services:
+  api:
+    host: containerapp
+    project: .
+    language: js
+```
+
+## Bicep — Functions on Container Apps
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param envId string
+param containerRegistryName string
+param imageName string
+param userAssignedIdentityId string
+param uamiClientId string
+param storageAccountName string
+
+resource funcApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: name
+  location: location
+  tags: union(tags, { 'azd-service-name': 'api' })
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${userAssignedIdentityId}': {} }
+  }
+  properties: {
+    managedEnvironmentId: envId
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 80
+        transport: 'auto'
+      }
+      registries: [
+        {
+          server: '${containerRegistryName}.azurecr.io'
+          identity: userAssignedIdentityId
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'functions'
+          image: imageName
+          resources: { cpu: json('0.5'), memory: '1Gi' }
+          env: [
+            {
+              name: 'AzureWebJobsStorage__accountName'
+              value: storageAccountName
+            }
+            {
+              name: 'AzureWebJobsStorage__credential'
+              value: 'managedidentity'
+            }
+            {
+              name: 'AzureWebJobsStorage__clientId'
+              value: uamiClientId
+            }
+            {
+              name: 'FUNCTIONS_EXTENSION_VERSION'
+              value: '~4'
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 30
+      }
+    }
+  }
+}
+```
+
+## Supported Triggers
+
+All Functions triggers work on Container Apps:
+
+| Trigger | KEDA Scaler | Notes |
+|---------|-------------|-------|
+| HTTP | `http` | Built-in HTTP scaling |
+| Timer | `cron` | Cron-based scheduling |
+| Service Bus | `azure-servicebus` | Queue/topic scaling |
+| Event Hubs | `azure-eventhub` | Partition-based scaling |
+| Cosmos DB | `azure-cosmosdb` | Change feed scaling |
+| Blob Storage | `azure-blob` | Blob count scaling |
+| Storage Queue | `azure-queue` | Queue length scaling |
+
+## KEDA Scale Rules for Triggers
+
+```bicep
+scale: {
+  minReplicas: 0
+  maxReplicas: 30
+  rules: [
+    {
+      name: 'servicebus-scale'
+      custom: {
+        type: 'azure-servicebus'
+        metadata: {
+          queueName: 'myqueue'
+          namespace: 'my-sb-namespace'
+          messageCount: '5'
+        }
+        identity: userAssignedIdentityId
+      }
+    }
+  ]
+}
+```
+
+## Key Differences from Standard Functions
+
+1. **You manage the Dockerfile** — base image must be `mcr.microsoft.com/azure-functions/<runtime>`
+2. **Scaling is KEDA-based** — configure scale rules explicitly
+3. **Storage is still required** — Functions runtime needs `AzureWebJobsStorage`
+4. **No Flex Consumption billing** — billed as Container Apps
+
+> ⚠️ **Always use the official Functions base images** from MCR.
+> Custom base images may break the Functions runtime.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/functions-on-aca.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/functions-on-aca.md
@@ -150,6 +150,8 @@ resource funcApp 'Microsoft.App/containerApps@2025-01-01' = {
   }
   dependsOn: [hostStorageAccess]
 }
+
+output principalId string = uamiPrincipalId
 ```
 
 The host identity requires **Storage Blob Data Owner** on `AzureWebJobsStorage`. Add Storage

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/functions-on-aca.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/functions-on-aca.md
@@ -72,11 +72,30 @@ param containerRegistryName string
 param imageName string
 param userAssignedIdentityId string
 param uamiClientId string
+param uamiPrincipalId string
 param storageAccountName string
 
-resource funcApp 'Microsoft.App/containerApps@2024-03-01' = {
+resource hostStorage 'Microsoft.Storage/storageAccounts@2023-05-01' existing = {
+  name: storageAccountName
+}
+
+resource hostStorageAccess 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(hostStorage.id, uamiPrincipalId, 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b')
+  scope: hostStorage
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
+    )
+    principalId: uamiPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+resource funcApp 'Microsoft.App/containerApps@2025-01-01' = {
   name: name
   location: location
+  kind: 'functionapp'
   tags: union(tags, { 'azd-service-name': 'api' })
   identity: {
     type: 'UserAssigned'
@@ -129,12 +148,18 @@ resource funcApp 'Microsoft.App/containerApps@2024-03-01' = {
       }
     }
   }
+  dependsOn: [hostStorageAccess]
 }
 ```
 
+The host identity requires **Storage Blob Data Owner** on `AzureWebJobsStorage`. Add Storage
+Queue Data Contributor for queue triggers. Blob triggers also require Storage Queue Data
+Contributor and Storage Account Contributor. Add Storage Table Data Contributor when the
+selected extension persists host or trigger state in tables.
+
 ## Supported Triggers
 
-All Functions triggers work on Container Apps:
+The platform generates KEDA rules from Functions trigger configuration:
 
 | Trigger | KEDA Scaler | Notes |
 |---------|-------------|-------|
@@ -143,38 +168,24 @@ All Functions triggers work on Container Apps:
 | Service Bus | `azure-servicebus` | Queue/topic scaling |
 | Event Hubs | `azure-eventhub` | Partition-based scaling |
 | Cosmos DB | `azure-cosmosdb` | Change feed scaling |
-| Blob Storage | `azure-blob` | Blob count scaling |
+| Blob Storage | Event Grid | Autoscaling requires an Event Grid source |
 | Storage Queue | `azure-queue` | Queue length scaling |
 
-## KEDA Scale Rules for Triggers
+Redis and Azure SQL triggers do not support autoscaling. Set `minReplicas` above zero for
+unsupported triggers. Durable Functions autoscaling supports SQL Server and Durable Task
+Scheduler storage providers.
 
-```bicep
-scale: {
-  minReplicas: 0
-  maxReplicas: 30
-  rules: [
-    {
-      name: 'servicebus-scale'
-      custom: {
-        type: 'azure-servicebus'
-        metadata: {
-          queueName: 'myqueue'
-          namespace: 'my-sb-namespace'
-          messageCount: '5'
-        }
-        identity: userAssignedIdentityId
-      }
-    }
-  ]
-}
-```
+Only set custom rules after opting out with `allowScalingRuleOverride`. Default deployments
+should let the Functions platform derive rules from trigger attributes and `host.json`.
 
 ## Key Differences from Standard Functions
 
 1. **You manage the Dockerfile** — base image must be `mcr.microsoft.com/azure-functions/<runtime>`
-2. **Scaling is KEDA-based** — configure scale rules explicitly
+2. **Scaling is KEDA-based** — platform-generated rules are the default
 3. **Storage is still required** — Functions runtime needs `AzureWebJobsStorage`
 4. **No Flex Consumption billing** — billed as Container Apps
 
 > ⚠️ **Always use the official Functions base images** from MCR.
 > Custom base images may break the Functions runtime.
+>
+> **Source:** [Azure Functions on Azure Container Apps](https://learn.microsoft.com/azure/container-apps/functions-overview)

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/job.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/job.md
@@ -1,0 +1,192 @@
+# Container Apps Job Template — REFERENCE ONLY
+
+Scheduled, event-triggered, and manual jobs on Azure Container Apps.
+
+## When to Use
+
+- Scheduled tasks (cron-based)
+- Event-driven batch processing
+- One-shot manual execution
+- ETL pipelines, data imports, cleanup tasks
+
+## Job Types
+
+| Type | Trigger | Example |
+|------|---------|---------|
+| **Scheduled** | Cron expression | Nightly data sync, hourly report |
+| **Event** | KEDA scaler (queue, event hub) | Process uploads, handle messages |
+| **Manual** | API call / CLI | Ad-hoc migration, one-time import |
+
+## Project Structure
+
+```
+project-root/
+├── azure.yaml
+├── Dockerfile
+├── src/
+│   └── (job code)
+└── infra/
+    ├── main.bicep
+    └── app/
+        └── job.bicep
+```
+
+## azure.yaml
+
+```yaml
+name: my-job
+metadata:
+  template: container-apps-job
+services:
+  job:
+    host: containerapp
+    project: .
+```
+
+## Bicep — Scheduled Job
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param envId string
+param containerRegistryName string
+param imageName string
+param userAssignedIdentityId string
+param cronExpression string = '0 0 * * *'
+
+resource job 'Microsoft.App/jobs@2024-03-01' = {
+  name: name
+  location: location
+  tags: union(tags, { 'azd-service-name': 'job' })
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${userAssignedIdentityId}': {} }
+  }
+  properties: {
+    environmentId: envId
+    configuration: {
+      triggerType: 'Schedule'
+      replicaTimeout: 1800
+      replicaRetryLimit: 1
+      scheduleTriggerConfig: {
+        cronExpression: cronExpression
+        parallelism: 1
+        replicaCompletionCount: 1
+      }
+      registries: [
+        {
+          server: '${containerRegistryName}.azurecr.io'
+          identity: userAssignedIdentityId
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'job'
+          image: imageName
+          resources: { cpu: json('0.5'), memory: '1Gi' }
+        }
+      ]
+    }
+  }
+}
+
+output name string = job.name
+```
+
+## Bicep — Event-Triggered Job
+
+```bicep
+resource eventJob 'Microsoft.App/jobs@2024-03-01' = {
+  name: '${name}-event'
+  location: location
+  tags: tags
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${userAssignedIdentityId}': {} }
+  }
+  properties: {
+    environmentId: envId
+    configuration: {
+      triggerType: 'Event'
+      replicaTimeout: 600
+      replicaRetryLimit: 2
+      registries: [
+        {
+          server: '${containerRegistryName}.azurecr.io'
+          identity: userAssignedIdentityId
+        }
+      ]
+      eventTriggerConfig: {
+        parallelism: 1
+        replicaCompletionCount: 1
+        scale: {
+          minExecutions: 0
+          maxExecutions: 10
+          rules: [
+            {
+              name: 'queue-trigger'
+              type: 'azure-servicebus'
+              metadata: {
+                namespace: '<sb-namespace>'
+                queueName: '<queue>'
+                messageCount: '1'
+              }
+              identity: userAssignedIdentityId
+            }
+          ]
+        }
+      }
+    }
+    template: {
+      containers: [
+        {
+          name: 'job'
+          image: imageName
+          resources: { cpu: json('1'), memory: '2Gi' }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Bicep — Manual Job
+
+```bicep
+configuration: {
+  triggerType: 'Manual'
+  replicaTimeout: 3600
+  replicaRetryLimit: 0
+}
+```
+
+Start manually:
+
+```bash
+az containerapp job start -n <job-name> -g <resource-group>
+```
+
+## Common Cron Expressions
+
+| Schedule | Expression |
+|----------|-----------|
+| Every hour | `0 * * * *` |
+| Daily at midnight UTC | `0 0 * * *` |
+| Every 15 minutes | `*/15 * * * *` |
+| Weekdays at 9 AM UTC | `0 9 * * 1-5` |
+| First day of month | `0 0 1 * *` |
+
+## Key Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `replicaTimeout` | Max seconds per execution | 1800 |
+| `replicaRetryLimit` | Retry count on failure | 1 |
+| `parallelism` | Concurrent replicas | 1 |
+| `replicaCompletionCount` | Required successful replicas | 1 |
+
+> ⚠️ **Jobs exit after completion.** Ensure your container exits with code 0 on success
+> and non-zero on failure. Container Apps tracks execution history.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/job.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/job.md
@@ -55,7 +55,7 @@ param imageName string
 param userAssignedIdentityId string
 param cronExpression string = '0 0 * * *'
 
-resource job 'Microsoft.App/jobs@2024-03-01' = {
+resource job 'Microsoft.App/jobs@2025-01-01' = {
   name: name
   location: location
   tags: union(tags, { 'azd-service-name': 'job' })
@@ -99,7 +99,7 @@ output name string = job.name
 ## Bicep — Event-Triggered Job
 
 ```bicep
-resource eventJob 'Microsoft.App/jobs@2024-03-01' = {
+resource eventJob 'Microsoft.App/jobs@2025-01-01' = {
   name: '${name}-event'
   location: location
   tags: tags

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/job.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/job.md
@@ -94,6 +94,7 @@ resource job 'Microsoft.App/jobs@2025-01-01' = {
 }
 
 output name string = job.name
+output principalId string = job.identity.userAssignedIdentities[userAssignedIdentityId].principalId
 ```
 
 ## Bicep — Event-Triggered Job

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/microservice.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/microservice.md
@@ -1,0 +1,159 @@
+# Microservice Template — REFERENCE ONLY
+
+Multi-service architecture on Azure Container Apps with service discovery.
+
+## When to Use
+
+- Multiple independent services communicating via HTTP/gRPC
+- Mono-repo or multi-repo microservice architecture
+- Services with independent scaling requirements
+- Dapr-enabled service mesh
+
+## Project Structure
+
+```
+project-root/
+├── azure.yaml
+├── src/
+│   ├── frontend/
+│   │   └── Dockerfile
+│   ├── api-gateway/
+│   │   └── Dockerfile
+│   └── worker-service/
+│       └── Dockerfile
+└── infra/
+    ├── main.bicep
+    └── app/
+        ├── frontend.bicep
+        ├── api-gateway.bicep
+        └── worker-service.bicep
+```
+
+## azure.yaml
+
+```yaml
+name: my-microservices
+metadata:
+  template: container-apps-microservices
+services:
+  frontend:
+    host: containerapp
+    project: ./src/frontend
+  api-gateway:
+    host: containerapp
+    project: ./src/api-gateway
+  worker-service:
+    host: containerapp
+    project: ./src/worker-service
+```
+
+## Bicep — Multi-Service Environment
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param logAnalyticsWorkspaceId string
+@secure()
+param logAnalyticsSharedKey string
+
+// logAnalytics resource must be declared or passed as parameter
+// Shared Container Apps Environment
+resource env 'Microsoft.App/managedEnvironments@2024-03-01' = {
+  name: '${name}-env'
+  location: location
+  tags: tags
+  properties: {
+    appLogsConfiguration: {
+      destination: 'log-analytics'
+      logAnalyticsConfiguration: {
+        customerId: logAnalyticsWorkspaceId
+        sharedKey: logAnalyticsSharedKey
+      }
+    }
+  }
+}
+```
+
+## Service Discovery
+
+Container Apps in the same environment discover each other by name:
+
+```
+https://<app-name>.internal.<default-domain>
+```
+
+### Internal Communication Pattern
+
+```bicep
+// Frontend (external ingress)
+ingress: {
+  external: true
+  targetPort: 3000
+}
+
+// API Gateway (internal ingress)
+ingress: {
+  external: false
+  targetPort: 8080
+}
+
+// Worker (no ingress — processes messages only)
+// Omit ingress block entirely
+```
+
+### Environment Variables for Service URLs
+
+Pass internal URLs via environment variables:
+
+```bicep
+env: [
+  {
+    name: 'API_GATEWAY_URL'
+    value: 'https://${apiGateway.properties.configuration.ingress.fqdn}'
+  }
+]
+```
+
+## Scaling Per Service
+
+Each service scales independently:
+
+| Service | Min | Max | Scale Rule |
+|---------|-----|-----|------------|
+| Frontend | 1 | 10 | HTTP concurrency |
+| API Gateway | 2 | 20 | HTTP concurrency |
+| Worker | 0 | 30 | Queue depth (KEDA) |
+
+## With Dapr
+
+For microservices using Dapr, apply the [Dapr recipe](recipes/dapr/README.md) to enable:
+- Service-to-service invocation
+- State management
+- Pub/sub messaging
+- Secrets management
+- Distributed tracing
+
+```bicep
+configuration: {
+  dapr: {
+    enabled: true
+    appId: 'api-gateway'
+    appPort: 8080
+    appProtocol: 'http'
+  }
+}
+```
+
+## Deployment Order
+
+Deploy services with dependencies in correct order:
+
+```bash
+azd provision --no-prompt
+sleep 60  # RBAC propagation
+azd deploy --no-prompt
+```
+
+> 💡 **Tip:** `azd deploy` deploys all services defined in `azure.yaml`.
+> Individual services: `azd deploy --service api-gateway`.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/README.md
@@ -1,0 +1,72 @@
+# Container Apps Template Recipes — REFERENCE ONLY
+
+Composable IaC + configuration modules that extend base Container Apps templates
+to support specific Azure service integrations.
+
+## Architecture
+
+```
+Base Template (web-app, api, worker, job, etc.)
+       │
+       ├── Dockerfile + app code
+       ├── IaC (Container Apps Environment, ACR, UAMI, RBAC)
+       └── AZD config (azure.yaml)
+
+       + Recipe (per integration)
+       │
+       ├── IaC module (new resource + RBAC + networking)
+       ├── Environment variables
+       └── Scaling rules (KEDA, if applicable)
+       │
+       = Complete deployable project → `azd up`
+```
+
+## Available Recipes
+
+| Recipe | IaC Delta | Scaling Rules | Status |
+|--------|-----------|---------------|--------|
+| [dapr](dapr/README.md) | ✅ Dapr components | ❌ | ✅ Available |
+| [cosmos](cosmos/README.md) | ✅ Cosmos account + DB + RBAC | ❌ | ✅ Available |
+| [servicebus](servicebus/README.md) | ✅ SB namespace + queue + RBAC | ✅ KEDA azure-servicebus | ✅ Available |
+| [redis](redis/README.md) | ✅ Redis cache + RBAC | ❌ | ✅ Available |
+| [acr](acr/README.md) | ✅ ACR + RBAC | ❌ | ✅ Available |
+| [postgres](postgres/README.md) | ✅ PostgreSQL Flexible + RBAC | ❌ | ✅ Available |
+
+## How It Works
+
+### Step 1: Select Base Template
+
+Choose from [selection.md](../selection.md) based on workload type.
+
+### Step 2: Apply Recipe(s)
+
+Read each recipe's README for:
+- **IaC modules** to copy into `infra/`
+- **RBAC roles** with exact GUIDs
+- **Environment variables** for the container app
+- **Scaling rules** (KEDA) for event-driven scenarios
+
+### Step 3: Wire Into Base
+
+**Bicep:** Add `module` reference in `main.bicep`
+**Terraform:** Copy `.tf` files, merge environment variables
+
+### Step 4: Deploy
+
+```bash
+azd env set AZURE_LOCATION eastus2
+azd provision --no-prompt
+sleep 60
+azd deploy --no-prompt
+```
+
+## Design Principles
+
+| Principle | Why |
+|-----------|-----|
+| **Never synthesize base IaC** | Always use proven templates |
+| **Never modify base; only extend** | Recipes are additive — no risk of breaking core |
+| **Recipes own their RBAC** | Exact role GUIDs, no LLM guessing |
+| **Stack-agnostic** | Container Apps runs any container — recipes work with any language |
+| **Same algorithm for Bicep & Terraform** | Only IaC files differ, not composition logic |
+| **UAMI everywhere** | Managed identity for all service connections |

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/README.md
@@ -28,6 +28,7 @@ Base Template (web-app, api, worker, job, etc.)
 | [dapr](dapr/README.md) | ✅ Dapr components | ❌ | ✅ Available |
 | [cosmos](cosmos/README.md) | ✅ Cosmos account + DB + RBAC | ❌ | ✅ Available |
 | [servicebus](servicebus/README.md) | ✅ SB namespace + queue + RBAC | ✅ KEDA azure-servicebus | ✅ Available |
+| [eventhubs](eventhubs/README.md) | ✅ Event Hubs + checkpoints + RBAC | ✅ KEDA azure-eventhub | ✅ Available |
 | [redis](redis/README.md) | ✅ Redis cache + RBAC | ❌ | ✅ Available |
 | [acr](acr/README.md) | ✅ ACR + RBAC | ❌ | ✅ Available |
 | [postgres](postgres/README.md) | ✅ PostgreSQL Flexible + RBAC | ❌ | ✅ Available |
@@ -36,7 +37,8 @@ Base Template (web-app, api, worker, job, etc.)
 
 ### Step 1: Select Base Template
 
-Choose from [selection.md](../selection.md) based on workload type.
+Choose from [selection.md](../selection.md) based on workload type, then follow
+[composition.md](../composition.md).
 
 ### Step 2: Apply Recipe(s)
 
@@ -49,7 +51,6 @@ Read each recipe's README for:
 ### Step 3: Wire Into Base
 
 **Bicep:** Add `module` reference in `main.bicep`
-**Terraform:** Copy `.tf` files, merge environment variables
 
 ### Step 4: Deploy
 
@@ -68,5 +69,5 @@ azd deploy --no-prompt
 | **Never modify base; only extend** | Recipes are additive — no risk of breaking core |
 | **Recipes own their RBAC** | Exact role GUIDs, no LLM guessing |
 | **Stack-agnostic** | Container Apps runs any container — recipes work with any language |
-| **Same algorithm for Bicep & Terraform** | Only IaC files differ, not composition logic |
+| **Bicep composition** | Add recipe modules without replacing base resources |
 | **UAMI everywhere** | Managed identity for all service connections |

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/README.md
@@ -1,0 +1,114 @@
+# ACR Recipe — REFERENCE ONLY
+
+Azure Container Registry build and push workflow for Container Apps.
+
+## When to Use
+
+- Building container images in Azure (no local Docker needed)
+- CI/CD pipeline for Container Apps
+- Private container registry with managed identity pull
+
+## Bicep — ACR Module
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param appPrincipalId string       // Container App MI — gets AcrPull only
+param deployerPrincipalId string  // CI/deployer MI — gets AcrPush
+
+resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: { name: 'Basic' }
+  properties: {
+    adminUserEnabled: false
+  }
+}
+
+// RBAC — AcrPull for Container App (least privilege — pull only)
+resource acrPull 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, appPrincipalId, '7f951dda-4ed3-4680-a7ca-43fe172d538d')
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '7f951dda-4ed3-4680-a7ca-43fe172d538d'
+    )
+    principalId: appPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC — AcrPush for build agent / deployer (separate principal)
+resource acrPush 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, deployerPrincipalId, '8311e382-0749-4cb8-b61a-304f252e45ec')
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '8311e382-0749-4cb8-b61a-304f252e45ec'
+    )
+    principalId: deployerPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output loginServer string = acr.properties.loginServer
+output name string = acr.name
+```
+
+## Container App Registry Configuration
+
+```bicep
+configuration: {
+  registries: [
+    {
+      server: acr.outputs.loginServer
+      identity: userAssignedIdentityId
+    }
+  ]
+}
+```
+
+## ACR Build (Cloud Build)
+
+Build images in Azure without local Docker:
+
+```bash
+az acr build \
+  --registry <acr-name> \
+  --image myapp:latest \
+  --file Dockerfile .
+```
+
+## AZD + ACR Workflow
+
+With `azd`, image build and push is handled automatically:
+
+```yaml
+# azure.yaml
+services:
+  web:
+    host: containerapp
+    project: .
+    docker:
+      path: Dockerfile
+```
+
+`azd deploy` automatically:
+1. Builds the image via ACR Tasks
+2. Pushes to the linked ACR
+3. Updates the Container App with the new image
+
+## RBAC Roles
+
+| Role | GUID | Access |
+|------|------|--------|
+| AcrPull | `7f951dda-4ed3-4680-a7ca-43fe172d538d` | Pull images |
+| AcrPush | `8311e382-0749-4cb8-b61a-304f252e45ec` | Push + pull images |
+| AcrDelete | `c2f4ef07-c644-48eb-af81-4b1b4947fb11` | Delete images |
+
+> ⚠️ **Never enable admin user** (`adminUserEnabled: false`).
+> Use managed identity for image pull.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/README.md
@@ -15,7 +15,7 @@ param name string
 param location string = resourceGroup().location
 param tags object = {}
 param appPrincipalId string       // Container App MI — gets AcrPull only
-param deployerPrincipalId string  // CI/deployer MI — gets AcrPush
+param deployerPrincipalId string  // CI/deployer MI — builds and pushes
 
 resource acr 'Microsoft.ContainerRegistry/registries@2023-07-01' = {
   name: name
@@ -49,6 +49,20 @@ resource acrPush 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
     roleDefinitionId: subscriptionResourceId(
       'Microsoft.Authorization/roleDefinitions',
       '8311e382-0749-4cb8-b61a-304f252e45ec'
+    )
+    principalId: deployerPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC — required to invoke quick builds (`az acr build`)
+resource acrTasks 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(acr.id, deployerPrincipalId, 'fb382eab-e894-4461-af04-94435c366c3f')
+  scope: acr
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'fb382eab-e894-4461-af04-94435c366c3f'
     )
     principalId: deployerPrincipalId
     principalType: 'ServicePrincipal'
@@ -95,6 +109,7 @@ services:
     project: .
     docker:
       path: Dockerfile
+      remoteBuild: true
 ```
 
 `azd deploy` automatically:
@@ -108,7 +123,19 @@ services:
 |------|------|--------|
 | AcrPull | `7f951dda-4ed3-4680-a7ca-43fe172d538d` | Pull images |
 | AcrPush | `8311e382-0749-4cb8-b61a-304f252e45ec` | Push + pull images |
+| Container Registry Tasks Contributor | `fb382eab-e894-4461-af04-94435c366c3f` | Run `az acr build` and manage task runs |
 | AcrDelete | `c2f4ef07-c644-48eb-af81-4b1b4947fb11` | Delete images |
 
 > ⚠️ **Never enable admin user** (`adminUserEnabled: false`).
 > Use managed identity for image pull.
+> For ABAC-enabled registries, replace `AcrPush` with repository-scoped Writer and
+> Catalog Lister roles for the build identity.
+>
+> **Source:** [ACR built-in roles](https://learn.microsoft.com/azure/container-registry/container-registry-rbac-built-in-roles-directory-reference)
+
+## Language Guides
+
+[C#](source/dotnet.md) | [Python](source/python.md) |
+[Node.js/TypeScript](source/nodejs.md) | [Go](source/go.md) | [Java](source/java.md)
+
+See [eval/summary.md](eval/summary.md) for static coverage.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/eval/summary.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/eval/summary.md
@@ -1,0 +1,13 @@
+# ACR Static Coverage
+
+| Language | Guide |
+|---|---|
+| C# | [Authored](../source/dotnet.md) |
+| Python | [Authored](../source/python.md) |
+| Node.js/TypeScript | [Authored](../source/nodejs.md) |
+| Go | [Authored](../source/go.md) |
+| Java | [Authored](../source/java.md) |
+
+Review criteria: multi-stage build, non-root runtime, admin account disabled, app pull-only
+identity, quick-build Tasks Contributor, push data-plane access, and ABAC caveat. This is
+static guidance coverage, not an executed deployment result.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/dotnet.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/dotnet.md
@@ -1,0 +1,13 @@
+# ACR Workflow for .NET
+
+Use the [.NET multi-stage Dockerfile](../../../dockerfiles/dotnet.md). In `azure.yaml`, set
+the service `host` to `containerapp`, `project` to the app directory, and
+`docker.path` to the Dockerfile. `azd deploy --no-prompt` builds and deploys the image.
+
+For direct quick builds:
+
+```bash
+az acr build --registry <registry> --image <app>:<tag> --file Dockerfile .
+```
+
+The caller needs Container Registry Tasks Contributor plus push data-plane access.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/go.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/go.md
@@ -1,0 +1,11 @@
+# ACR Workflow for Go
+
+Use the [Go multi-stage Dockerfile](../../../dockerfiles/go.md). Configure `azure.yaml`
+with `host: containerapp`, the app `project`, and `docker.path`.
+
+```bash
+az acr build --registry <registry> --image <app>:<tag> --file Dockerfile .
+```
+
+Build a static binary and use a non-root runtime stage. The Container App identity needs
+pull access only.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/java.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/java.md
@@ -1,0 +1,10 @@
+# ACR Workflow for Java
+
+Use the [Java multi-stage Dockerfile](../../../dockerfiles/java.md). Configure `azure.yaml`
+with `host: containerapp`, the app `project`, and `docker.path`.
+
+```bash
+az acr build --registry <registry> --image <app>:<tag> --file Dockerfile .
+```
+
+Cache dependencies in the build stage and copy only the packaged JAR into the runtime image.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/nodejs.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/nodejs.md
@@ -1,0 +1,10 @@
+# ACR Workflow for Node.js / TypeScript
+
+Use the [Node.js multi-stage Dockerfile](../../../dockerfiles/node.md). Configure
+`azure.yaml` with `host: containerapp`, the app `project`, and `docker.path`.
+
+```bash
+az acr build --registry <registry> --image <app>:<tag> --file Dockerfile .
+```
+
+Keep dev dependencies in the build stage and run the runtime image as the `node` user.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/python.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/acr/source/python.md
@@ -1,0 +1,11 @@
+# ACR Workflow for Python
+
+Use the [Python multi-stage Dockerfile](../../../dockerfiles/python.md). Configure
+`azure.yaml` with `host: containerapp`, the app `project`, and `docker.path`.
+
+```bash
+az acr build --registry <registry> --image <app>:<tag> --file Dockerfile .
+```
+
+Use a deployment identity with Container Registry Tasks Contributor and push data-plane
+access. The Container App identity needs pull access only.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/composition.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/composition.md
@@ -1,0 +1,145 @@
+# Composition Algorithm — REFERENCE ONLY
+
+Step-by-step algorithm for composing a Container Apps base template with integration recipes.
+
+> **This is the authoritative process. Follow it exactly.**
+
+## Algorithm
+
+```
+INPUT:
+  - base:        web-app | api | microservice | worker | job | functions-on-aca
+  - recipes:     dapr | cosmos | servicebus | redis | acr | postgres (zero or more)
+  - iac:         bicep | terraform
+
+OUTPUT:
+  - Complete project directory ready for `azd up`
+```
+
+### Step 1: Select Base Template
+
+Choose the base template from [selection.md](../selection.md) based on the workload type.
+Use `-t <template-name>` when initializing new projects so the project starts from proven IaC. Only omit `-t` if you are inside an existing template directory.
+
+```bash
+ENV_NAME="$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')-dev"
+azd init -t "<template-name-from-selection.md>" -e "$ENV_NAME" --no-prompt
+```
+
+### Step 2: Check if Recipes Needed
+
+```
+IF no integrations detected:
+  → DONE. Base template is complete.
+
+IF recipes detected:
+  → Continue to Step 3 for each recipe.
+```
+
+### Step 3: Add IaC Module (per recipe)
+
+Read the recipe's README for IaC patterns, env vars, RBAC roles, and scaling rules:
+
+- [recipes/acr/README.md](acr/README.md) — Container Registry build + push
+- [recipes/cosmos/README.md](cosmos/README.md) — Cosmos DB NoSQL
+- [recipes/dapr/README.md](dapr/README.md) — Dapr components (state, pub/sub, invocation, secrets)
+- [recipes/postgres/README.md](postgres/README.md) — PostgreSQL Flexible Server
+- [recipes/redis/README.md](redis/README.md) — Redis cache / state store
+- [recipes/servicebus/README.md](servicebus/README.md) — Service Bus messaging + KEDA scaling
+
+**Bicep:**
+1. Create recipe Bicep module in `infra/app/` based on the recipe's documented patterns
+2. Add module reference in `infra/main.bicep`:
+   ```bicep
+   module cosmos './app/cosmos.bicep' = {
+     name: 'cosmos'
+     scope: rg
+     params: {
+       name: name
+       location: location
+       tags: tags
+       principalId: app.outputs.principalId
+     }
+   }
+   ```
+
+**Terraform:**
+1. Copy recipe `.tf` file into `infra/`
+2. Merge recipe app settings into container app environment variables
+
+### Step 4: Add Environment Variables
+
+Read the recipe's `README.md` for required env vars. Add them to the container app config.
+
+> **CRITICAL: User Assigned Managed Identity (UAMI)**
+>
+> Use managed identity for all service connections. Never use connection strings or keys.
+>
+> ```bicep
+> env: [
+>   { name: 'COSMOS_ENDPOINT', value: cosmos.outputs.endpoint }
+>   { name: 'AZURE_CLIENT_ID', value: uami.outputs.clientId }
+> ]
+> ```
+
+### Step 5: Add RBAC Role Assignments
+
+Each recipe defines required RBAC roles. Use exact role definition GUIDs from recipe docs.
+
+```bicep
+resource cosmosRbac 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = {
+  parent: cosmos
+  name: guid(cosmos.id, uami.id, 'data-contributor')
+  properties: {
+    roleDefinitionId: '${cosmos.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002'
+    principalId: uami.outputs.principalId
+    scope: cosmos.id
+  }
+}
+```
+
+### Step 6: Add Scaling Rules (if applicable)
+
+For workers and event-driven apps, add KEDA scaling rules from the recipe:
+
+```bicep
+scale: {
+  minReplicas: 0
+  maxReplicas: 30
+  rules: [
+    // From recipe scaling configuration
+  ]
+}
+```
+
+### Step 7: Validate and Deploy
+
+```bash
+azd env set AZURE_LOCATION eastus2
+azd provision --no-prompt
+sleep 60                         # Wait for RBAC propagation
+azd deploy --no-prompt
+```
+
+## Multiple Recipes
+
+Recipes are additive. Apply each recipe independently:
+
+```
+Base (web-app)
+  + cosmos recipe   → adds Cosmos module + RBAC + env vars
+  + redis recipe    → adds Redis module + RBAC + env vars
+  + acr recipe      → adds ACR build pipeline
+  = Complete project
+```
+
+> ⚠️ **Each recipe is independent.** No recipe should modify another recipe's resources.
+
+## Critical Rules
+
+1. **Never synthesize IaC from scratch** — always extend base template
+2. **Don't replace or remove base IaC resources** — extend base files only by adding module references and additive resources
+3. **Always use recipe RBAC role GUIDs** — never let the LLM guess role IDs
+4. **Always use UAMI** — never use connection strings or access keys
+5. **Always use `--no-prompt`** with azd commands
+6. **Always wait for RBAC propagation** — use two-phase deploy

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/README.md
@@ -1,0 +1,123 @@
+# Cosmos DB Recipe — REFERENCE ONLY
+
+Azure Cosmos DB integration for Container Apps.
+
+## When to Use
+
+- NoSQL document database
+- Global distribution requirements
+- Low-latency reads/writes
+- Change feed processing
+
+## Bicep — Cosmos DB Module
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param principalId string
+
+resource cosmos 'Microsoft.DocumentDB/databaseAccounts@2024-05-15' = {
+  name: name
+  location: location
+  tags: tags
+  kind: 'GlobalDocumentDB'
+  properties: {
+    databaseAccountOfferType: 'Standard'
+    disableLocalAuth: true
+    locations: [
+      { locationName: location, failoverPriority: 0 }
+    ]
+    capabilities: [
+      { name: 'EnableServerless' }
+    ]
+  }
+}
+
+resource database 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases@2024-05-15' = {
+  parent: cosmos
+  name: 'appdb'
+  properties: {
+    resource: { id: 'appdb' }
+  }
+}
+
+resource container 'Microsoft.DocumentDB/databaseAccounts/sqlDatabases/containers@2024-05-15' = {
+  parent: database
+  name: 'items'
+  properties: {
+    resource: {
+      id: 'items'
+      partitionKey: { paths: ['/partitionKey'], kind: 'Hash' }
+    }
+  }
+}
+
+// RBAC — Cosmos DB Built-in Data Contributor (data-plane, not ARM roleAssignments)
+resource cosmosRbac 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-05-15' = {
+  parent: cosmos
+  name: guid(cosmos.id, principalId, 'data-contributor')
+  properties: {
+    roleDefinitionId: '${cosmos.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002'
+    principalId: principalId
+    scope: cosmos.id
+  }
+}
+
+output endpoint string = cosmos.properties.documentEndpoint
+output databaseName string = database.name
+```
+
+## Environment Variables
+
+```bicep
+env: [
+  { name: 'COSMOS_ENDPOINT', value: cosmos.outputs.endpoint }
+  { name: 'COSMOS_DATABASE', value: cosmos.outputs.databaseName }
+  { name: 'AZURE_CLIENT_ID', value: uami.outputs.clientId }
+]
+```
+
+## SDK Connection (Python Example)
+
+```python
+from azure.cosmos import CosmosClient
+from azure.identity import DefaultAzureCredential
+import os
+
+credential = DefaultAzureCredential(
+    managed_identity_client_id=os.environ["AZURE_CLIENT_ID"]
+)
+client = CosmosClient(
+    url=os.environ["COSMOS_ENDPOINT"],
+    credential=credential,
+)
+database = client.get_database_client(os.environ["COSMOS_DATABASE"])
+```
+
+## Node.js Connection
+
+```javascript
+const { CosmosClient } = require("@azure/cosmos");
+const { DefaultAzureCredential } = require("@azure/identity");
+
+const credential = new DefaultAzureCredential({
+  managedIdentityClientId: process.env.AZURE_CLIENT_ID,
+});
+const client = new CosmosClient({
+  endpoint: process.env.COSMOS_ENDPOINT,
+  aadCredentials: credential,
+});
+const database = client.database(process.env.COSMOS_DATABASE);
+```
+
+## RBAC Role
+
+| Role | GUID | Access |
+|------|------|--------|
+| Cosmos DB Built-in Data Contributor | `00000000-0000-0000-0000-000000000002` | Read + write data |
+| Cosmos DB Built-in Data Reader | `00000000-0000-0000-0000-000000000001` | Read-only |
+
+> ⚠️ **Use `sqlRoleAssignments`, not ARM `roleAssignments`.** Cosmos DB data-plane RBAC
+> requires the resource-specific role assignment type shown above.
+> Also set `disableLocalAuth: true` to disable primary/secondary key auth.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/README.md
@@ -121,3 +121,10 @@ const database = client.database(process.env.COSMOS_DATABASE);
 > ⚠️ **Use `sqlRoleAssignments`, not ARM `roleAssignments`.** Cosmos DB data-plane RBAC
 > requires the resource-specific role assignment type shown above.
 > Also set `disableLocalAuth: true` to disable primary/secondary key auth.
+
+## Language Guides
+
+[C#](source/dotnet.md) | [Python](source/python.md) |
+[Node.js/TypeScript](source/nodejs.md) | [Go](source/go.md) | [Java](source/java.md)
+
+See [eval/summary.md](eval/summary.md) for static coverage.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/eval/summary.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/eval/summary.md
@@ -1,0 +1,13 @@
+# Cosmos DB Static Coverage
+
+| Language | Guide |
+|---|---|
+| C# | [Authored](../source/dotnet.md) |
+| Python | [Authored](../source/python.md) |
+| Node.js/TypeScript | [Authored](../source/nodejs.md) |
+| Go | [Authored](../source/go.md) |
+| Java | [Authored](../source/java.md) |
+
+Review criteria: `DefaultAzureCredential`, UAMI selection, data-plane RBAC, local auth
+disabled, shared client lifetime, database, container, and partition-key configuration.
+This is static guidance coverage, not an executed deployment result.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/dotnet.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/dotnet.md
@@ -1,0 +1,17 @@
+# Cosmos DB with C#
+
+Packages: `Microsoft.Azure.Cosmos`, `Azure.Identity`.
+
+```csharp
+var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions {
+    ManagedIdentityClientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID")
+});
+var client = new CosmosClient(Environment.GetEnvironmentVariable("COSMOS_ENDPOINT"), credential);
+var container = client
+    .GetDatabase(Environment.GetEnvironmentVariable("COSMOS_DATABASE"))
+    .GetContainer("items");
+```
+
+Register `CosmosClient` as a singleton and reuse it for connection pooling.
+
+**Source:** [Azure identity with Cosmos DB](https://learn.microsoft.com/azure/cosmos-db/nosql/how-to-connect-role-based-access-control)

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/go.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/go.md
@@ -1,0 +1,14 @@
+# Cosmos DB with Go
+
+Packages: `github.com/Azure/azure-sdk-for-go/sdk/azidentity` and
+`github.com/Azure/azure-sdk-for-go/sdk/data/azcosmos`.
+
+```go
+credential, err := azidentity.NewDefaultAzureCredential(nil)
+if err != nil { return err }
+client, err := azcosmos.NewClient(os.Getenv("COSMOS_ENDPOINT"), credential, nil)
+if err != nil { return err }
+container, err := client.NewContainer(os.Getenv("COSMOS_DATABASE"), "items")
+```
+
+Reuse the client and container for the process lifetime.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/java.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/java.md
@@ -1,0 +1,18 @@
+# Cosmos DB with Java
+
+Packages: `com.azure:azure-cosmos`, `com.azure:azure-identity`.
+
+```java
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .managedIdentityClientId(System.getenv("AZURE_CLIENT_ID"))
+    .build();
+CosmosClient client = new CosmosClientBuilder()
+    .endpoint(System.getenv("COSMOS_ENDPOINT"))
+    .credential(credential)
+    .buildClient();
+CosmosContainer container = client
+    .getDatabase(System.getenv("COSMOS_DATABASE"))
+    .getContainer("items");
+```
+
+Create the client as an application singleton and close it during shutdown.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/nodejs.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/nodejs.md
@@ -1,0 +1,18 @@
+# Cosmos DB with Node.js / TypeScript
+
+Packages: `@azure/cosmos`, `@azure/identity`.
+
+```typescript
+const credential = new DefaultAzureCredential({
+  managedIdentityClientId: process.env.AZURE_CLIENT_ID,
+});
+const client = new CosmosClient({
+  endpoint: process.env.COSMOS_ENDPOINT!,
+  aadCredentials: credential,
+});
+const container = client
+  .database(process.env.COSMOS_DATABASE!)
+  .container("items");
+```
+
+Create one client per process and reuse it.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/python.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/cosmos/source/python.md
@@ -1,0 +1,19 @@
+# Cosmos DB with Python
+
+Packages: `azure-cosmos`, `azure-identity`.
+
+```python
+import os
+from azure.cosmos import CosmosClient
+from azure.identity import DefaultAzureCredential
+
+credential = DefaultAzureCredential(
+    managed_identity_client_id=os.environ["AZURE_CLIENT_ID"]
+)
+client = CosmosClient(os.environ["COSMOS_ENDPOINT"], credential)
+container = client.get_database_client(
+    os.environ["COSMOS_DATABASE"]
+).get_container_client("items")
+```
+
+Create the client once at process startup.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/README.md
@@ -56,6 +56,8 @@ within the same Managed Environment.
 ### Component (backed by Service Bus)
 
 ```bicep
+param daprAppIds array
+
 resource pubsub 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01' = {
   parent: env
   name: 'pubsub'
@@ -66,6 +68,7 @@ resource pubsub 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01' = 
       { name: 'namespaceName', value: sbNamespaceFqdn }
       { name: 'azureClientId', value: uamiClientId }
     ]
+    scopes: daprAppIds
   }
 }
 ```
@@ -97,6 +100,8 @@ spec:
 ### Component (backed by Redis)
 
 ```bicep
+param daprAppIds array
+
 resource statestore 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01' = {
   parent: env
   name: 'statestore'
@@ -109,6 +114,7 @@ resource statestore 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01
       { name: 'azureClientId', value: uamiClientId }
       { name: 'useEntraID', value: 'true' }
     ]
+    scopes: daprAppIds
   }
 }
 ```
@@ -130,6 +136,8 @@ Access Key Vault secrets through the Dapr sidecar without embedding the Key Vaul
 ### Component (backed by Key Vault, UAMI auth)
 
 ```bicep
+param daprAppIds array
+
 resource secretstore 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01' = {
   parent: env
   name: 'secretstore'
@@ -140,6 +148,7 @@ resource secretstore 'Microsoft.App/managedEnvironments/daprComponents@2024-03-0
       { name: 'vaultName', value: keyVaultName }
       { name: 'azureClientId', value: uamiClientId }
     ]
+    scopes: daprAppIds
   }
 }
 
@@ -198,8 +207,8 @@ carry the connection metadata, and the sidecar handles authentication via UAMI.
 
 | Recipe Component | Role | GUID |
 |---|---|---|
-| Pub/sub (Service Bus) | Azure Service Bus Data Owner | `090c5cfd-751d-490a-894a-3ce6f1109419` |
-| State (Redis) | Redis Data Owner (access policy) | N/A — see [redis recipe](../redis/README.md) |
+| Pub/sub (Service Bus) | Data Sender + Data Receiver | `69a216fc-b8fb-44d8-bc22-1f3c2cd27a39`, `4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0` |
+| State (Redis) | Redis Data Contributor (access policy) | N/A; see [redis recipe](../redis/README.md) |
 | Secrets (Key Vault) | Key Vault Secrets User | `4633458b-17de-408a-b874-0445c86b69e6` |
 
 ## Critical Rules
@@ -208,4 +217,13 @@ carry the connection metadata, and the sidecar handles authentication via UAMI.
 2. **Always set `appId` to a stable, unique name** — other services invoke by this ID
 3. **Always use UAMI for component authentication** — never embed connection strings in component metadata
 4. **Secrets components require `Key Vault Secrets User`, not broader roles**
-5. **Components are environment-scoped** — all apps in the same Managed Environment can reference the same component names
+5. **Set component `scopes`** — list only the Dapr app IDs that require access
+
+**Source:** [Connect to services with Dapr components](https://learn.microsoft.com/azure/container-apps/dapr-component-connect-services)
+
+## Language Guides
+
+[C#](source/dotnet.md) | [Python](source/python.md) |
+[Node.js/TypeScript](source/nodejs.md) | [Go](source/go.md) | [Java](source/java.md)
+
+See [eval/summary.md](eval/summary.md) for static coverage.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/README.md
@@ -1,0 +1,211 @@
+# Dapr Recipe — REFERENCE ONLY
+
+Dapr (Distributed Application Runtime) sidecar integration for Container Apps —
+service invocation, pub/sub, state management, and secrets.
+
+## When to Use
+
+- Multi-service architectures needing service discovery + invocation
+- Pub/sub messaging without SDK lock-in
+- Portable state management (Redis, Cosmos, etc. behind one API)
+- Secrets access without hardcoding Key Vault SDK calls
+- Sidecar pattern preferred over embedding cloud SDKs in app code
+
+## Enable Dapr on Container App
+
+```bicep
+resource containerApp 'Microsoft.App/containerApps@2024-03-01' = {
+  name: name
+  location: location
+  properties: {
+    managedEnvironmentId: environmentId
+    configuration: {
+      dapr: {
+        enabled: true
+        appId: name
+        appPort: 8080
+        appProtocol: 'http'
+      }
+    }
+  }
+}
+```
+
+## 1. Service Invocation
+
+Call other Container Apps by `appId` through the Dapr sidecar — no service discovery code needed.
+
+```bash
+# From app code, call another Dapr-enabled app named "orders"
+curl http://localhost:3500/v1.0/invoke/orders/method/api/create
+```
+
+```python
+import requests
+resp = requests.post(
+    "http://localhost:3500/v1.0/invoke/orders/method/api/create",
+    json={"item": "widget"},
+)
+```
+
+No RBAC or IaC needed — Dapr service invocation uses mTLS between sidecars automatically
+within the same Managed Environment.
+
+## 2. Pub/Sub
+
+### Component (backed by Service Bus)
+
+```bicep
+resource pubsub 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01' = {
+  parent: env
+  name: 'pubsub'
+  properties: {
+    componentType: 'pubsub.azure.servicebus.topics'
+    version: 'v1'
+    metadata: [
+      { name: 'namespaceName', value: sbNamespaceFqdn }
+      { name: 'azureClientId', value: uamiClientId }
+    ]
+  }
+}
+```
+
+### Publish
+
+```bash
+curl -X POST http://localhost:3500/v1.0/publish/pubsub/orders \
+  -H "Content-Type: application/json" \
+  -d '{"orderId": "123"}'
+```
+
+### Subscribe (declarative)
+
+```yaml
+apiVersion: dapr.io/v2alpha1
+kind: Subscription
+metadata:
+  name: order-sub
+spec:
+  topic: orders
+  routes:
+    default: /orders
+  pubsubname: pubsub
+```
+
+## 3. State Management
+
+### Component (backed by Redis)
+
+```bicep
+resource statestore 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01' = {
+  parent: env
+  name: 'statestore'
+  properties: {
+    componentType: 'state.redis'
+    version: 'v1'
+    metadata: [
+      { name: 'redisHost', value: '${redisHost}:${redisSslPort}' }
+      { name: 'enableTLS', value: 'true' }
+      { name: 'azureClientId', value: uamiClientId }
+      { name: 'useEntraID', value: 'true' }
+    ]
+  }
+}
+```
+
+### Save / Get State
+
+```bash
+curl -X POST http://localhost:3500/v1.0/state/statestore \
+  -H "Content-Type: application/json" \
+  -d '[{"key": "cart-1", "value": {"items": 3}}]'
+
+curl http://localhost:3500/v1.0/state/statestore/cart-1
+```
+
+## 4. Secrets
+
+Access Key Vault secrets through the Dapr sidecar without embedding the Key Vault SDK.
+
+### Component (backed by Key Vault, UAMI auth)
+
+```bicep
+resource secretstore 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01' = {
+  parent: env
+  name: 'secretstore'
+  properties: {
+    componentType: 'secretstores.azure.keyvault'
+    version: 'v1'
+    metadata: [
+      { name: 'vaultName', value: keyVaultName }
+      { name: 'azureClientId', value: uamiClientId }
+    ]
+  }
+}
+
+// RBAC — Key Vault Secrets User (UAMI reads secrets via Dapr)
+resource kvSecretsRbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(keyVault.id, uamiPrincipalId, '4633458b-17de-408a-b874-0445c86b69e6')
+  scope: keyVault
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '4633458b-17de-408a-b874-0445c86b69e6'
+    )
+    principalId: uamiPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+```
+
+### Read a Secret (Python Example)
+
+```python
+import requests
+
+resp = requests.get(
+    "http://localhost:3500/v1.0/secrets/secretstore/db-password"
+)
+secret_value = resp.json()["db-password"]
+```
+
+### Read a Secret (Node.js Example)
+
+```javascript
+const axios = require("axios");
+
+const resp = await axios.get(
+  "http://localhost:3500/v1.0/secrets/secretstore/db-password"
+);
+const secretValue = resp.data["db-password"];
+```
+
+> ⚠️ **Grant `Key Vault Secrets User` (not `Secrets Officer`) to the app's UAMI** —
+> the Dapr sidecar only needs read access, never write/manage permissions.
+
+## Environment Variables
+
+```bicep
+env: [
+  { name: 'AZURE_CLIENT_ID', value: uami.outputs.clientId }
+]
+```
+
+No app-level SDK env vars are required for Dapr-mediated integrations — components
+carry the connection metadata, and the sidecar handles authentication via UAMI.
+
+## RBAC Roles Reference
+
+| Recipe Component | Role | GUID |
+|---|---|---|
+| Pub/sub (Service Bus) | Azure Service Bus Data Owner | `090c5cfd-751d-490a-894a-3ce6f1109419` |
+| State (Redis) | Redis Data Owner (access policy) | N/A — see [redis recipe](../redis/README.md) |
+| Secrets (Key Vault) | Key Vault Secrets User | `4633458b-17de-408a-b874-0445c86b69e6` |
+
+## Critical Rules
+
+1. **Always enable Dapr at the Container App level** (`configuration.dapr.enabled: true`)
+2. **Always set `appId` to a stable, unique name** — other services invoke by this ID
+3. **Always use UAMI for component authentication** — never embed connection strings in component metadata
+4. **Secrets components require `Key Vault Secrets User`, not broader roles**
+5. **Components are environment-scoped** — all apps in the same Managed Environment can reference the same component names

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/eval/summary.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/eval/summary.md
@@ -1,0 +1,13 @@
+# Dapr Static Coverage
+
+| Language | Guide |
+|---|---|
+| C# | [Authored](../source/dotnet.md) |
+| Python | [Authored](../source/python.md) |
+| Node.js/TypeScript | [Authored](../source/nodejs.md) |
+| Go | [Authored](../source/go.md) |
+| Java | [Authored](../source/java.md) |
+
+Review criteria: sidecar invocation, pub/sub, state, secret retrieval, managed identity,
+component scopes, HTTP failures, and timeouts. This is static guidance coverage, not an
+executed deployment result.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/dotnet.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/dotnet.md
@@ -1,0 +1,15 @@
+# Dapr with C#
+
+Use `HttpClient` against the local sidecar. No Azure credential is needed in application
+code because the Dapr component authenticates with the app UAMI.
+
+```csharp
+var daprPort = Environment.GetEnvironmentVariable("DAPR_HTTP_PORT") ?? "3500";
+using var client = new HttpClient { BaseAddress = new($"http://localhost:{daprPort}") };
+await client.PostAsJsonAsync("/v1.0/publish/pubsub/orders", new { orderId = "123" });
+var secret = await client.GetFromJsonAsync<Dictionary<string, string>>(
+    "/v1.0/secrets/secretstore/db-password");
+```
+
+Use `/v1.0/invoke/<app-id>/method/<path>` for service invocation and
+`/v1.0/state/statestore` for state.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/go.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/go.md
@@ -1,0 +1,18 @@
+# Dapr with Go
+
+Use `net/http` against the local sidecar:
+
+```go
+port := os.Getenv("DAPR_HTTP_PORT")
+if port == "" { port = "3500" }
+body := strings.NewReader(`{"orderId":"123"}`)
+req, _ := http.NewRequest(http.MethodPost,
+    "http://localhost:"+port+"/v1.0/publish/pubsub/orders", body)
+req.Header.Set("Content-Type", "application/json")
+resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+if err != nil { return err }
+defer resp.Body.Close()
+if resp.StatusCode >= 300 { return fmt.Errorf("dapr publish: %s", resp.Status) }
+```
+
+Apply the same status and timeout handling to invocation, state, and secrets calls.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/java.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/java.md
@@ -1,0 +1,17 @@
+# Dapr with Java
+
+Use `java.net.http.HttpClient` against the local sidecar:
+
+```java
+String port = System.getenv().getOrDefault("DAPR_HTTP_PORT", "3500");
+HttpRequest request = HttpRequest.newBuilder()
+    .uri(URI.create("http://localhost:" + port + "/v1.0/publish/pubsub/orders"))
+    .header("Content-Type", "application/json")
+    .POST(HttpRequest.BodyPublishers.ofString("{\"orderId\":\"123\"}"))
+    .build();
+HttpResponse<String> response = HttpClient.newHttpClient()
+    .send(request, HttpResponse.BodyHandlers.ofString());
+if (response.statusCode() >= 300) {
+    throw new IllegalStateException("Dapr publish failed: " + response.statusCode());
+}
+```

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/nodejs.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/nodejs.md
@@ -1,0 +1,17 @@
+# Dapr with Node.js / TypeScript
+
+Use the built-in `fetch` API against the local sidecar:
+
+```typescript
+const base = `http://localhost:${process.env.DAPR_HTTP_PORT ?? "3500"}`;
+const publish = await fetch(`${base}/v1.0/publish/pubsub/orders`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ orderId: "123" }),
+});
+if (!publish.ok) throw new Error(`Dapr publish failed: ${publish.status}`);
+
+const response = await fetch(`${base}/v1.0/secrets/secretstore/db-password`);
+if (!response.ok) throw new Error(`Dapr secret read failed: ${response.status}`);
+const secret = (await response.json())["db-password"];
+```

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/python.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/dapr/source/python.md
@@ -1,0 +1,17 @@
+# Dapr with Python
+
+Use `httpx` against the local sidecar. The Dapr component, not the app, authenticates to
+Azure services.
+
+```python
+import os
+import httpx
+
+base = f"http://localhost:{os.getenv('DAPR_HTTP_PORT', '3500')}"
+httpx.post(f"{base}/v1.0/publish/pubsub/orders", json={"orderId": "123"}).raise_for_status()
+secret = httpx.get(
+    f"{base}/v1.0/secrets/secretstore/db-password"
+).raise_for_status().json()["db-password"]
+```
+
+Use timeouts and retry only idempotent operations in production.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/README.md
@@ -1,0 +1,112 @@
+# Event Hubs Recipe
+
+Use Event Hubs for high-throughput event streams. Consumers should use a dedicated consumer
+group, Blob Storage checkpoints, managed identity, and KEDA scaling.
+
+## Infrastructure
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param appPrincipalId string
+param userAssignedIdentityId string
+
+var receiverRoleId = 'a638d3c7-ab3a-418d-83e6-5f17a39d4fde'
+var blobContributorRoleId = 'ba92f5b4-2d11-453d-a403-e96b0029c9fe'
+
+resource ns 'Microsoft.EventHub/namespaces@2024-01-01' = {
+  name: name
+  location: location
+  sku: { name: 'Standard', tier: 'Standard', capacity: 1 }
+  properties: { disableLocalAuth: true }
+}
+resource hub 'Microsoft.EventHub/namespaces/eventhubs@2024-01-01' = {
+  parent: ns
+  name: 'events'
+  properties: { partitionCount: 4, messageRetentionInDays: 1 }
+}
+resource group 'Microsoft.EventHub/namespaces/eventhubs/consumergroups@2024-01-01' = {
+  parent: hub
+  name: 'workers'
+}
+
+resource checkpointStorage 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: take('${uniqueString(resourceGroup().id, name)}checkpoints', 24)
+  location: location
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+  properties: {
+    allowBlobPublicAccess: false
+    minimumTlsVersion: 'TLS1_2'
+  }
+}
+resource blobService 'Microsoft.Storage/storageAccounts/blobServices@2023-05-01' = {
+  parent: checkpointStorage
+  name: 'default'
+}
+resource checkpointContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2023-05-01' = {
+  parent: blobService
+  name: 'checkpoints'
+  properties: { publicAccess: 'None' }
+}
+
+resource eventHubReceiver 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(ns.id, appPrincipalId, receiverRoleId)
+  scope: ns
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', receiverRoleId)
+    principalId: appPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+resource checkpointWriter 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(checkpointStorage.id, appPrincipalId, blobContributorRoleId)
+  scope: checkpointStorage
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', blobContributorRoleId)
+    principalId: appPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output eventHubFqdn string = '${ns.name}.servicebus.windows.net'
+output eventHubName string = hub.name
+output consumerGroup string = group.name
+output checkpointStorageUrl string = 'https://${checkpointStorage.name}.blob.${environment().suffixes.storage}'
+```
+
+## KEDA Rule
+
+```bicep
+custom: {
+  type: 'azure-eventhub'
+  metadata: {
+    eventHubNamespace: ns.name
+    eventHubName: hub.name
+    consumerGroup: group.name
+    storageAccountName: checkpointStorage.name
+    blobContainer: checkpointContainer.name
+    checkpointStrategy: 'blobMetadata'
+    unprocessedEventThreshold: '64'
+  }
+  identity: userAssignedIdentityId
+}
+```
+
+Set the four endpoint/name outputs as `EVENTHUB_FQDN`, `EVENTHUB_NAME`,
+`EVENTHUB_CONSUMER_GROUP`, and `CHECKPOINT_STORAGE_URL`; also set `AZURE_CLIENT_ID`.
+
+## Language Guides
+
+| Language | Guide |
+|---|---|
+| C# | [source/dotnet.md](source/dotnet.md) |
+| Python | [source/python.md](source/python.md) |
+| Node.js/TypeScript | [source/nodejs.md](source/nodejs.md) |
+| Go | [source/go.md](source/go.md) |
+| Java | [source/java.md](source/java.md) |
+
+See [eval/summary.md](eval/summary.md) for static coverage.
+
+**Sources:** [Event Hubs managed identity](https://learn.microsoft.com/azure/event-hubs/authenticate-managed-identity),
+[Container Apps scale rules](https://learn.microsoft.com/azure/container-apps/scale-app)

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/eval/summary.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/eval/summary.md
@@ -1,0 +1,13 @@
+# Event Hubs Static Coverage
+
+| Language | Guide |
+|---|---|
+| C# | [Authored](../source/dotnet.md) |
+| Python | [Authored](../source/python.md) |
+| Node.js/TypeScript | [Authored](../source/nodejs.md) |
+| Go | [Authored](../source/go.md) |
+| Java | [Authored](../source/java.md) |
+
+Review criteria: managed identity, receiver and checkpoint RBAC, consumer-group isolation,
+Blob checkpoints, partition ownership, graceful shutdown, and KEDA identity. This is static
+guidance coverage, not an executed deployment result.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/dotnet.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/dotnet.md
@@ -1,0 +1,20 @@
+# Event Hubs with C#
+
+Packages: `Azure.Messaging.EventHubs.Processor`, `Azure.Storage.Blobs`, `Azure.Identity`.
+
+```csharp
+var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions {
+    ManagedIdentityClientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID")
+});
+var checkpoints = new BlobContainerClient(
+    new Uri($"{Environment.GetEnvironmentVariable("CHECKPOINT_STORAGE_URL")}/checkpoints"),
+    credential);
+var processor = new EventProcessorClient(
+    checkpoints,
+    Environment.GetEnvironmentVariable("EVENTHUB_CONSUMER_GROUP"),
+    Environment.GetEnvironmentVariable("EVENTHUB_FQDN"),
+    Environment.GetEnvironmentVariable("EVENTHUB_NAME"),
+    credential);
+```
+
+Register event and error handlers, then call `StartProcessingAsync`.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/go.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/go.md
@@ -1,0 +1,40 @@
+# Event Hubs with Go
+
+Packages: `github.com/Azure/azure-sdk-for-go/sdk/azidentity` and
+`github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2`,
+`github.com/Azure/azure-sdk-for-go/sdk/messaging/azeventhubs/v2/checkpoints`, and
+`github.com/Azure/azure-sdk-for-go/sdk/storage/azblob`.
+
+```go
+credential, err := azidentity.NewDefaultAzureCredential(nil)
+if err != nil { return err }
+blobClient, err := azblob.NewClient(
+    os.Getenv("CHECKPOINT_STORAGE_URL"), credential, nil)
+if err != nil { return err }
+store, err := checkpoints.NewBlobStore(
+    blobClient.ServiceClient().NewContainerClient("checkpoints"), nil)
+if err != nil { return err }
+consumer, err := azeventhubs.NewConsumerClient(
+    os.Getenv("EVENTHUB_FQDN"),
+    os.Getenv("EVENTHUB_NAME"),
+    os.Getenv("EVENTHUB_CONSUMER_GROUP"),
+    credential, nil)
+if err != nil { return err }
+defer consumer.Close(ctx)
+
+processor, err := azeventhubs.NewProcessor(consumer, store, nil)
+if err != nil { return err }
+go func() {
+    if err := processor.Run(ctx); err != nil {
+        log.Printf("Event Hubs processor stopped: %v", err)
+    }
+}()
+for {
+    partition := processor.NextPartitionClient(ctx)
+    if partition == nil { break }
+    go consumePartition(ctx, partition)
+}
+```
+
+In `consumePartition`, defer `partition.Close`, receive batches with `ReceiveEvents`, process
+them, then call `UpdateCheckpoint` with the last successfully handled event.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/java.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/java.md
@@ -1,0 +1,29 @@
+# Event Hubs with Java
+
+Packages: `com.azure:azure-messaging-eventhubs`,
+`com.azure:azure-messaging-eventhubs-checkpointstore-blob`, `com.azure:azure-storage-blob`,
+`com.azure:azure-identity`.
+
+```java
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .managedIdentityClientId(System.getenv("AZURE_CLIENT_ID"))
+    .build();
+BlobContainerAsyncClient checkpointContainer = new BlobContainerClientBuilder()
+    .endpoint(System.getenv("CHECKPOINT_STORAGE_URL") + "/checkpoints")
+    .credential(credential)
+    .buildAsyncClient();
+EventProcessorClient processor = new EventProcessorClientBuilder()
+    .fullyQualifiedNamespace(System.getenv("EVENTHUB_FQDN"))
+    .eventHubName(System.getenv("EVENTHUB_NAME"))
+    .consumerGroup(System.getenv("EVENTHUB_CONSUMER_GROUP"))
+    .credential(credential)
+    .checkpointStore(new BlobCheckpointStore(checkpointContainer))
+    .processEvent(context -> {
+        handle(context.getEventData());
+        context.updateCheckpoint();
+    })
+    .processError(context -> logger.error("Event Hubs", context.getThrowable()))
+    .buildEventProcessorClient();
+processor.start();
+Runtime.getRuntime().addShutdownHook(new Thread(processor::stop));
+```

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/nodejs.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/nodejs.md
@@ -1,0 +1,22 @@
+# Event Hubs with Node.js / TypeScript
+
+Packages: `@azure/event-hubs`, `@azure/identity`, `@azure/storage-blob`,
+`@azure/eventhubs-checkpointstore-blob`.
+
+```typescript
+const credential = new DefaultAzureCredential({
+  managedIdentityClientId: process.env.AZURE_CLIENT_ID,
+});
+const container = new ContainerClient(
+  `${process.env.CHECKPOINT_STORAGE_URL!}/checkpoints`, credential);
+const store = new BlobCheckpointStore(container);
+const client = new EventHubConsumerClient(
+  process.env.EVENTHUB_CONSUMER_GROUP!,
+  process.env.EVENTHUB_FQDN!,
+  process.env.EVENTHUB_NAME!,
+  credential,
+  store,
+);
+```
+
+Call `client.subscribe` with event and error handlers, and close the subscription on shutdown.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/python.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/eventhubs/source/python.md
@@ -1,0 +1,23 @@
+# Event Hubs with Python
+
+Packages: `azure-eventhub`, `azure-eventhub-checkpointstoreblob-aio`, `azure-identity`.
+
+```python
+credential = DefaultAzureCredential(
+    managed_identity_client_id=os.environ["AZURE_CLIENT_ID"]
+)
+checkpoint = BlobCheckpointStore(
+    blob_account_url=os.environ["CHECKPOINT_STORAGE_URL"],
+    container_name="checkpoints",
+    credential=credential,
+)
+client = EventHubConsumerClient(
+    fully_qualified_namespace=os.environ["EVENTHUB_FQDN"],
+    eventhub_name=os.environ["EVENTHUB_NAME"],
+    consumer_group=os.environ["EVENTHUB_CONSUMER_GROUP"],
+    credential=credential,
+    checkpoint_store=checkpoint,
+)
+```
+
+Use the async clients for long-running workers.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/README.md
@@ -1,0 +1,139 @@
+# PostgreSQL Recipe — REFERENCE ONLY
+
+Azure Database for PostgreSQL Flexible Server integration for Container Apps.
+
+## When to Use
+
+- Relational database for CRUD applications
+- PostgreSQL-compatible workloads
+- Applications requiring SQL queries, joins, transactions
+- Django, Rails, Spring Data, Prisma backends
+
+## Bicep — PostgreSQL Module
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param principalId string
+param principalName string
+param databaseName string = 'appdb'
+
+resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard_B1ms'
+    tier: 'Burstable'
+  }
+  properties: {
+    version: '16'
+    storage: { storageSizeGB: 32 }
+    authConfig: {
+      activeDirectoryAuth: 'Enabled'
+      passwordAuth: 'Disabled'
+    }
+    highAvailability: { mode: 'Disabled' }
+  }
+}
+
+resource database 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
+  parent: postgres
+  name: databaseName
+  properties: { charset: 'UTF8', collation: 'en_US.utf8' }
+}
+
+// Entra ID administrator
+resource admin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2024-08-01' = {
+  parent: postgres
+  name: principalId
+  properties: {
+    principalType: 'ServicePrincipal'
+    principalName: principalName
+    tenantId: tenant().tenantId
+  }
+}
+
+output fqdn string = postgres.properties.fullyQualifiedDomainName
+output databaseName string = database.name
+```
+
+## Environment Variables
+
+```bicep
+env: [
+  { name: 'PGHOST', value: postgres.outputs.fqdn }
+  { name: 'PGDATABASE', value: postgres.outputs.databaseName }
+  { name: 'PGPORT', value: '5432' }
+  { name: 'PGSSLMODE', value: 'require' }
+  { name: 'AZURE_CLIENT_ID', value: uami.outputs.clientId }
+  { name: 'PGUSER', value: uami.outputs.name }  // Entra principal name configured as PG admin
+]
+```
+
+## Authentication
+
+Use Entra ID (passwordless) authentication:
+
+```python
+# Python example
+from azure.identity import DefaultAzureCredential
+import psycopg2
+import os
+
+credential = DefaultAzureCredential(
+    managed_identity_client_id=os.environ["AZURE_CLIENT_ID"]
+)
+token = credential.get_token("https://ossrdbms-aad.database.windows.net/.default")
+
+conn = psycopg2.connect(
+    host=os.environ["PGHOST"],
+    database=os.environ["PGDATABASE"],
+    user=os.environ["PGUSER"],
+    password=token.token,
+    sslmode="require",
+)
+```
+
+## Node.js Connection
+
+```javascript
+const { DefaultAzureCredential } = require("@azure/identity");
+const { Client } = require("pg");
+
+const credential = new DefaultAzureCredential({
+  managedIdentityClientId: process.env.AZURE_CLIENT_ID,
+});
+const token = await credential.getToken(
+  "https://ossrdbms-aad.database.windows.net/.default"
+);
+
+const client = new Client({
+  host: process.env.PGHOST,
+  database: process.env.PGDATABASE,
+  user: process.env.PGUSER,
+  password: token.token,
+  ssl: { rejectUnauthorized: true },
+  port: 5432,
+});
+```
+
+## Firewall
+
+For Container Apps with VNet integration, use private endpoints or service endpoints.
+Without VNet, allow Azure services:
+
+```bicep
+resource firewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
+  parent: postgres
+  name: 'AllowAzureServices'
+  properties: {
+    startIpAddress: '0.0.0.0'
+    endIpAddress: '0.0.0.0'
+  }
+}
+```
+
+> ⚠️ **Always disable password auth** — set `passwordAuth: 'Disabled'`
+> and use Entra ID authentication only.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/README.md
@@ -1,32 +1,52 @@
-# PostgreSQL Recipe — REFERENCE ONLY
+# PostgreSQL Recipe
 
-Azure Database for PostgreSQL Flexible Server integration for Container Apps.
+Use Azure Database for PostgreSQL Flexible Server for relational workloads. Use Microsoft
+Entra authentication, a separate deployment administrator, and a non-admin app role.
 
-## When to Use
-
-- Relational database for CRUD applications
-- PostgreSQL-compatible workloads
-- Applications requiring SQL queries, joins, transactions
-- Django, Rails, Spring Data, Prisma backends
-
-## Bicep — PostgreSQL Module
+## Infrastructure
 
 ```bicep
 param name string
 param location string = resourceGroup().location
-param tags object = {}
-param principalId string
-param principalName string
-param databaseName string = 'appdb'
+param adminPrincipalId string
+param adminPrincipalName string
+param virtualNetworkName string
+param postgresSubnetPrefix string = '10.0.2.0/24'
+
+resource vnet 'Microsoft.Network/virtualNetworks@2024-05-01' existing = {
+  name: virtualNetworkName
+}
+resource postgresSubnet 'Microsoft.Network/virtualNetworks/subnets@2024-05-01' = {
+  parent: vnet
+  name: 'postgres'
+  properties: {
+    addressPrefix: postgresSubnetPrefix
+    delegations: [
+      {
+        name: 'postgres'
+        properties: { serviceName: 'Microsoft.DBforPostgreSQL/flexibleServers' }
+      }
+    ]
+  }
+}
+resource privateDns 'Microsoft.Network/privateDnsZones@2024-06-01' = {
+  name: 'private.postgres.database.azure.com'
+  location: 'global'
+}
+resource privateDnsLink 'Microsoft.Network/privateDnsZones/virtualNetworkLinks@2024-06-01' = {
+  parent: privateDns
+  name: '${name}-vnet-link'
+  location: 'global'
+  properties: {
+    registrationEnabled: false
+    virtualNetwork: { id: vnet.id }
+  }
+}
 
 resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
   name: name
   location: location
-  tags: tags
-  sku: {
-    name: 'Standard_B1ms'
-    tier: 'Burstable'
-  }
+  sku: { name: 'Standard_B1ms', tier: 'Burstable' }
   properties: {
     version: '16'
     storage: { storageSizeGB: 32 }
@@ -34,106 +54,74 @@ resource postgres 'Microsoft.DBforPostgreSQL/flexibleServers@2024-08-01' = {
       activeDirectoryAuth: 'Enabled'
       passwordAuth: 'Disabled'
     }
-    highAvailability: { mode: 'Disabled' }
+    network: {
+      delegatedSubnetResourceId: postgresSubnet.id
+      privateDnsZoneArmResourceId: privateDns.id
+      publicNetworkAccess: 'Disabled'
+    }
   }
+  dependsOn: [privateDnsLink]
 }
 
 resource database 'Microsoft.DBforPostgreSQL/flexibleServers/databases@2024-08-01' = {
   parent: postgres
-  name: databaseName
+  name: 'appdb'
   properties: { charset: 'UTF8', collation: 'en_US.utf8' }
 }
 
-// Entra ID administrator
 resource admin 'Microsoft.DBforPostgreSQL/flexibleServers/administrators@2024-08-01' = {
   parent: postgres
-  name: principalId
+  name: adminPrincipalId
   properties: {
     principalType: 'ServicePrincipal'
-    principalName: principalName
+    principalName: adminPrincipalName
     tenantId: tenant().tenantId
   }
 }
 
 output fqdn string = postgres.properties.fullyQualifiedDomainName
-output databaseName string = database.name
 ```
 
-## Environment Variables
+## Application Configuration
 
-```bicep
-env: [
-  { name: 'PGHOST', value: postgres.outputs.fqdn }
-  { name: 'PGDATABASE', value: postgres.outputs.databaseName }
-  { name: 'PGPORT', value: '5432' }
-  { name: 'PGSSLMODE', value: 'require' }
-  { name: 'AZURE_CLIENT_ID', value: uami.outputs.clientId }
-  { name: 'PGUSER', value: uami.outputs.name }  // Entra principal name configured as PG admin
-]
-```
+Set `PGHOST`, `PGDATABASE=appdb`, `PGPORT=5432`, `PGSSLMODE=require`,
+`PGUSER=<appPrincipalName>`, and `AZURE_CLIENT_ID=<app-UAMI-client-id>`.
 
-## Authentication
+The administrator must create a non-admin role mapped to the app UAMI. Run this once from
+a deployment hook authenticated as `adminPrincipalId`:
 
-Use Entra ID (passwordless) authentication:
-
-```python
-# Python example
-from azure.identity import DefaultAzureCredential
-import psycopg2
-import os
-
-credential = DefaultAzureCredential(
-    managed_identity_client_id=os.environ["AZURE_CLIENT_ID"]
-)
-token = credential.get_token("https://ossrdbms-aad.database.windows.net/.default")
-
-conn = psycopg2.connect(
-    host=os.environ["PGHOST"],
-    database=os.environ["PGDATABASE"],
-    user=os.environ["PGUSER"],
-    password=token.token,
-    sslmode="require",
-)
-```
-
-## Node.js Connection
-
-```javascript
-const { DefaultAzureCredential } = require("@azure/identity");
-const { Client } = require("pg");
-
-const credential = new DefaultAzureCredential({
-  managedIdentityClientId: process.env.AZURE_CLIENT_ID,
-});
-const token = await credential.getToken(
-  "https://ossrdbms-aad.database.windows.net/.default"
+```sql
+SELECT * FROM pg_catalog.pgaadauth_create_principal_with_oid(
+  '<app-principal-name>', '<app-principal-object-id>', 'service', false, false
 );
-
-const client = new Client({
-  host: process.env.PGHOST,
-  database: process.env.PGDATABASE,
-  user: process.env.PGUSER,
-  password: token.token,
-  ssl: { rejectUnauthorized: true },
-  port: 5432,
-});
+GRANT CONNECT ON DATABASE appdb TO "<app-principal-name>";
+GRANT USAGE ON SCHEMA public TO "<app-principal-name>";
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public
+  TO "<app-principal-name>";
+GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public
+  TO "<app-principal-name>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO "<app-principal-name>";
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO "<app-principal-name>";
 ```
 
-## Firewall
+Run the `ALTER DEFAULT PRIVILEGES` statements as the role that owns future migration objects.
 
-For Container Apps with VNet integration, use private endpoints or service endpoints.
-Without VNet, allow Azure services:
+## Language Guides
 
-```bicep
-resource firewallRule 'Microsoft.DBforPostgreSQL/flexibleServers/firewallRules@2024-08-01' = {
-  parent: postgres
-  name: 'AllowAzureServices'
-  properties: {
-    startIpAddress: '0.0.0.0'
-    endIpAddress: '0.0.0.0'
-  }
-}
-```
+| Language | Guide |
+|---|---|
+| C# | [source/dotnet.md](source/dotnet.md) |
+| Python | [source/python.md](source/python.md) |
+| Node.js/TypeScript | [source/nodejs.md](source/nodejs.md) |
+| Go | [source/go.md](source/go.md) |
+| Java | [source/java.md](source/java.md) |
 
-> ⚠️ **Always disable password auth** — set `passwordAuth: 'Disabled'`
-> and use Entra ID authentication only.
+> ⚠️ Keep `adminPrincipalId` separate from `appPrincipalId`; the application identity must
+> not be a PostgreSQL administrator. Pass the VNet used by the Container Apps environment;
+> the recipe creates a separate delegated database subnet and disables public access.
+>
+> **Source:** [Manage Microsoft Entra roles in PostgreSQL](https://learn.microsoft.com/azure/postgresql/security/security-manage-entra-users)
+
+See [eval/summary.md](eval/summary.md) for static coverage.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/eval/summary.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/eval/summary.md
@@ -1,0 +1,13 @@
+# PostgreSQL Static Coverage
+
+| Language | Guide |
+|---|---|
+| C# | [Authored](../source/dotnet.md) |
+| Python | [Authored](../source/python.md) |
+| Node.js/TypeScript | [Authored](../source/nodejs.md) |
+| Go | [Authored](../source/go.md) |
+| Java | [Authored](../source/java.md) |
+
+Review criteria: separate admin/app identities, non-admin app role, password auth disabled,
+TLS, access-token refresh, pooling, and private networking. This is static guidance
+coverage, not an executed deployment result.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/dotnet.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/dotnet.md
@@ -1,0 +1,20 @@
+# PostgreSQL with C#
+
+Packages: `Npgsql`, `Azure.Identity`, `Azure.Core`.
+
+```csharp
+var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions {
+    ManagedIdentityClientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID")
+});
+var token = await credential.GetTokenAsync(
+    new TokenRequestContext(["https://ossrdbms-aad.database.windows.net/.default"]));
+var cs = new NpgsqlConnectionStringBuilder {
+    Host = Environment.GetEnvironmentVariable("PGHOST"),
+    Database = Environment.GetEnvironmentVariable("PGDATABASE"),
+    Username = Environment.GetEnvironmentVariable("PGUSER"),
+    Password = token.Token,
+    SslMode = SslMode.Require,
+};
+```
+
+Use Npgsql's periodic password provider for pooled, long-running connections.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/go.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/go.md
@@ -1,0 +1,19 @@
+# PostgreSQL with Go
+
+Packages: `github.com/Azure/azure-sdk-for-go/sdk/azidentity`,
+`github.com/jackc/pgx/v5`, and `github.com/jackc/pgx/v5/pgxpool`.
+
+```go
+credential, err := azidentity.NewDefaultAzureCredential(nil)
+if err != nil { return err }
+token, err := credential.GetToken(ctx, policy.TokenRequestOptions{
+    Scopes: []string{"https://ossrdbms-aad.database.windows.net/.default"},
+})
+if err != nil { return err }
+config, err := pgxpool.ParseConfig(os.Getenv("DATABASE_URL"))
+if err != nil { return err }
+config.ConnConfig.Password = token.Token
+pool, err := pgxpool.NewWithConfig(ctx, config)
+```
+
+Set `sslmode=require` in `DATABASE_URL` and refresh pools before token expiry.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/java.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/java.md
@@ -1,0 +1,20 @@
+# PostgreSQL with Java
+
+Packages: `org.postgresql:postgresql`, `com.azure:azure-identity`.
+
+```java
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .managedIdentityClientId(System.getenv("AZURE_CLIENT_ID"))
+    .build();
+AccessToken token = credential.getToken(new TokenRequestContext()
+    .addScopes("https://ossrdbms-aad.database.windows.net/.default")).block();
+Properties props = new Properties();
+props.setProperty("user", System.getenv("PGUSER"));
+props.setProperty("password", token.getToken());
+props.setProperty("sslmode", "require");
+Connection connection = DriverManager.getConnection(
+    "jdbc:postgresql://" + System.getenv("PGHOST") + ":5432/"
+        + System.getenv("PGDATABASE"), props);
+```
+
+Refresh the data source before token expiry.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/nodejs.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/nodejs.md
@@ -1,0 +1,21 @@
+# PostgreSQL with Node.js / TypeScript
+
+Packages: `pg`, `@azure/identity`.
+
+```typescript
+const credential = new DefaultAzureCredential({
+  managedIdentityClientId: process.env.AZURE_CLIENT_ID,
+});
+const token = await credential.getToken(
+  "https://ossrdbms-aad.database.windows.net/.default",
+);
+const client = new Client({
+  host: process.env.PGHOST,
+  database: process.env.PGDATABASE,
+  user: process.env.PGUSER,
+  password: token.token,
+  ssl: { rejectUnauthorized: true },
+});
+```
+
+Refresh credentials when the pool creates connections after token expiry.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/python.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/postgres/source/python.md
@@ -1,0 +1,21 @@
+# PostgreSQL with Python
+
+Packages: `psycopg[binary]`, `azure-identity`.
+
+```python
+credential = DefaultAzureCredential(
+    managed_identity_client_id=os.environ["AZURE_CLIENT_ID"]
+)
+token = credential.get_token(
+    "https://ossrdbms-aad.database.windows.net/.default"
+)
+connection = psycopg.connect(
+    host=os.environ["PGHOST"],
+    dbname=os.environ["PGDATABASE"],
+    user=os.environ["PGUSER"],
+    password=token.token,
+    sslmode="require",
+)
+```
+
+Refresh the token before opening new pooled connections after expiry.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/README.md
@@ -1,0 +1,120 @@
+# Redis Recipe — REFERENCE ONLY
+
+Azure Managed Redis (or Azure Cache for Redis) integration for Container Apps.
+
+## When to Use
+
+- Application caching (session, output, data)
+- Distributed state store
+- Rate limiting
+- Dapr state store backend
+
+## Bicep — Redis Module
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param principalId string
+
+resource redis 'Microsoft.Cache/redis@2024-03-01' = {
+  name: name
+  location: location
+  tags: tags
+  properties: {
+    sku: {
+      name: 'Standard'
+      family: 'C'
+      capacity: 1
+    }
+    enableNonSslPort: false
+    minimumTlsVersion: '1.2'
+    redisConfiguration: {
+      'aad-enabled': 'true'
+    }
+  }
+}
+
+// Data access — Redis uses its own access policy system, not ARM roleAssignments
+resource accessPolicy 'Microsoft.Cache/redis/accessPolicyAssignments@2024-03-01' = {
+  parent: redis
+  name: guid(redis.id, principalId, 'data-owner')
+  properties: {
+    accessPolicyName: 'Data Owner'
+    objectId: principalId
+    objectIdAlias: 'appIdentity'
+  }
+}
+
+output hostName string = redis.properties.hostName
+output sslPort int = redis.properties.sslPort
+```
+
+## Environment Variables
+
+```bicep
+env: [
+  { name: 'REDIS_HOSTNAME', value: redis.outputs.hostName }
+  { name: 'REDIS_PORT', value: string(redis.outputs.sslPort) }
+  { name: 'AZURE_CLIENT_ID', value: uami.outputs.clientId }
+  { name: 'REDIS_USER_OID', value: uami.outputs.principalId }  // objectId for Redis username
+]
+```
+
+## Access Policies
+
+Redis uses its own data access policy system (not ARM roleAssignments):
+
+| Policy | Access |
+|--------|--------|
+| Data Owner | Read + write data, manage access policies |
+| Data Contributor | Read + write data |
+| Data Reader | Read-only data |
+
+> ⚠️ **Do not use ARM `roleAssignments`** for Redis data access — those are control-plane only. Use `Microsoft.Cache/redis/accessPolicyAssignments` as shown above.
+
+## SDK Connection (Node.js Example)
+
+```javascript
+const { createClient } = require("redis");
+const { DefaultAzureCredential } = require("@azure/identity");
+
+const credential = new DefaultAzureCredential({
+  managedIdentityClientId: process.env.AZURE_CLIENT_ID,
+});
+
+async function createRedisClient() {
+  const { token } = await credential.getToken("https://redis.azure.com/.default");
+  const client = createClient({
+    url: `rediss://${process.env.REDIS_HOSTNAME}:${process.env.REDIS_PORT}`,
+    username: process.env.REDIS_USER_OID,  // objectId (principalId), not clientId
+    password: token,
+  });
+  await client.connect();
+  return client;
+}
+```
+
+## Dapr State Store
+
+Redis can also be used as a Dapr state store component:
+
+```bicep
+resource stateStore 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01' = {
+  parent: env
+  name: 'statestore'
+  properties: {
+    componentType: 'state.redis'
+    version: 'v1'
+    metadata: [
+      { name: 'redisHost', value: '${redis.outputs.hostName}:${redis.outputs.sslPort}' }
+      { name: 'enableTLS', value: 'true' }
+      { name: 'azureClientId', value: uamiClientId }
+      { name: 'useEntraID', value: 'true' }
+    ]
+  }
+}
+```
+
+> ⚠️ **Always enable Entra ID authentication** via `aad-enabled: true`
+> and disable non-SSL port.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/README.md
@@ -35,12 +35,12 @@ resource redis 'Microsoft.Cache/redis@2024-03-01' = {
   }
 }
 
-// Data access — Redis uses its own access policy system, not ARM roleAssignments
+// Data access — application read/write without access-policy administration
 resource accessPolicy 'Microsoft.Cache/redis/accessPolicyAssignments@2024-03-01' = {
   parent: redis
   name: guid(redis.id, principalId, 'data-owner')
   properties: {
-    accessPolicyName: 'Data Owner'
+    accessPolicyName: 'Data Contributor'
     objectId: principalId
     objectIdAlias: 'appIdentity'
   }
@@ -100,6 +100,8 @@ async function createRedisClient() {
 Redis can also be used as a Dapr state store component:
 
 ```bicep
+param daprAppIds array
+
 resource stateStore 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01' = {
   parent: env
   name: 'statestore'
@@ -112,9 +114,17 @@ resource stateStore 'Microsoft.App/managedEnvironments/daprComponents@2024-03-01
       { name: 'azureClientId', value: uamiClientId }
       { name: 'useEntraID', value: 'true' }
     ]
+    scopes: daprAppIds
   }
 }
 ```
 
 > ⚠️ **Always enable Entra ID authentication** via `aad-enabled: true`
 > and disable non-SSL port.
+
+## Language Guides
+
+[C#](source/dotnet.md) | [Python](source/python.md) |
+[Node.js/TypeScript](source/nodejs.md) | [Go](source/go.md) | [Java](source/java.md)
+
+See [eval/summary.md](eval/summary.md) for static coverage.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/eval/summary.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/eval/summary.md
@@ -1,0 +1,13 @@
+# Redis Static Coverage
+
+| Language | Guide |
+|---|---|
+| C# | [Authored](../source/dotnet.md) |
+| Python | [Authored](../source/python.md) |
+| Node.js/TypeScript | [Authored](../source/nodejs.md) |
+| Go | [Authored](../source/go.md) |
+| Java | [Authored](../source/java.md) |
+
+Review criteria: Entra authentication, app Data Contributor access, TLS, UAMI object ID as
+username, token refresh, non-SSL disabled, and Dapr scopes. This is static guidance
+coverage, not an executed deployment result.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/dotnet.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/dotnet.md
@@ -1,0 +1,16 @@
+# Redis with C#
+
+Packages: `StackExchange.Redis`, `Azure.Identity`.
+
+Acquire `https://redis.azure.com/.default` with `DefaultAzureCredential`. Configure TLS,
+use the UAMI object ID from `REDIS_USER_OID` as the Redis username, and use the access token
+as the password. Re-authenticate before the token expires.
+
+```csharp
+var token = await credential.GetTokenAsync(
+    new TokenRequestContext(["https://redis.azure.com/.default"]));
+var options = ConfigurationOptions.Parse($"{host}:6380,ssl=true");
+options.User = Environment.GetEnvironmentVariable("REDIS_USER_OID");
+options.Password = token.Token;
+var redis = await ConnectionMultiplexer.ConnectAsync(options);
+```

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/go.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/go.md
@@ -1,0 +1,19 @@
+# Redis with Go
+
+Packages: `github.com/Azure/azure-sdk-for-go/sdk/azidentity` and
+`github.com/redis/go-redis/v9`.
+
+```go
+credential, err := azidentity.NewDefaultAzureCredential(nil)
+if err != nil { return err }
+token, err := credential.GetToken(ctx,
+    policy.TokenRequestOptions{Scopes: []string{"https://redis.azure.com/.default"}})
+if err != nil { return err }
+client := redis.NewClient(&redis.Options{
+    Addr: os.Getenv("REDIS_HOSTNAME") + ":" + os.Getenv("REDIS_PORT"),
+    Username: os.Getenv("REDIS_USER_OID"), Password: token.Token,
+    TLSConfig: &tls.Config{MinVersion: tls.VersionTLS12},
+})
+```
+
+Refresh the connection before token expiry.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/java.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/java.md
@@ -1,0 +1,17 @@
+# Redis with Java
+
+Packages: `com.azure:azure-identity`, `io.lettuce:lettuce-core`.
+
+Acquire `https://redis.azure.com/.default` with `DefaultAzureCredential`. Configure a
+`RedisURI` with SSL, the UAMI object ID as username, and the token as password:
+
+```java
+AccessToken token = credential.getToken(
+    new TokenRequestContext().addScopes("https://redis.azure.com/.default")).block();
+RedisURI uri = RedisURI.Builder.redis(System.getenv("REDIS_HOSTNAME"), 6380)
+    .withSsl(true)
+    .withAuthentication(System.getenv("REDIS_USER_OID"), token.getToken())
+    .build();
+```
+
+Refresh the connection before token expiry.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/nodejs.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/nodejs.md
@@ -1,0 +1,18 @@
+# Redis with Node.js / TypeScript
+
+Packages: `redis`, `@azure/identity`.
+
+```typescript
+const credential = new DefaultAzureCredential({
+  managedIdentityClientId: process.env.AZURE_CLIENT_ID,
+});
+const token = await credential.getToken("https://redis.azure.com/.default");
+const client = createClient({
+  url: `rediss://${process.env.REDIS_HOSTNAME}:${process.env.REDIS_PORT ?? "6380"}`,
+  username: process.env.REDIS_USER_OID,
+  password: token.token,
+});
+await client.connect();
+```
+
+Reconnect with a fresh token before expiry.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/python.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/redis/source/python.md
@@ -1,0 +1,19 @@
+# Redis with Python
+
+Packages: `redis`, `azure-identity`.
+
+```python
+credential = DefaultAzureCredential(
+    managed_identity_client_id=os.environ["AZURE_CLIENT_ID"]
+)
+token = credential.get_token("https://redis.azure.com/.default")
+client = redis.Redis(
+    host=os.environ["REDIS_HOSTNAME"],
+    port=int(os.getenv("REDIS_PORT", "6380")),
+    ssl=True,
+    username=os.environ["REDIS_USER_OID"],
+    password=token.token,
+)
+```
+
+Refresh credentials before token expiry for long-running workers.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/README.md
@@ -1,0 +1,121 @@
+# Service Bus Recipe — REFERENCE ONLY
+
+Azure Service Bus integration with KEDA scaling for Container Apps.
+
+## When to Use
+
+- Reliable message queuing between services
+- Pub/sub with topics and subscriptions
+- Worker scaling based on queue depth
+- Ordered message processing
+
+## Bicep — Service Bus Module
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param principalId string
+param queueName string = 'tasks'
+
+resource sb 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
+  name: name
+  location: location
+  tags: tags
+  sku: { name: 'Standard', tier: 'Standard' }
+  properties: {
+    disableLocalAuth: true
+  }
+}
+
+resource queue 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' = {
+  parent: sb
+  name: queueName
+  properties: {
+    maxDeliveryCount: 10
+    lockDuration: 'PT1M'
+    deadLetteringOnMessageExpiration: true
+  }
+}
+
+// RBAC — Azure Service Bus Data Owner
+resource rbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(sb.id, principalId, '090c5cfd-751d-490a-894a-3ce6f1109419')
+  scope: sb
+  properties: {
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      '090c5cfd-751d-490a-894a-3ce6f1109419'
+    )
+    principalId: principalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+output namespace string = sb.name
+output fqdn string = '${sb.name}.servicebus.windows.net'
+output queueName string = queue.name
+```
+
+## Environment Variables
+
+```bicep
+env: [
+  { name: 'SERVICEBUS_FQDN', value: sb.outputs.fqdn }
+  { name: 'SERVICEBUS_QUEUE', value: sb.outputs.queueName }
+  { name: 'AZURE_CLIENT_ID', value: uami.outputs.clientId }
+]
+```
+
+## KEDA Scaling Rule
+
+Scale workers based on queue message count:
+
+```bicep
+scale: {
+  minReplicas: 0
+  maxReplicas: 30
+  rules: [
+    {
+      name: 'servicebus-scale'
+      custom: {
+        type: 'azure-servicebus'
+        metadata: {
+          namespace: sb.outputs.namespace
+          queueName: sb.outputs.queueName
+          messageCount: '5'
+        }
+        identity: userAssignedIdentityId
+      }
+    }
+  ]
+}
+```
+
+> 💡 **Tip:** Set `identity` to the UAMI resource ID to authenticate the KEDA scaler via managed identity instead of connection strings.
+
+## RBAC Roles
+
+| Role | GUID | Access |
+|------|------|--------|
+| Azure Service Bus Data Owner | `090c5cfd-751d-490a-894a-3ce6f1109419` | Full access |
+| Azure Service Bus Data Sender | `69a216fc-b8fb-44d8-bc22-1f3c2cd27a39` | Send only |
+| Azure Service Bus Data Receiver | `4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0` | Receive only |
+
+## SDK Connection (Python Example)
+
+```python
+from azure.servicebus import ServiceBusClient
+from azure.identity import DefaultAzureCredential
+import os
+
+credential = DefaultAzureCredential(
+    managed_identity_client_id=os.environ["AZURE_CLIENT_ID"]
+)
+client = ServiceBusClient(
+    fully_qualified_namespace=os.environ["SERVICEBUS_FQDN"],
+    credential=credential,
+)
+```
+
+> ⚠️ **Always set `disableLocalAuth: true`** — use RBAC only, never SAS keys.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/README.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/README.md
@@ -38,14 +38,14 @@ resource queue 'Microsoft.ServiceBus/namespaces/queues@2024-01-01' = {
   }
 }
 
-// RBAC — Azure Service Bus Data Owner
+// RBAC — receiver for queue-processing workers
 resource rbac 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(sb.id, principalId, '090c5cfd-751d-490a-894a-3ce6f1109419')
+  name: guid(sb.id, principalId, '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0')
   scope: sb
   properties: {
     roleDefinitionId: subscriptionResourceId(
       'Microsoft.Authorization/roleDefinitions',
-      '090c5cfd-751d-490a-894a-3ce6f1109419'
+      '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0'
     )
     principalId: principalId
     principalType: 'ServicePrincipal'
@@ -98,7 +98,6 @@ scale: {
 
 | Role | GUID | Access |
 |------|------|--------|
-| Azure Service Bus Data Owner | `090c5cfd-751d-490a-894a-3ce6f1109419` | Full access |
 | Azure Service Bus Data Sender | `69a216fc-b8fb-44d8-bc22-1f3c2cd27a39` | Send only |
 | Azure Service Bus Data Receiver | `4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0` | Receive only |
 
@@ -119,3 +118,12 @@ client = ServiceBusClient(
 ```
 
 > ⚠️ **Always set `disableLocalAuth: true`** — use RBAC only, never SAS keys.
+> Assign Data Sender to publishers and Data Receiver to consumers. Use Data Owner only
+> when one identity must perform both roles and manage entities.
+
+## Language Guides
+
+[C#](source/dotnet.md) | [Python](source/python.md) |
+[Node.js/TypeScript](source/nodejs.md) | [Go](source/go.md) | [Java](source/java.md)
+
+See [eval/summary.md](eval/summary.md) for static coverage.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/eval/summary.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/eval/summary.md
@@ -1,0 +1,13 @@
+# Service Bus Static Coverage
+
+| Language | Guide |
+|---|---|
+| C# | [Authored](../source/dotnet.md) |
+| Python | [Authored](../source/python.md) |
+| Node.js/TypeScript | [Authored](../source/nodejs.md) |
+| Go | [Authored](../source/go.md) |
+| Java | [Authored](../source/java.md) |
+
+Review criteria: managed identity, sender/receiver least privilege, local auth disabled,
+message settlement, error handling, graceful shutdown, and KEDA identity. This is static
+guidance coverage, not an executed deployment result.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/dotnet.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/dotnet.md
@@ -1,0 +1,16 @@
+# Service Bus with C#
+
+Packages: `Azure.Messaging.ServiceBus`, `Azure.Identity`.
+
+```csharp
+var credential = new DefaultAzureCredential(new DefaultAzureCredentialOptions {
+    ManagedIdentityClientId = Environment.GetEnvironmentVariable("AZURE_CLIENT_ID")
+});
+await using var client = new ServiceBusClient(
+    Environment.GetEnvironmentVariable("SERVICEBUS_FQDN"), credential);
+ServiceBusProcessor processor = client.CreateProcessor(
+    Environment.GetEnvironmentVariable("SERVICEBUS_QUEUE"));
+```
+
+Register message and error handlers before `StartProcessingAsync`. Complete a message only
+after processing succeeds.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/go.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/go.md
@@ -1,0 +1,16 @@
+# Service Bus with Go
+
+Packages: `github.com/Azure/azure-sdk-for-go/sdk/azidentity` and
+`github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus`.
+
+```go
+credential, err := azidentity.NewDefaultAzureCredential(nil)
+if err != nil { return err }
+client, err := azservicebus.NewClient(
+    os.Getenv("SERVICEBUS_FQDN"), credential, nil)
+if err != nil { return err }
+receiver, err := client.NewReceiverForQueue(
+    os.Getenv("SERVICEBUS_QUEUE"), nil)
+```
+
+Use a bounded context for receive calls and close the receiver and client during shutdown.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/java.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/java.md
@@ -1,0 +1,18 @@
+# Service Bus with Java
+
+Packages: `com.azure:azure-messaging-servicebus`, `com.azure:azure-identity`.
+
+```java
+TokenCredential credential = new DefaultAzureCredentialBuilder()
+    .managedIdentityClientId(System.getenv("AZURE_CLIENT_ID"))
+    .build();
+ServiceBusProcessorClient processor = new ServiceBusClientBuilder()
+    .fullyQualifiedNamespace(System.getenv("SERVICEBUS_FQDN"))
+    .credential(credential)
+    .processor()
+    .queueName(System.getenv("SERVICEBUS_QUEUE"))
+    .processMessage(context -> handle(context.getMessage().getBody()))
+    .processError(context -> logger.error("Service Bus", context.getException()))
+    .buildProcessorClient();
+processor.start();
+```

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/nodejs.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/nodejs.md
@@ -1,0 +1,17 @@
+# Service Bus with Node.js / TypeScript
+
+Packages: `@azure/service-bus`, `@azure/identity`.
+
+```typescript
+const credential = new DefaultAzureCredential({
+  managedIdentityClientId: process.env.AZURE_CLIENT_ID,
+});
+const client = new ServiceBusClient(process.env.SERVICEBUS_FQDN!, credential);
+const receiver = client.createReceiver(process.env.SERVICEBUS_QUEUE!);
+receiver.subscribe({
+  processMessage: async (message) => handle(message.body),
+  processError: async (args) => console.error(args.error),
+});
+```
+
+Close the receiver and client on process shutdown.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/python.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/recipes/servicebus/source/python.md
@@ -1,0 +1,20 @@
+# Service Bus with Python
+
+Packages: `azure-servicebus`, `azure-identity`.
+
+```python
+import os
+from azure.identity import DefaultAzureCredential
+from azure.servicebus import ServiceBusClient
+
+credential = DefaultAzureCredential(
+    managed_identity_client_id=os.environ["AZURE_CLIENT_ID"]
+)
+client = ServiceBusClient(
+    fully_qualified_namespace=os.environ["SERVICEBUS_FQDN"],
+    credential=credential,
+)
+receiver = client.get_queue_receiver(queue_name=os.environ["SERVICEBUS_QUEUE"])
+```
+
+Use context managers so clients and receivers close cleanly.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/selection.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/selection.md
@@ -1,0 +1,97 @@
+# Template Selection Decision Tree — REFERENCE ONLY
+
+**CRITICAL**: Run Part A once to choose exactly one base template, then always run Part B to layer every matching recipe.
+
+**Architecture**: All deployments start from an appropriate base template for the workload (e.g., [web-app.md](web-app.md), [api.md](api.md), [worker.md](worker.md)).
+Integrations are applied as [composable recipes](recipes/README.md) on top of the base.
+See [composition.md](recipes/composition.md) for the merge algorithm.
+
+Container Apps hosts **any** containerized app — any language, any framework, any SDK.
+Event-driven processing with triggers/bindings uses [Functions on Container Apps](functions-on-aca.md).
+
+### Part A — Pick the Base Template
+
+```
+1. Is this event-driven with Functions triggers/bindings?
+   Indicators: BlobTrigger, ServiceBusTrigger, EventHubTrigger,
+               TimerTrigger, CosmosDBTrigger, DurableOrchestration,
+               host.json, @app.service_bus_queue, @app.schedule
+   └─► YES → Functions on Container Apps (see functions-on-aca.md)
+
+2. Is this a Container Apps Job (not a long-running service)?
+   Indicators: scheduled task, cron job, one-shot batch,
+               event-triggered processing, manual job
+   └─► YES → Job template (see job.md)
+
+3. Is this a microservices architecture?
+   Indicators: multiple services, service discovery, Dapr,
+               docker-compose with 3+ services, mono-repo with services/
+   └─► YES → Microservice template (see microservice.md)
+
+4. Is this a background worker / queue processor?
+   Indicators: queue consumer, long-running task, KEDA scaling on queue depth,
+               no HTTP ingress needed, worker process
+   └─► YES → Worker template (see worker.md)
+
+5. Is this a REST or gRPC API?
+   Indicators: REST API, OpenAPI/Swagger, gRPC, API gateway,
+               /api/ routes, Express/FastAPI/ASP.NET controllers
+   └─► YES → API template (see api.md)
+
+6. DEFAULT → Web app template (see web-app.md)
+```
+
+### Part B — Layer Integration Recipes
+
+After selecting the base template, always check whether the app needs integration recipes.
+Recipes are additive — apply every matching recipe independently on top of the base.
+See [composition.md](recipes/composition.md) for the merge algorithm.
+
+```
+Does it use Dapr?
+  Indicators: dapr.io/enabled annotation, Dapr SDK imports,
+              state store, pub/sub, service invocation, secrets
+  └─► YES → Add dapr recipe (recipes/dapr/README.md)
+
+Does it need a database?
+  Indicators: Cosmos DB, PostgreSQL, Redis, SQL
+  └─► YES → Add database recipe (recipes/cosmos/, recipes/postgres/, or recipes/redis/)
+
+Does it use messaging?
+  Indicators: Service Bus, Event Hubs, Storage Queues
+  └─► YES → Add messaging recipe (recipes/servicebus/README.md)
+
+Does it build/push container images?
+  └─► YES → Add ACR recipe (recipes/acr/README.md)
+```
+
+## Recipe Index
+
+| Integration | Recipe | Description |
+|-------------|--------|-------------|
+| Dapr | [recipes/dapr/](recipes/dapr/README.md) | Service invocation, state, pub/sub, secrets |
+| Cosmos DB | [recipes/cosmos/](recipes/cosmos/README.md) | NoSQL database |
+| Service Bus | [recipes/servicebus/](recipes/servicebus/README.md) | Messaging with KEDA scaling |
+| Redis | [recipes/redis/](recipes/redis/README.md) | Cache / state store |
+| ACR | [recipes/acr/](recipes/acr/README.md) | Container registry build + push |
+| PostgreSQL | [recipes/postgres/](recipes/postgres/README.md) | PostgreSQL Flexible Server |
+
+## Base Templates
+
+| Template | Use Case | File |
+|----------|----------|------|
+| Web app | General-purpose serverless web app | [web-app.md](web-app.md) |
+| API | REST / gRPC API services | [api.md](api.md) |
+| Microservice | Multi-service architecture | [microservice.md](microservice.md) |
+| Worker | Background processing | [worker.md](worker.md) |
+| Job | Scheduled / event / manual jobs | [job.md](job.md) |
+| Functions on ACA | Event-driven triggers/bindings | [functions-on-aca.md](functions-on-aca.md) |
+
+## Critical Rules
+
+1. **Container Apps is stack-agnostic** — any language, any framework, any container image
+2. **Use UAMI (User Assigned Managed Identity)** for all service connections — never connection strings
+3. **Always use `--no-prompt`** with azd commands
+4. **Never synthesize Bicep/Terraform from scratch** — use AZD templates or proven modules
+5. **Use KEDA scaling rules** for event-driven workloads (queue depth, HTTP concurrency, cron)
+6. **Disable local auth** on all backing services (Cosmos, Service Bus, etc.)

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/selection.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/selection.md
@@ -4,7 +4,7 @@
 
 **Architecture**: All deployments start from an appropriate base template for the workload (e.g., [web-app.md](web-app.md), [api.md](api.md), [worker.md](worker.md)).
 Integrations are applied as [composable recipes](recipes/README.md) on top of the base.
-See [composition.md](recipes/composition.md) for the merge algorithm.
+See [composition.md](composition.md) for the merge algorithm.
 
 Container Apps hosts **any** containerized app — any language, any framework, any SDK.
 Event-driven processing with triggers/bindings uses [Functions on Container Apps](functions-on-aca.md).
@@ -45,7 +45,7 @@ Event-driven processing with triggers/bindings uses [Functions on Container Apps
 
 After selecting the base template, always check whether the app needs integration recipes.
 Recipes are additive — apply every matching recipe independently on top of the base.
-See [composition.md](recipes/composition.md) for the merge algorithm.
+See [composition.md](composition.md) for the merge algorithm.
 
 ```
 Does it use Dapr?
@@ -59,7 +59,8 @@ Does it need a database?
 
 Does it use messaging?
   Indicators: Service Bus, Event Hubs, Storage Queues
-  └─► YES → Add messaging recipe (recipes/servicebus/README.md)
+  └─► Service Bus → Add recipes/servicebus/README.md
+  └─► Event Hubs → Add recipes/eventhubs/README.md
 
 Does it build/push container images?
   └─► YES → Add ACR recipe (recipes/acr/README.md)
@@ -72,6 +73,7 @@ Does it build/push container images?
 | Dapr | [recipes/dapr/](recipes/dapr/README.md) | Service invocation, state, pub/sub, secrets |
 | Cosmos DB | [recipes/cosmos/](recipes/cosmos/README.md) | NoSQL database |
 | Service Bus | [recipes/servicebus/](recipes/servicebus/README.md) | Messaging with KEDA scaling |
+| Event Hubs | [recipes/eventhubs/](recipes/eventhubs/README.md) | Event streaming with KEDA scaling |
 | Redis | [recipes/redis/](recipes/redis/README.md) | Cache / state store |
 | ACR | [recipes/acr/](recipes/acr/README.md) | Container registry build + push |
 | PostgreSQL | [recipes/postgres/](recipes/postgres/README.md) | PostgreSQL Flexible Server |
@@ -87,11 +89,13 @@ Does it build/push container images?
 | Job | Scheduled / event / manual jobs | [job.md](job.md) |
 | Functions on ACA | Event-driven triggers/bindings | [functions-on-aca.md](functions-on-aca.md) |
 
+Choose a runtime image from [multi-stage Dockerfiles](dockerfiles/README.md).
+
 ## Critical Rules
 
 1. **Container Apps is stack-agnostic** — any language, any framework, any container image
 2. **Use UAMI (User Assigned Managed Identity)** for all service connections — never connection strings
 3. **Always use `--no-prompt`** with azd commands
-4. **Never synthesize Bicep/Terraform from scratch** — use AZD templates or proven modules
+4. **Generate from these verified guides** — do not treat Markdown filenames as AZD template IDs
 5. **Use KEDA scaling rules** for event-driven workloads (queue depth, HTTP concurrency, cron)
 6. **Disable local auth** on all backing services (Cosmos, Service Bus, etc.)

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/web-app.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/web-app.md
@@ -1,0 +1,147 @@
+# Web App Template — REFERENCE ONLY
+
+High-scale serverless web app on Azure Container Apps.
+Supports any language/framework: Node.js, Python, .NET, Java, Go, Rust, etc.
+
+## When to Use
+
+- General-purpose web application with HTTP ingress
+- Frontend + backend in a single container
+- Any framework: Express, FastAPI, ASP.NET, Spring Boot, Gin, etc.
+
+## Project Structure
+
+```
+project-root/
+├── azure.yaml
+├── Dockerfile
+├── src/
+│   └── (application code)
+└── infra/
+    ├── main.bicep          # or *.tf
+    ├── main.parameters.json
+    └── app/
+        └── container-app.bicep
+```
+
+## azure.yaml
+
+```yaml
+name: my-web-app
+metadata:
+  template: container-apps-web-app
+services:
+  web:
+    host: containerapp
+    project: .
+    language: <js|ts|python|csharp|java|go>
+```
+
+## Bicep — Container App Module
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param containerRegistryName string
+param imageName string
+param envId string
+param userAssignedIdentityId string
+
+resource app 'Microsoft.App/containerApps@2024-03-01' = {
+  name: name
+  location: location
+  tags: union(tags, { 'azd-service-name': 'web' })
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${userAssignedIdentityId}': {} }
+  }
+  properties: {
+    managedEnvironmentId: envId
+    configuration: {
+      ingress: {
+        external: true
+        targetPort: 3000
+        transport: 'auto'
+      }
+      registries: [
+        {
+          server: '${containerRegistryName}.azurecr.io'
+          identity: userAssignedIdentityId
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'main'
+          image: imageName
+          resources: { cpu: json('0.5'), memory: '1Gi' }
+        }
+      ]
+      scale: {
+        minReplicas: 1
+        maxReplicas: 10
+        rules: [
+          {
+            name: 'http-scale'
+            http: { metadata: { concurrentRequests: '100' } }
+          }
+        ]
+      }
+    }
+  }
+}
+
+output fqdn string = app.properties.configuration.ingress.fqdn
+output name string = app.name
+output principalId string = app.identity.userAssignedIdentities[userAssignedIdentityId].principalId
+```
+
+## Deployment
+
+```bash
+ENV_NAME="$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | tr ' _' '-')-dev"
+azd init -e "$ENV_NAME" --no-prompt
+azd env set AZURE_LOCATION eastus2
+azd up --no-prompt
+```
+
+## Scaling
+
+| Rule | Trigger | Default |
+|------|---------|---------|
+| HTTP | Concurrent requests | 100 per instance |
+| Min replicas | Baseline instance count | 1 |
+| Max replicas | Burst limit | 10 |
+
+## Language-Specific `targetPort`
+
+| Framework | Default Port |
+|-----------|-------------|
+| Node.js (Express) | 3000 |
+| Python (FastAPI/Gunicorn) | 8000 |
+| .NET (Kestrel) | 8080 |
+| Java (Spring Boot) | 8080 |
+| Go (net/http) | 8080 |
+
+> ⚠️ **Set `targetPort` to match your app's listen port.** Mismatched ports cause 502 errors.
+
+## Health Probes
+
+Always configure liveness and readiness probes. See [health-probes.md](../health-probes.md).
+
+```bicep
+probes: [
+  {
+    type: 'liveness'
+    httpGet: { path: '/healthz', port: 3000 }
+    periodSeconds: 10
+  }
+  {
+    type: 'readiness'
+    httpGet: { path: '/ready', port: 3000 }
+    periodSeconds: 5
+  }
+]
+```

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/worker.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/worker.md
@@ -1,0 +1,189 @@
+# Worker Template — REFERENCE ONLY
+
+Background processing and long-running tasks on Azure Container Apps.
+
+## When to Use
+
+- Queue consumer (Service Bus, Storage Queue, Event Hubs)
+- Long-running background processing
+- No HTTP ingress required
+- Event-driven scaling with KEDA
+
+## Project Structure
+
+```
+project-root/
+├── azure.yaml
+├── Dockerfile
+├── src/
+│   └── (worker code)
+└── infra/
+    ├── main.bicep
+    └── app/
+        └── worker.bicep
+```
+
+## azure.yaml
+
+```yaml
+name: my-worker
+metadata:
+  template: container-apps-worker
+services:
+  worker:
+    host: containerapp
+    project: .
+    language: <js|ts|python|csharp|java|go>
+```
+
+## Bicep — Worker Container App
+
+```bicep
+param name string
+param location string = resourceGroup().location
+param tags object = {}
+param envId string
+param containerRegistryName string
+param imageName string
+param userAssignedIdentityId string
+param uamiClientId string
+// Service Bus params — provided by servicebus recipe, omit if not using SB
+param serviceBusNamespace string
+param queueName string
+
+resource worker 'Microsoft.App/containerApps@2024-03-01' = {
+  name: name
+  location: location
+  tags: union(tags, { 'azd-service-name': 'worker' })
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: { '${userAssignedIdentityId}': {} }
+  }
+  properties: {
+    managedEnvironmentId: envId
+    configuration: {
+      // No ingress — worker has no HTTP endpoint
+      registries: [
+        {
+          server: '${containerRegistryName}.azurecr.io'
+          identity: userAssignedIdentityId
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'worker'
+          image: imageName
+          resources: { cpu: json('0.5'), memory: '1Gi' }
+          env: [
+            {
+              name: 'SERVICEBUS_NAMESPACE'
+              value: '${serviceBusNamespace}.servicebus.windows.net'
+            }
+            { name: 'QUEUE_NAME', value: queueName }
+            {
+              name: 'AZURE_CLIENT_ID'
+              value: uamiClientId
+            }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 30
+        rules: [
+          {
+            name: 'queue-scale'
+            custom: {
+              type: 'azure-servicebus'
+              metadata: {
+                namespace: serviceBusNamespace
+                queueName: queueName
+                messageCount: '5'
+              }
+              identity: userAssignedIdentityId
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+
+output name string = worker.name
+```
+
+## Scaling Patterns
+
+### Service Bus Queue Scaling (KEDA)
+
+```bicep
+rules: [
+  {
+    name: 'queue-scale'
+    custom: {
+      type: 'azure-servicebus'
+      metadata: {
+        namespace: '<namespace>'
+        queueName: '<queue>'
+        messageCount: '5'  // scale up when > 5 messages
+      }
+      identity: userAssignedIdentityId
+    }
+  }
+]
+```
+
+### Event Hubs Scaling (KEDA)
+
+```bicep
+rules: [
+  {
+    name: 'eventhub-scale'
+    custom: {
+      type: 'azure-eventhub'
+      metadata: {
+        eventHubNamespace: '<namespace>'
+        eventHubName: '<eventhub>'
+        consumerGroup: '$Default'
+        storageAccountName: '<checkpoint-storage-account>'
+        blobContainer: '<checkpoint-container>'
+        unprocessedEventThreshold: '64'
+      }
+      identity: userAssignedIdentityId
+    }
+  }
+]
+```
+
+### Storage Queue Scaling (KEDA)
+
+```bicep
+rules: [
+  {
+    name: 'storage-queue-scale'
+    custom: {
+      type: 'azure-queue'
+      metadata: {
+        accountName: '<storage-account>'
+        queueName: '<queue>'
+        queueLength: '5'
+      }
+      identity: userAssignedIdentityId
+    }
+  }
+]
+```
+
+## Key Differences from Web App
+
+| Aspect | Web App | Worker |
+|--------|---------|--------|
+| Ingress | External HTTP | None |
+| Scale trigger | HTTP concurrency | Queue depth / events |
+| Min replicas | 0–1 | 0 (scale to zero) |
+| Health probes | HTTP liveness/readiness | TCP or none |
+
+> ⚠️ **Workers with no ingress cannot use HTTP health probes.**
+> Use TCP probes or omit probes and rely on container restart policy.

--- a/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/worker.md
+++ b/plugins/azure-skills/skills/azure-prepare/references/services/container-apps/templates/worker.md
@@ -78,10 +78,10 @@ resource worker 'Microsoft.App/containerApps@2024-03-01' = {
           resources: { cpu: json('0.5'), memory: '1Gi' }
           env: [
             {
-              name: 'SERVICEBUS_NAMESPACE'
+              name: 'SERVICEBUS_FQDN'
               value: '${serviceBusNamespace}.servicebus.windows.net'
             }
-            { name: 'QUEUE_NAME', value: queueName }
+            { name: 'SERVICEBUS_QUEUE', value: queueName }
             {
               name: 'AZURE_CLIENT_ID'
               value: uamiClientId
@@ -112,6 +112,7 @@ resource worker 'Microsoft.App/containerApps@2024-03-01' = {
 }
 
 output name string = worker.name
+output principalId string = worker.identity.userAssignedIdentities[userAssignedIdentityId].principalId
 ```
 
 ## Scaling Patterns


### PR DESCRIPTION
## Summary
- add Container Apps workload selection and Bicep composition guidance for web apps, APIs, microservices, workers, jobs, and Functions
- add Dapr, Cosmos DB, Service Bus, Event Hubs, Redis, ACR, and PostgreSQL recipes with five language guides each
- add five multi-stage Dockerfile guides, static recipe coverage summaries, managed identity defaults, and least-privilege RBAC patterns

## Validation
- `npm run build`
- `cd scripts && npm run references`
- `cd scripts && npm run frontmatter`
- `cd tests && npm run lint`
- `cd tests && npm run typecheck`
- `cd tests && npm test`
- representative ACR, Event Hubs, Functions, and PostgreSQL Bicep compilation
- changed-file token budgets pass; 129 unrelated repository-wide overages remain

Closes #1610