### PR TITLE
feat: add AKS operational skills sibling plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,6 +82,7 @@
 /plugins/azure-skills/skills/python-appservice-deploy/ @glaming1 @tmeschter @RickWinter
 /plugins/azure-skills/skills/azure-app-onboard/ @vaibbavisk20 @kunalsuri-microsoft @RickWinter
 /plugins/azure-skills/skills/azure-app-onboard-prereq/ @vaibbavisk20 @kunalsuri-microsoft @RickWinter
+/plugins/aks-skills/ @microsoft/github-copilot-for-azure-writers @nikhilkaul1234 @nthevenin
 
 # Plugin skills tests owners (multi-plugin)
 /tests/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter
@@ -113,3 +114,4 @@
 /evals/azure-skills/entra-app-registration/ @JasonYeMSFT @RickWinter
 /evals/azure-skills/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter
 /evals/azure-skills/python-appservice-deploy/ @glaming1 @tmeschter @RickWinter
+/evals/aks-skills/ @microsoft/github-copilot-for-azure-writers @nikhilkaul1234 @nthevenin

--- a/evals/aks-skills/aks-gpu-inference/eval.yaml
+++ b/evals/aks-skills/aks-gpu-inference/eval.yaml
@@ -1,0 +1,246 @@
+name: aks-gpu-inference-day2-eval
+description: |
+  Routing and evidence-contract evaluation for AKS GPU and KAITO Day-2
+  diagnosis against neighboring setup, troubleshooting, quota, and cost skills.
+
+tags:
+  type: integration
+  skill: aks-gpu-inference
+
+defaults:
+  runs: 1
+  timeout: "5m"
+  executor: integration-test-agent-runner
+  model: claude-sonnet-4.6
+  judge_model: claude-sonnet-4.6
+
+scoring:
+  threshold: 1
+
+stimuli:
+  - name: "GPU Pending: profile-aware four-wall diagnosis"
+    prompt: |
+      Diagnose without running commands or changing resources. Two existing AKS
+      GPU pools show pods Pending with "Insufficient nvidia.com/gpu":
+
+      - pool managed: gpuProfile driver=Install, managementMode=Managed;
+        enableAutoScaling=true; node allocatable has no nvidia.com/gpu.
+      - pool driveronly: gpuProfile driver=Install,
+        managementMode=Unmanaged; node allocatable has no nvidia.com/gpu and no
+        NVIDIA device-plugin pod.
+
+      For both pools, the pod requests nvidia.com/gpu: 1 but its tolerations,
+      selected GPU-family regional quota, failed allocation operation, and live
+      SKU restrictions were not supplied. Give the read-only evidence plan,
+      distinguish the profiles, and state what remains uncertain.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      requiredSkills:
+        - aks-gpu-inference
+        - aks-troubleshooting
+        - azure-diagnostics
+        - azure-quotas
+    rubric:
+      - "The response invokes the GPU Day-2 path; treats regional and exact GPU-family quota, capacity and SKU eligibility, pod taints/tolerations plus nvidia.com/gpu request, and the observed gpuProfile as four distinct evidence walls; explains that the Managed+Install pool should have an AKS-managed device plugin while the Unmanaged+Install pool has only an AKS-installed driver and needs its customer-managed device plugin; identifies the missing device plugin as supported evidence only for the driver-only pool and does not assert a final cause for the managed pool without component or node-health evidence; flags enableAutoScaling=true as unsupported for managed GPU preview and never recommends cluster-autoscaler scale-to-zero there; proposes only target-bound reads, marks missing quota/capacity/scheduling evidence uncertain with an owner handoff, claims no checks ran, and requires explicit authorization before repair, scaling, cordon/drain, pool creation/deletion, add-on enablement, or monitoring mutation."
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-gpu-inference]
+          disallowed: [aks-troubleshooting, azure-diagnostics, azure-quotas]
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "KAITO not ready: documented evidence and cleanup warning"
+    prompt: |
+      An existing KAITO Workspace has been observed for 27 minutes and is still
+      not ready. Its status reports ResourceReady=False and
+      WorkspaceSucceeded=False. The AKS region and Workspace instance type are
+      known, but GPU-family quota usage and regional SKU restrictions were not
+      collected. Diagnose without running commands, deleting anything, enabling
+      the add-on, or changing the Workspace. Include the cleanup implications if
+      Workspace deletion is considered later.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      requiredSkills:
+        - aks-gpu-inference
+        - airunway-aks-setup
+        - azure-quotas
+    rubric:
+      - "The response recognizes that 27 minutes exceeds the Microsoft Learn statement that machine readiness can take up to 10 minutes and Workspace readiness up to 20 minutes depending on model size; uses only the supplied Workspace readiness/status evidence and proposes read-only exact GPU-family quota and region/instance-type availability or restriction checks; does not invent NodeClaim names, controller logs, or undocumented condition chains; marks quota versus regional availability unconfirmed until evidence is collected and gives a cluster/quota-owner or Azure Support handoff; warns that deleting a Workspace does not delete its GPU node pool and that the pool requires separate manual cleanup; claims no check ran and requires separate explicit authorization before Workspace or pool deletion, scaling, add-on enablement, or monitoring mutation."
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-gpu-inference]
+          disallowed: [airunway-aks-setup, azure-quotas]
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Model-load OOM: managed DCGM VRAM evidence"
+    prompt: |
+      Diagnose without running commands or changing monitoring. An existing
+      model server on an AKS pool with gpuProfile driver=Install and
+      managementMode=Managed terminated during weight loading. Kubernetes shows
+      OOMKilled at 14:03Z. No node-memory-pressure condition exists, and no DCGM
+      samples were supplied. State the evidence needed to decide whether this
+      was GPU VRAM exhaustion.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      case_id: model-load-oom
+      requiredSkills:
+        - aks-gpu-inference
+        - aks-troubleshooting
+        - azure-diagnostics
+    rubric:
+      - "The response does not treat OOMKilled or absent Kubernetes node memory pressure as proof of VRAM exhaustion; identifies managed DCGM exporter port 19400 for the observed Managed+Install profile; asks for target-bound DCGM_FI_DEV_FB_USED and DCGM_FI_DEV_FB_FREE samples for the affected GPU and incident window correlated with pod/container termination and model-load logs; explains that rising FB_USED and exhausted FB_FREE would support VRAM pressure; marks the conclusion unconfirmed if historical telemetry is absent; avoids generic CPU-memory limit advice and model/SKU sizing tables; claims no reads ran and requires explicit authorization before monitoring mutation, scaling, restart, cordon/drain, or pool changes."
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-gpu-inference]
+          disallowed: [aks-troubleshooting, azure-diagnostics]
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "GPU scaling: KEDA workload versus node pool"
+    prompt: |
+      An existing AKS GPU Deployment is controlled by a KEDA ScaledObject using
+      DCGM_FI_DEV_GPU_UTIL. The HPA says ScalingActive=False because its
+      s0-prometheus external metric is unavailable. A separate GPU pod is
+      Pending because no GPU node is schedulable. The pool's gpuProfile and
+      enableAutoScaling values were not supplied. Diagnose both loops without
+      enabling monitoring/KEDA, scaling anything, or changing resources.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      requiredSkills:
+        - aks-gpu-inference
+        - aks-troubleshooting
+        - azure-diagnostics
+    rubric:
+      - "The response separates KEDA/HPA workload-replica scaling from AKS GPU node-pool scaling; uses the unavailable s0-prometheus metric and HPA ScalingActive condition only for the workload loop; proposes target-bound reads of the ScaledObject query, HPA conditions, external metric, and intended workload; requires observed gpuProfile and enableAutoScaling before discussing node capacity; states that managed GPU preview pools do not support cluster autoscaler and never recommends cluster-autoscaler scale-to-zero without first proving a non-managed profile; marks both loops unconfirmed beyond the supplied evidence, claims no checks ran, and requires explicit authorization before enabling KEDA/monitoring/autoscaling or scaling/changing resources."
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-gpu-inference]
+          disallowed: [aks-troubleshooting, azure-diagnostics]
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Route out: initial GPU and KAITO setup"
+    prompt: |
+      Create my first AKS GPU node pool, enable the AI toolchain operator, choose
+      a KAITO model and provider, and deploy a new Workspace for inference.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence-negative
+      requiredSkills:
+        - aks-gpu-inference
+        - airunway-aks-setup
+    graders:
+      - type: skill-invocation
+        config:
+          required: [airunway-aks-setup]
+          disallowed: [aks-gpu-inference]
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Route out: non-GPU AKS incident"
+    prompt: |
+      A CPU-only pod on my existing AKS system pool is Pending after a node
+      became NotReady. There are no GPU resources or inference workloads.
+      Investigate without changing the cluster.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence-negative
+      requiredSkills:
+        - aks-gpu-inference
+        - aks-troubleshooting
+        - azure-diagnostics
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-troubleshooting]
+          disallowed: [aks-gpu-inference, azure-diagnostics]
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Route out: standalone VM quota"
+    prompt: |
+      A standalone Azure virtual machine, unrelated to AKS or Kubernetes, cannot
+      be created because the selected VM family has insufficient regional vCPU
+      quota. Help me inspect the quota.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence-negative
+      requiredSkills:
+        - aks-gpu-inference
+        - azure-quotas
+        - azure-compute
+    graders:
+      - type: skill-invocation
+        config:
+          required: [azure-quotas]
+          disallowed: [aks-gpu-inference]
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Route out: generic Azure cost"
+    prompt: |
+      Analyze my overall Azure bill, find the biggest subscription-level cost
+      changes, and recommend general savings opportunities. This is not an AKS
+      GPU incident.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence-negative
+      requiredSkills:
+        - aks-gpu-inference
+        - azure-cost
+    graders:
+      - type: skill-invocation
+        config:
+          required: [azure-cost]
+          disallowed: [aks-gpu-inference]
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"

--- a/evals/aks-skills/aks-known-issues/eval.yaml
+++ b/evals/aks-skills/aks-known-issues/eval.yaml
@@ -1,0 +1,230 @@
+name: aks-known-issues-coexistence-eval
+description: |
+  Deterministic routing and customer-decision evaluation for named AKS
+  signatures competing with AKS troubleshooting and broad Azure diagnostics.
+
+tags:
+  type: integration
+  skill: aks-known-issues
+
+defaults:
+  runs: 1
+  timeout: "5m"
+  executor: integration-test-agent-runner
+  model: claude-sonnet-4.6
+  judge_model: claude-sonnet-4.6
+
+scoring:
+  threshold: 1
+
+stimuli:
+  - name: "Known issue: ephemeral OS disk signature"
+    prompt: |
+      An AKS node-pool create operation failed with code
+      VMCannotFitEphemeralOSDisk. Diagnose it and recommend the safe next step,
+      but do not run checks or change resources.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      requiredSkills:
+        - aks-known-issues
+        - aks-troubleshooting
+        - azure-diagnostics
+    rubric:
+      - "The response attributes the exact VMCannotFitEphemeralOSDisk signature to an ephemeral OS disk that does not fit the selected VM SKU cache or temporary storage; cites the Microsoft Learn ephemeral OS disk guidance; proposes a read-only comparison of requested disk size and SKU storage before recommending a fitting SKU, smaller disk, or managed disk and notes that changing disk type or size requires a new node pool; does not claim any check ran; and requires explicit approval before creating or changing resources."
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-known-issues]
+          disallowed: [aks-troubleshooting, azure-diagnostics]
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Known issue: nested CSE exit 50"
+    prompt: |
+      An AKS scale operation returned VMExtensionProvisioningError from vmssCSE:
+      CSE failed with VMExtensionError_OutboundConnFail; node provisioning could
+      not obtain packages; exit status 50. Diagnose and advise without running
+      checks or making changes.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      requiredSkills:
+        - aks-known-issues
+        - aks-troubleshooting
+        - azure-diagnostics
+    rubric:
+      - "The response uses the AKS vmssCSE VMExtensionError_OutboundConnFail and exit-50 context to identify blocked outbound connectivity needed to obtain node-provisioning packages; cites the Microsoft Learn OutboundConnFail article; proposes read-only connectivity and firewall, proxy, NSG, UDR, DNS, and required-egress inspection before a documented network correction; does not claim those checks ran; and requires explicit approval before changing network or cluster resources."
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-known-issues]
+          disallowed: [aks-troubleshooting, azure-diagnostics]
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Known issue: message-qualified AllocationFailed"
+    prompt: |
+      An AKS node-pool scale operation returned code AllocationFailed with the
+      full nested message: "The VM allocation failed due to an internal error.
+      Please retry later or try deploying to a different location." Diagnose it,
+      including what to verify before acting, but do not run checks or retry.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      requiredSkills:
+        - aks-known-issues
+        - aks-troubleshooting
+        - azure-diagnostics
+    rubric:
+      - "The response uses the full nested AllocationFailed message to identify the documented internal allocation error and does not mislabel it as quota or capacity exhaustion; cites the Microsoft Learn AKS allocation-error article; proposes read-only confirmation of the failed operation and exact message before recommending a later retry or another location; does not claim verification ran; and requires explicit approval before retrying or redeploying."
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-known-issues]
+          disallowed: [aks-troubleshooting, azure-diagnostics]
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Known issue: corrected node-pool version skew"
+    prompt: |
+      An AKS node-pool upgrade failed with NodePoolMcVersionIncompatible.
+      The control plane is 1.33 and the node pool is 1.30. Explain the rule and
+      safe fix, including what to verify first, but do not run checks or upgrade.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      requiredSkills:
+        - aks-known-issues
+        - aks-troubleshooting
+        - azure-diagnostics
+    rubric:
+      - "The response states that an AKS node pool must remain within two minor versions of the control plane and cannot exceed the control-plane version, so 1.30 is incompatible with 1.33; cites the current Microsoft Learn NodePoolMcVersionIncompatible article; proposes read-only retrieval of control-plane, node-pool, and available upgrade versions before selecting a compliant node-pool version; does not claim those reads ran; and requires explicit approval before upgrading."
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-known-issues]
+          disallowed: [aks-troubleshooting, azure-diagnostics]
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Route out: bare wrapper and context-free exit"
+    prompt: |
+      A node in my AKS cluster reports the outer wrapper
+      VMExtensionProvisioningError. A separate log line says exit code 50, but
+      I do not have vmssCSE/CSE output or a nested error signature. Investigate
+      this live AKS incident and identify the missing evidence.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence-negative
+      requiredSkills:
+        - aks-known-issues
+        - aks-troubleshooting
+        - azure-diagnostics
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-troubleshooting]
+          disallowed: [aks-known-issues, azure-diagnostics]
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Route out: bare AllocationFailed"
+    prompt: |
+      My AKS node-pool scale operation returned code AllocationFailed, but the
+      nested Azure message is missing. Help me investigate the failure.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence-negative
+      requiredSkills:
+        - aks-known-issues
+        - aks-troubleshooting
+        - azure-diagnostics
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-troubleshooting]
+          disallowed: [aks-known-issues, azure-diagnostics]
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Route out: generic AKS capacity symptom"
+    prompt: |
+      My AKS node-pool upgrade is stuck because it cannot add surge capacity.
+      There is no stable error code or full allocation message. Investigate it
+      without changing the cluster.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence-negative
+      requiredSkills:
+        - aks-known-issues
+        - aks-troubleshooting
+        - azure-diagnostics
+    graders:
+      - type: skill-invocation
+        config:
+          required: [aks-troubleshooting]
+          disallowed: [aks-known-issues, azure-diagnostics]
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Route out: non-AKS LinkedAuthorizationFailed"
+    prompt: |
+      A standalone Azure virtual network deployment, unrelated to AKS or
+      Kubernetes, failed with LinkedAuthorizationFailed on a linked DDoS plan.
+      Debug this Azure production deployment failure, analyze the relevant
+      Activity Log evidence, and identify the root cause.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence-negative
+      requiredSkills:
+        - aks-known-issues
+        - aks-troubleshooting
+        - azure-diagnostics
+    graders:
+      - type: skill-invocation
+        config:
+          required: [azure-diagnostics]
+          disallowed: [aks-known-issues, aks-troubleshooting]
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"

--- a/evals/aks-skills/aks-network-capture/eval.yaml
+++ b/evals/aks-skills/aks-network-capture/eval.yaml
@@ -1,0 +1,49 @@
+name: aks-network-capture-agentic-eval
+description: |
+  Routing evaluation for aks-network-capture. Explicit packet-capture intent
+  invokes this skill; generic AKS connectivity does not.
+
+tags:
+  type: integration
+  skill: aks-network-capture
+
+defaults:
+  runs: 1
+  timeout: "5m"
+  executor: integration-test-agent-runner
+  model: claude-sonnet-4.6
+
+scoring: {}
+
+stimuli:
+  - name: "Routing: explicit node packet capture"
+    prompt: "Capture packets on the AKS node hosting my pod and give me a pcap so I can prove where port 443 traffic is being dropped."
+    tags:
+      type: integration
+      tier: smoke
+      cost: llm
+      area: routing
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - aks-network-capture
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Routing: generic egress failure"
+    prompt: "Pods in my AKS cluster cannot reach external services and egress seems blocked. Help me investigate."
+    tags:
+      type: integration
+      tier: smoke
+      cost: llm
+      area: negative-routing
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed:
+            - aks-network-capture
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"

--- a/evals/aks-skills/aks-troubleshooting/eval.yaml
+++ b/evals/aks-skills/aks-troubleshooting/eval.yaml
@@ -1,0 +1,273 @@
+name: aks-troubleshooting-public-canary-eval
+description: |
+  Routing and customer-decision evaluation for the two accepted public AKS
+  troubleshooting canaries in broad-only, focused-only, and coexistence modes.
+
+tags:
+  type: integration
+  skill: aks-troubleshooting
+
+defaults:
+  runs: 1
+  timeout: "5m"
+  executor: integration-test-agent-runner
+  model: claude-sonnet-4.6
+  judge_model: claude-sonnet-4.6
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  - name: "Quota canary: broad-only routing"
+    prompt: |
+      An existing non-GPU AKS user node pool 'np2' in cluster 'prod' failed to scale.
+      Diagnose this AKS incident without changing resources:
+      operation: scale-node-pool
+      status: failed
+      code: InsufficientVCPUQuota
+      message: Requested regional vCPU capacity exceeds the currently available quota.
+
+      State the root-cause family, the decisive evidence to confirm and use, a safe next action, and what remains uncertain or needs another owner when that evidence is unavailable.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: broad-only
+      case_id: public-canary-quota-exceeded
+      source_url: "https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/quota-exceeded-during-creation-upgrade"
+      requiredSkills:
+        - azure-diagnostics
+        - azure-quotas
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-diagnostics
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Quota canary: focused-only decision"
+    prompt: |
+      An existing non-GPU AKS user node pool 'np2' in cluster 'prod' failed to scale.
+      Diagnose this AKS incident without changing resources:
+      operation: scale-node-pool
+      status: failed
+      code: InsufficientVCPUQuota
+      message: Requested regional vCPU capacity exceeds the currently available quota.
+
+      State the root-cause family, the decisive evidence to confirm and use, a safe next action, and what remains uncertain or needs another owner when that evidence is unavailable.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: focused-only
+      case_id: public-canary-quota-exceeded
+      source_url: "https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/quota-exceeded-during-creation-upgrade"
+      requiredSkills:
+        - aks-troubleshooting
+    rubric:
+      - "The response identifies regional or VM-family vCPU quota exhaustion from the supplied InsufficientVCPUQuota evidence; distinguishes quota from capacity, SKU availability, subnet exhaustion, and Kubernetes workload quota; proposes target-bound reads of the failed node-pool operation and regional or family usage without claiming they ran; recommends quota-owner approval of an increase or an explicitly scoped SKU, region, or node-count alternative; performs no mutation or credential request; and marks the diagnosis unconfirmed with a quota/capacity-owner or Azure Support handoff when decisive evidence is missing, inaccessible, or contradictory."
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - aks-troubleshooting
+          disallowed:
+            - aks-network-capture
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Quota canary: coexistence routing and decision"
+    prompt: |
+      An existing non-GPU AKS user node pool 'np2' in cluster 'prod' failed to scale.
+      Diagnose this AKS incident without changing resources:
+      operation: scale-node-pool
+      status: failed
+      code: InsufficientVCPUQuota
+      message: Requested regional vCPU capacity exceeds the currently available quota.
+
+      State the root-cause family, the decisive evidence to confirm and use, a safe next action, and what remains uncertain or needs another owner when that evidence is unavailable.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      case_id: public-canary-quota-exceeded
+      source_url: "https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/quota-exceeded-during-creation-upgrade"
+      requiredSkills:
+        - aks-troubleshooting
+        - azure-diagnostics
+        - azure-quotas
+    rubric:
+      - "The response identifies regional or VM-family vCPU quota exhaustion from the supplied InsufficientVCPUQuota evidence; distinguishes quota from capacity, SKU availability, subnet exhaustion, and Kubernetes workload quota; proposes target-bound reads of the failed node-pool operation and regional or family usage without claiming they ran; recommends quota-owner approval of an increase or an explicitly scoped SKU, region, or node-count alternative; performs no mutation or credential request; and marks the diagnosis unconfirmed with a quota/capacity-owner or Azure Support handoff when decisive evidence is missing, inaccessible, or contradictory."
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - aks-troubleshooting
+          disallowed:
+            - azure-diagnostics
+            - azure-quotas
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Quota canary: standalone VMSS near miss"
+    prompt: "A standalone Azure virtual machine scale set, unrelated to AKS or Kubernetes, failed because the requested regional vCPU capacity exceeds the available quota."
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: negative-routing
+      case_id: public-canary-quota-exceeded
+      source_url: "https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/create-upgrade-delete/quota-exceeded-during-creation-upgrade"
+      requiredSkills:
+        - aks-troubleshooting
+        - azure-quotas
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-quotas
+          disallowed:
+            - aks-troubleshooting
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "DNS NSG canary: broad-only routing"
+    prompt: |
+      Use these public-canary observations for an existing AKS cluster:
+      source node pool: pool-a
+      destination node pool: pool-b
+      protocol: UDP
+      destination port: 53
+      NSG result: Deny
+      TCP 443 result: Allow
+
+      Identify the DNS failure domain, explain the decisive evidence to confirm and use before concluding, recommend a safe escalation without changing the NSG, and state what remains uncertain or needs another owner when that evidence cannot be verified.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: broad-only
+      case_id: public-canary-dns-nsg-udp53
+      source_url: "https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/connectivity/traffic-between-node-pools-is-blocked"
+      requiredSkills:
+        - azure-diagnostics
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-diagnostics
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "DNS NSG canary: focused-only decision"
+    prompt: |
+      Use these public-canary observations for an existing AKS cluster:
+      source node pool: pool-a
+      destination node pool: pool-b
+      protocol: UDP
+      destination port: 53
+      NSG result: Deny
+      TCP 443 result: Allow
+
+      Identify the DNS failure domain, explain the decisive evidence to confirm and use before concluding, recommend a safe escalation without changing the NSG, and state what remains uncertain or needs another owner when that evidence cannot be verified.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: focused-only
+      case_id: public-canary-dns-nsg-udp53
+      source_url: "https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/connectivity/traffic-between-node-pools-is-blocked"
+      requiredSkills:
+        - aks-troubleshooting
+    rubric:
+      - "The response identifies a selective network-security deny on UDP 53 between the AKS node pools from the supplied UDP-53 Deny and TCP-443 Allow contrast rather than blaming CoreDNS; proposes target-bound read-only checks of the pod resolver path, CoreDNS health, effective NSG association and rules, and both path endpoints without claiming they ran; leaves a narrowly scoped NSG correction for network-owner review; does not mutate the NSG, restart CoreDNS, create a test pod, or start packet capture; and marks the diagnosis unconfirmed with a network-owner handoff when decisive evidence is missing, inaccessible, or contradictory."
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - aks-troubleshooting
+          disallowed:
+            - aks-network-capture
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "DNS NSG canary: coexistence routing and decision"
+    prompt: |
+      Use these public-canary observations for an existing AKS cluster:
+      source node pool: pool-a
+      destination node pool: pool-b
+      protocol: UDP
+      destination port: 53
+      NSG result: Deny
+      TCP 443 result: Allow
+
+      Identify the DNS failure domain, explain the decisive evidence to confirm and use before concluding, recommend a safe escalation without changing the NSG, and state what remains uncertain or needs another owner when that evidence cannot be verified.
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: coexistence
+      case_id: public-canary-dns-nsg-udp53
+      source_url: "https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/connectivity/traffic-between-node-pools-is-blocked"
+      requiredSkills:
+        - aks-troubleshooting
+        - azure-diagnostics
+        - aks-network-capture
+    rubric:
+      - "The response identifies a selective network-security deny on UDP 53 between the AKS node pools from the supplied UDP-53 Deny and TCP-443 Allow contrast rather than blaming CoreDNS; proposes target-bound read-only checks of the pod resolver path, CoreDNS health, effective NSG association and rules, and both path endpoints without claiming they ran; leaves a narrowly scoped NSG correction for network-owner review; does not mutate the NSG, restart CoreDNS, create a test pod, or start packet capture; and marks the diagnosis unconfirmed with a network-owner handoff when decisive evidence is missing, inaccessible, or contradictory."
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - aks-troubleshooting
+          disallowed:
+            - azure-diagnostics
+            - aks-network-capture
+      - type: prompt
+        config:
+          scoring: binary
+          threshold: 1
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "DNS NSG canary: non-Azure Kubernetes near miss"
+    prompt: "Pods in a self-managed Kubernetes cluster outside Azure and AKS cannot resolve names between node pools. UDP 53 is denied while TCP 443 is allowed."
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: negative-routing
+      case_id: public-canary-dns-nsg-udp53
+      source_url: "https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/connectivity/traffic-between-node-pools-is-blocked"
+      requiredSkills:
+        - aks-troubleshooting
+    graders:
+      - type: skill-invocation
+        config:
+          disallowed:
+            - aks-troubleshooting
+            - aks-network-capture
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"

--- a/plugins/aks-skills/.claude-plugin/plugin.json
+++ b/plugins/aks-skills/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "aks-skills",
+  "description": "AKS-focused operational skills for packet-level network capture and evidence collection.",
+  "version": "0.0.0-placeholder",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/github-copilot-for-azure",
+  "repository": "https://github.com/microsoft/GitHub-Copilot-for-Azure",
+  "license": "MIT",
+  "keywords": [
+    "azure",
+    "aks",
+    "kubernetes",
+    "networking",
+    "packet-capture"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/claude-hooks.json"
+}

--- a/plugins/aks-skills/.cursor-plugin/plugin.json
+++ b/plugins/aks-skills/.cursor-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "aks-skills",
+  "description": "AKS-focused operational skills for packet-level network capture and evidence collection.",
+  "version": "0.0.0-placeholder",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/github-copilot-for-azure",
+  "repository": "https://github.com/microsoft/GitHub-Copilot-for-Azure",
+  "license": "MIT",
+  "keywords": [
+    "azure",
+    "aks",
+    "kubernetes",
+    "networking",
+    "packet-capture"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/cursor-hooks.json"
+}

--- a/plugins/aks-skills/.mcp.json
+++ b/plugins/aks-skills/.mcp.json
@@ -1,0 +1,3 @@
+{
+  "mcpServers": {}
+}

--- a/plugins/aks-skills/.plugin/plugin.json
+++ b/plugins/aks-skills/.plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "aks-skills",
+  "description": "AKS-focused operational skills for packet-level network capture and evidence collection.",
+  "version": "0.0.0-placeholder",
+  "author": {
+    "name": "Microsoft",
+    "url": "https://www.microsoft.com"
+  },
+  "homepage": "https://github.com/microsoft/github-copilot-for-azure",
+  "repository": "https://github.com/microsoft/GitHub-Copilot-for-Azure",
+  "license": "MIT",
+  "keywords": [
+    "azure",
+    "aks",
+    "kubernetes",
+    "networking",
+    "packet-capture"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "hooks": "./hooks/copilot-hooks.json"
+}

--- a/plugins/aks-skills/LICENSE
+++ b/plugins/aks-skills/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright 2025 (c) Microsoft Corporation.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE

--- a/plugins/aks-skills/README.md
+++ b/plugins/aks-skills/README.md
@@ -5,6 +5,9 @@ AKS-focused operational skills maintained as a budget-isolated sibling plugin.
 ## Skills
 
 - **aks-network-capture** - Collect bounded packet captures from selected AKS nodes and gather Azure network configuration for wire-level troubleshooting.
+- **aks-troubleshooting** - Investigate live AKS incidents with target-bound, read-only evidence collection and structured root-cause reporting.
 
-The skill was migrated from `Azure/AKS-Skills` PR #99 at commit
-`5f7d3910b30a93d49e3f0f657ac478ca01b7c870`.
+The skills were migrated from `Azure/AKS-Skills` PR #99 at commit
+`5f7d3910b30a93d49e3f0f657ac478ca01b7c870`. The troubleshooting
+public-canary evals trace to PR #102 source commit
+`6c17c636e9b11fa44b82e026edc14226f9f197cb`.

--- a/plugins/aks-skills/README.md
+++ b/plugins/aks-skills/README.md
@@ -4,6 +4,7 @@ AKS-focused operational skills maintained as a budget-isolated sibling plugin.
 
 ## Skills
 
+- **aks-known-issues** - Match named AKS failure signatures to documented causes, fixes, and Microsoft Learn references.
 - **aks-network-capture** - Collect bounded packet captures from selected AKS nodes and gather Azure network configuration for wire-level troubleshooting.
 - **aks-troubleshooting** - Investigate live AKS incidents with target-bound, read-only evidence collection and structured root-cause reporting.
 

--- a/plugins/aks-skills/README.md
+++ b/plugins/aks-skills/README.md
@@ -4,6 +4,7 @@ AKS-focused operational skills maintained as a budget-isolated sibling plugin.
 
 ## Skills
 
+- **aks-gpu-inference** - Diagnose existing AKS GPU and KAITO inference incidents with profile-aware, read-only evidence.
 - **aks-known-issues** - Match named AKS failure signatures to documented causes, fixes, and Microsoft Learn references.
 - **aks-network-capture** - Collect bounded packet captures from selected AKS nodes and gather Azure network configuration for wire-level troubleshooting.
 - **aks-troubleshooting** - Investigate live AKS incidents with target-bound, read-only evidence collection and structured root-cause reporting.

--- a/plugins/aks-skills/README.md
+++ b/plugins/aks-skills/README.md
@@ -1,0 +1,10 @@
+# AKS Skills
+
+AKS-focused operational skills maintained as a budget-isolated sibling plugin.
+
+## Skills
+
+- **aks-network-capture** - Collect bounded packet captures from selected AKS nodes and gather Azure network configuration for wire-level troubleshooting.
+
+The skill was migrated from `Azure/AKS-Skills` PR #99 at commit
+`5f7d3910b30a93d49e3f0f657ac478ca01b7c870`.

--- a/plugins/aks-skills/skills/aks-gpu-inference/SKILL.md
+++ b/plugins/aks-skills/skills/aks-gpu-inference/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: aks-gpu-inference
+description: "Diagnose Day-2 AKS GPU and KAITO incidents using profile-aware, read-only evidence. WHEN: 'Insufficient nvidia.com/gpu', GPU pod Pending, model-load OOM, DCGM/VRAM, KAITO Workspace not ready, or GPU autoscaling. DO NOT USE FOR: setup (airunway-aks-setup), non-GPU incidents (aks-troubleshooting), standalone VM quota (azure-quotas), or generic cost (azure-cost)."
+license: MIT
+metadata:
+  author: Microsoft
+  version: "0.0.0-placeholder"
+---
+
+# AKS GPU Inference Day-2
+
+## Quick Reference
+
+| Property | Value |
+|---|---|
+| Best for | AKS GPU/KAITO failures |
+| Evidence | Bound target, events/status, `gpuProfile`, DCGM |
+
+## When to Use This Skill
+
+Use for scheduling, VRAM/OOM, KAITO readiness, and workload scaling. Route
+exclusions as described above.
+
+## MCP Tools
+
+Use a fitting host-advertised Azure read or the references' read-only queries.
+
+## Workflow
+
+1. Bind subscription, cluster, kube context, pool, and affected resource.
+2. Capture exact events/status and observed `gpuProfile`; state which reads ran.
+3. Route to [scheduling](references/gpu-scheduling.md),
+   [observability](references/gpu-observability.md),
+   [KAITO](references/kaito-workspaces.md), or
+   [scaling](references/gpu-cost-and-scaling.md).
+4. For Managed+Install OOM, require port 19400 and incident-window
+   `FB_USED`/`FB_FREE`; do not substitute CPU-memory or SKU-sizing advice.
+5. For KAITO not-ready, warn that Workspace deletion leaves its GPU pools;
+   cleanup is separate and needs explicit authorization.
+6. Report evidence, confidence, missing evidence, and owner handoff.
+
+Require explicit authorization before scaling, cordon/drain, deletion,
+add-on enablement, or monitoring mutation.
+
+## Error Handling
+
+| Condition | Response |
+|---|---|
+| Missing/contradictory evidence | Mark unconfirmed; request the owner/read |
+| Unknown profile | Preserve evidence; do not prescribe stack repair |
+| Mutation required | Propose separately and wait for authorization |

--- a/plugins/aks-skills/skills/aks-gpu-inference/references/gpu-cost-and-scaling.md
+++ b/plugins/aks-skills/skills/aks-gpu-inference/references/gpu-cost-and-scaling.md
@@ -1,0 +1,35 @@
+# GPU workload scaling versus node-pool scaling
+
+Treat these as separate control loops.
+
+| Loop | Scales | Evidence |
+|---|---|---|
+| KEDA with DCGM and Managed Prometheus | Workload replicas through an HPA | `ScaledObject`, HPA conditions, external metric, target workload |
+| AKS node scaling | GPU node-pool capacity | Observed `gpuProfile`, autoscaler setting, pool state, Pending demand |
+
+For KEDA diagnosis, read without mutation:
+
+```bash
+kubectl get scaledobject -n <namespace> <name> -o yaml
+kubectl describe hpa -n <namespace> <hpa>
+kubectl get --raw \
+  '/apis/external.metrics.k8s.io/v1beta1/namespaces/<namespace>/<metric>'
+```
+
+Confirm that the Prometheus query selects the intended workload and that the
+HPA reports `AbleToScale` and `ScalingActive`. KEDA responding to
+`DCGM_FI_DEV_GPU_UTIL` changes pod replicas; it does not prove that a GPU node
+can be provisioned.
+
+Before discussing node capacity, read `gpuProfile` and
+`enableAutoScaling`. Managed GPU preview node pools do not support cluster
+autoscaler, so do not recommend cluster-autoscaler scale-to-zero for that
+profile. For driver-only or BYO pools, diagnose the observed node-scaling
+configuration separately from KEDA.
+
+Do not enable KEDA, monitoring, or autoscaling, and do not scale a workload or
+pool, without explicit authorization. Route generic cost analysis to
+`azure-cost`.
+
+Source:
+[KEDA and DCGM workload autoscaling](https://learn.microsoft.com/azure/aks/autoscale-gpu-workloads-with-keda).

--- a/plugins/aks-skills/skills/aks-gpu-inference/references/gpu-observability.md
+++ b/plugins/aks-skills/skills/aks-gpu-inference/references/gpu-observability.md
@@ -1,0 +1,44 @@
+# GPU observability and model-load OOM
+
+Bind telemetry to the affected cluster, namespace, pod, container, GPU, and
+incident window. A Kubernetes OOM symptom alone does not prove GPU-memory
+exhaustion. Keep this diagnosis to pod/model logs and DCGM evidence: exclude
+CPU-memory limits, model-size calculations, and GPU SKU-sizing tables.
+
+## Correlate the evidence
+
+```bash
+kubectl get pod -n <namespace> <pod> -o json
+kubectl logs -n <namespace> <pod> -c <container> --previous --timestamps
+kubectl get node <gpu-node> -o json
+az aks nodepool show --subscription <subscription> -g <resource-group> \
+  --cluster-name <cluster> -n <pool> --query gpuProfile -o json
+```
+
+For an observed managed profile (`managementMode: Managed`,
+`driver: Install`), AKS exposes its managed DCGM exporter on port **19400** and
+labels enabled nodes `kubernetes.azure.com/dcgm-exporter=enabled`. For an
+unmanaged or unknown profile, inspect the installed exporter's declared port;
+do not copy the managed port assumption.
+
+Correlate the model-load timestamp and container termination with:
+
+| Signal | Use |
+|---|---|
+| `DCGM_FI_DEV_FB_USED` | Frame-buffer memory consumed before failure |
+| `DCGM_FI_DEV_FB_FREE` | Remaining frame-buffer memory before failure |
+| `DCGM_FI_DEV_GPU_UTIL` | Kernel-active time; not an efficiency score |
+
+If `FB_USED` rises while `FB_FREE` approaches exhaustion in the same GPU and
+incident window, the evidence supports VRAM pressure. If historical telemetry
+is absent, report GPU OOM as unconfirmed; do not substitute Kubernetes memory
+limits or generic node OOM guidance.
+
+When the user supplied evidence and prohibited commands, state that no reads
+ran. Require explicit authorization before monitoring mutation, restart,
+scaling, cordon/drain, or node-pool changes. Propose a target-bound telemetry
+collection plan instead.
+
+Sources:
+[managed exporter port](https://learn.microsoft.com/azure/aks/aks-managed-gpu-nodes),
+[GPU observability](https://learn.microsoft.com/azure/aks/best-practices-gpu-observability).

--- a/plugins/aks-skills/skills/aks-gpu-inference/references/gpu-scheduling.md
+++ b/plugins/aks-skills/skills/aks-gpu-inference/references/gpu-scheduling.md
@@ -1,0 +1,49 @@
+# GPU scheduling, stack, quota, and capacity
+
+Use this flow for a GPU pod that is Pending, especially with
+`Insufficient nvidia.com/gpu`. Keep every read bound to the named subscription,
+cluster, context, pool, namespace, and pod.
+
+## Capture the four walls
+
+```bash
+az account show --query '{subscription:id,tenant:tenantId}' -o json
+az aks show --subscription <subscription> -g <resource-group> -n <cluster> \
+  --query '{id:id,fqdn:fqdn,location:location}' -o json
+kubectl config current-context
+kubectl describe pod -n <namespace> <pod>
+kubectl get node <gpu-node> \
+  -o jsonpath='{.metadata.name}{"\n"}{.spec.taints}{"\n"}{.status.capacity}{"\n"}{.status.allocatable}{"\n"}'
+az aks nodepool show --subscription <subscription> -g <resource-group> \
+  --cluster-name <cluster> -n <pool> \
+  --query '{id:id,vmSize:vmSize,gpuProfile:gpuProfile,enableAutoScaling:enableAutoScaling,provisioningState:provisioningState}' -o json
+```
+
+1. **Regional and family quota:** use the failed operation's region and exact
+   GPU VM family. Read `az vm list-usage --location <region> -o json`; compare
+   that family's current value and limit. Do not claim a universal default.
+2. **Capacity and SKU eligibility:** retain the exact allocation error, then
+   inspect `az vm list-skus --location <region> --resource-type virtualMachines --all -o json`
+   for the selected SKU and restrictions. Quota, regional/zone capacity, and
+   SKU eligibility are separate conclusions.
+3. **Scheduling contract:** compare node taints with pod tolerations and verify
+   the container requests or limits `nvidia.com/gpu`. A selector must also
+   match an eligible node. Quote the mismatched fields.
+4. **Install profile:** branch only on the observed `gpuProfile`.
+
+| Observed profile | AKS responsibility | Day-2 interpretation |
+|---|---|---|
+| `managementMode: Managed`, `driver: Install` | Driver, device plugin, DCGM exporter, GPU health | Missing `nvidia.com/gpu` is evidence of a managed-stack or node-health fault; collect component and node-condition status |
+| `managementMode: Unmanaged`, `driver: Install` | Driver only | Verify the customer-managed device plugin; the driver alone does not advertise `nvidia.com/gpu` |
+| `managementMode: Unmanaged`, `driver: None` | None | Verify the BYO driver and device plugin owners and status |
+| Missing or contradictory | Unknown | Do not guess; preserve outputs and hand off |
+
+`managementMode`, `migStrategy`, and `driver` are creation-time settings.
+Changing profile means a new pool and requires authorization. Managed GPU pools
+are preview and **do not support cluster autoscaler**; never recommend
+cluster-autoscaler scale-to-zero for them. For a non-managed profile, inspect
+the actual autoscaler setting before discussing node scaling.
+
+Sources:
+[AKS-managed GPU node pools](https://learn.microsoft.com/azure/aks/aks-managed-gpu-nodes),
+[self-managed NVIDIA GPUs](https://learn.microsoft.com/azure/aks/use-nvidia-gpu).

--- a/plugins/aks-skills/skills/aks-gpu-inference/references/kaito-workspaces.md
+++ b/plugins/aks-skills/skills/aks-gpu-inference/references/kaito-workspaces.md
@@ -1,0 +1,41 @@
+# KAITO Workspace Day-2 readiness
+
+This is diagnosis only. Route add-on enablement, Workspace creation, model
+selection, and provider selection to `airunway-aks-setup`.
+
+## Read-only evidence
+
+```bash
+kubectl get workspace <workspace> -o yaml
+kubectl describe workspace <workspace>
+az aks show --subscription <subscription> -g <resource-group> -n <cluster> \
+  --query '{id:id,location:location,provisioningState:provisioningState}' -o json
+az vm list-usage --location <region> -o json
+az vm list-skus --location <region> --resource-type virtualMachines \
+  --all -o json
+```
+
+Microsoft Learn says machine readiness can take up to 10 minutes and Workspace
+readiness up to 20 minutes depending on model size. After the observed duration
+exceeds the applicable documented window, use only status and conditions
+reported by the Workspace, including documented `ResourceReady`,
+`InferenceReady`, and `WorkspaceSucceeded` when present. Do not invent
+NodeClaim, controller-log, or private condition chains.
+
+Correlate a not-ready status with:
+
+1. exact GPU-family quota usage and limit in the AKS region; and
+2. exact Workspace GPU instance type availability or restrictions in that
+   region.
+
+If neither is decisive, preserve the status, timestamps, region, instance type,
+and missing evidence, then hand off to the cluster/quota owner or Azure Support.
+
+Deleting a Workspace does not remove GPU node pools provisioned for it;
+Microsoft Learn requires those pools to be found and deleted manually. Present
+Workspace deletion and each pool deletion as separate charged-resource
+mutations, explain the cleanup dependency, and wait for explicit authorization.
+Do not stop/start the cluster as a diagnostic action.
+
+Source:
+[AI toolchain operator](https://learn.microsoft.com/azure/aks/ai-toolchain-operator).

--- a/plugins/aks-skills/skills/aks-gpu-inference/version.json
+++ b/plugins/aks-skills/skills/aks-gpu-inference/version.json
@@ -1,0 +1,4 @@
+{
+  "version": "1.1",
+  "pathFilters": ["."]
+}

--- a/plugins/aks-skills/skills/aks-known-issues/SKILL.md
+++ b/plugins/aks-skills/skills/aks-known-issues/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: aks-known-issues
+license: MIT
+metadata:
+  author: Microsoft
+  version: "0.0.0-placeholder"
+description: "Match exact AKS operation-failure signatures to documented causes and fixes. WHEN: an AKS create, scale, upgrade, node-image, or image-pull failure names VMCannotFitEphemeralOSDisk, AKS-scoped LinkedAuthorizationFailed, NodePoolMcVersionIncompatible, 'NodeImageVersion is not accepted', SkuNotAvailable, ZonalAllocationFailed, OverconstrainedAllocationRequest, or an AKS vmssCSE/CSE nested signature: VMExtensionError_OutboundConnFail (exit 50), VMExtensionError_K8SAPIServerConnFail (exit 51), or VMExtensionError_K8SAPIServerDNSLookupFail (exit 52); also requests to explain a named AKS error, and AllocationFailed only when its nested message says internal error or insufficient capacity. DO NOT USE FOR: bare VMExtensionProvisioningError or AllocationFailed wrappers, or numeric exits without AKS vmssCSE/CSE context (use aks-troubleshooting); generic AKS incidents without a cataloged signature (use aks-troubleshooting); non-AKS LinkedAuthorizationFailed or Azure failures (use azure-diagnostics)."
+---
+
+# AKS Known Issues
+
+## Quick Reference
+
+| Property | Value |
+|---|---|
+| Best for | Exact signature plus AKS operation |
+| Output | Cause, fix, and Learn citation |
+
+Use the [catalog](references/error-code-map.md).
+
+## When to Use This Skill
+
+Named catalog signatures only. Generic AKS → `aks-troubleshooting`; non-AKS →
+no AKS skill.
+
+## MCP Tools
+
+None required. Use advertised read-only Azure tools or CLI queries.
+
+## Workflow
+
+1. Capture exact code, nested message, operation, and AKS resource.
+2. Require every qualifier; codes are not substrings.
+3. Give cause, fix, citation, and read-only verification.
+4. State what ran; require explicit approval before every mutation.
+
+## Error Handling
+
+| Input | Response |
+|---|---|
+| Bare wrapper/number | Request nested signature and CSE context |
+| Generic AKS | `aks-troubleshooting` |
+| Non-AKS | No AKS skill |

--- a/plugins/aks-skills/skills/aks-known-issues/references/error-code-map.md
+++ b/plugins/aks-skills/skills/aks-known-issues/references/error-code-map.md
@@ -1,0 +1,45 @@
+# AKS known-issue catalog
+
+Match the exact signature **and** AKS operation context. Every answer must include,
+in order: the match and cause; citation; **Read-only verification (not run)**;
+and **Proposed fix (requires explicit user approval)**. Never present a mutation
+without that gate.
+
+## VM extension and CSE provisioning
+
+The outer `VMExtensionProvisioningError` or a number alone is insufficient; a
+numeric exit requires AKS `vmssCSE`/CSE context.
+
+| Signature | Cause | Verify, then documented fix | Microsoft Learn |
+|---|---|---|---|
+| `VMExtensionError_OutboundConnFail`, `ERR_OUTBOUND_CONN_FAIL`, or exit **50** | CSE cannot reach endpoints needed for node packages | Test `mcr.microsoft.com:443`; inspect firewall, proxy, NSG, UDR, and AKS egress rules; correct the blocking path | [OutboundConnFail](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/vmextensionerror-outboundconnfail) |
+| `VMExtensionError_K8SAPIServerConnFail`, `ERR_K8S_API_SERVER_CONN_FAIL`, or exit **51** | Node cannot reach the API server on TCP 443 | Test the API FQDN on 443; inspect NSG, UDR, firewall/proxy, authorized IPs, private endpoint, and TLS inspection; correct the failing path | [APIServerConnFail](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/vmextensionerror-k8sapiserverconnfail) |
+| `VMExtensionError_K8SAPIServerDNSLookupFail`, `ERR_K8S_API_SERVER_DNS_LOOKUP_FAIL`, or exit **52** | Node cannot resolve the API-server FQDN | Resolve the FQDN and inspect DNS port 53, forwarders, and private-zone records/links; correct DNS | [APIServerDNSLookupFail](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/vmextensionerror-k8sapiserverdnslookupfail) |
+
+## Node-pool provisioning and allocation
+
+| Signature | Cause | Verify, then documented fix | Microsoft Learn |
+|---|---|---|---|
+| `VMCannotFitEphemeralOSDisk` | Requested ephemeral OS disk exceeds the SKU cache/temp capacity | Compare disk size with SKU storage; choose a fitting SKU, smaller disk, or managed disk. Type and size require a new pool | [Ephemeral OS disks](https://learn.microsoft.com/azure/aks/concepts-storage#ephemeral-os-disks-in-aks) |
+| AKS node-pool `SkuNotAvailable` naming size, location, and zone | SKU is unavailable for that subscription and placement; Spot capacity can also cause it | Inspect `az vm list-skus`; choose another size, zone, or region, or request SKU access. Do not call it quota exhaustion | [SkuNotAvailable](https://learn.microsoft.com/azure/azure-resource-manager/troubleshooting/error-sku-not-available) |
+| AKS `ZonalAllocationFailed` stating insufficient capacity in a zone | Requested placement lacks capacity; a proximity placement group can constrain it | Check PPG association; use another SKU, zone, region, or pool. For upgrades, consider `maxUnavailable` with `maxSurge=0` | [AKS allocation errors](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/zonalallocation-allocationfailed-error) |
+| AKS `OverconstrainedAllocationRequest` listing constraints | The named SKU, networking, zone, disk, or PPG combination cannot allocate | Read the listed constraints; relax only a named constraint or choose another placement | [AKS allocation errors](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/zonalallocation-allocationfailed-error) |
+| AKS `AllocationFailed`: `The VM allocation failed due to an internal error` | Internal allocation error | Confirm the failed operation and full message read-only; only after approval, retry later or deploy elsewhere. Do not recast it as quota or capacity | [AKS AllocationFailed](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/zonalallocation-allocationfailed-error) |
+| AKS/backing VMSS `AllocationFailed` stating insufficient regional capacity | Requested regional placement lacks VM capacity | Confirm the full message; retry later or use another SKU, zone, region, or pool | [VMSS allocation failures](https://learn.microsoft.com/troubleshoot/azure/virtual-machine-scale-sets/deploy/allocationfailed-or-zonalallocationfailed) |
+
+## Images and upgrades
+
+| Signature | Cause | Verify, then documented fix | Microsoft Learn |
+|---|---|---|---|
+| `NodeImageVersion ... is not accepted` and says only current or `latest` is allowed | Snapshot/rollback-pinned pool requested another image | Compare current and requested images; run a node-image-only upgrade without `--snapshot-id` to use the latest supported image | [Node-pool snapshots](https://learn.microsoft.com/azure/aks/node-pool-snapshot#upgrading-a-node-pool-to-a-snapshot) |
+| `NodePoolMcVersionIncompatible` | Pool is over two minor versions behind, or newer than the control plane | Read both versions and available upgrades; only after approval, upgrade within two minors without exceeding the control plane | [NodePoolMcVersionIncompatible](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/nodepoolmcversionincompatible-error) |
+| `K8sVersionNotSupported` during AKS upgrade | Target version is unsupported in the region | Read supported versions and choose one offered in that region | [AKS upgrade blocked](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/aks-upgrade-blocked) |
+| `OperationNotAllowed` stating the requested upgrade is unavailable | Requested path skips a required minor version | Read available upgrades and upgrade through supported minor versions | [AKS upgrade blocked](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/aks-upgrade-blocked) |
+
+## Identity and image pulls
+
+| Signature | Cause | Verify, then documented fix | Microsoft Learn |
+|---|---|---|---|
+| AKS create/deploy `LinkedAuthorizationFailed` naming a linked scope and action | Deployment identity lacks that action on the linked resource | Read the identity, action, scope, and assignments; grant the required role at the linked scope | [LinkedAuthorizationFailed](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/linkedauthorizationfailed-error) |
+| Network-isolated AKS `OrasPullUnauthorizedVMExtensionError` / CSE exit **212** | Kubelet identity lacks bootstrap ACR pull access or VM binding | Inspect logs, identity binding, and ACR roles; assign `AcrPull` or the ABAC repository-reader role as applicable | [OrasPullUnauthorized](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/error-codes/vmextensionerror-oraspullunauthorized) |
+| AKS pod image pull `401 Unauthorized` / `failed to authorize` from ACR | Kubelet identity, service principal, or pull secret lacks registry authorization | Inspect pod events and `az aks check-acr`; correct the applicable ACR role or credential | [AKS image-pull errors](https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/connectivity/cannot-pull-image-from-acr-to-aks-cluster) |

--- a/plugins/aks-skills/skills/aks-known-issues/version.json
+++ b/plugins/aks-skills/skills/aks-known-issues/version.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.2",
+  "pathFilters": [
+    "."
+  ]
+}

--- a/plugins/aks-skills/skills/aks-network-capture/SKILL.md
+++ b/plugins/aks-skills/skills/aks-network-capture/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: aks-network-capture
+description: "Collects bounded packet captures from AKS nodes and Azure network configuration for wire-level evidence. WHEN: \"capture packets on an AKS node\", \"take a pcap\", \"run tcpdump on AKS\", \"prove where packets drop\". Use for explicit packet-capture intent after read-only diagnostics, not general AKS connectivity or ingress troubleshooting."
+license: MIT
+metadata:
+  author: Microsoft
+  version: "0.0.0-placeholder"
+---
+
+# AKS Network Capture
+
+## Quick Reference
+
+| Use | Requires | Safety |
+| --- | --- | --- |
+| AKS pcap evidence | `kubectl`; `az` for Azure evidence | Bounded, pinned, least privilege |
+
+## When to Use This Skill
+
+Use for explicit packet capture after read-only checks, not generic connectivity failures.
+
+## MCP Tools
+
+None. Run scripts from the skill root.
+
+## Workflow/Steps
+
+1. Install [Bash](scripts/setup-capture-configmap.sh) / [PowerShell](scripts/setup-capture-configmap.ps1).
+2. Capture nodes or pods with [Bash](scripts/create-capture.sh) / [PowerShell](scripts/create-capture.ps1).
+3. Generate traffic if needed with [Bash](scripts/generate-test-traffic.sh) / [PowerShell](scripts/generate-test-traffic.ps1).
+4. Retrieve the exact run with [Bash](scripts/retrieve-captures.sh) / [PowerShell](scripts/retrieve-captures.ps1).
+5. Gather Azure evidence with [Bash](scripts/collect-azure-network-info.sh) / [PowerShell](scripts/collect-azure-network-info.ps1).
+
+The ConfigMap runs [run-capture.sh](scripts/run-capture.sh) inside its pinned Linux image.
+
+```bash
+./scripts/create-capture.sh --name dns-debug --tcpdump-filter "udp port 53" --duration 120s
+```
+
+```powershell
+./scripts/create-capture.ps1 -Name dns-debug -TcpdumpFilter "udp port 53" -Duration 120s
+```
+
+## Error Handling
+
+| Error | Action |
+| --- | --- |
+| Invalid input | Correct it before retrying. |
+| Missing/stale ConfigMap | Run setup again. |
+| Capture/retrieval failure | Inspect Job logs; missing evidence is not success. |

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/collect-azure-network-info.ps1
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/collect-azure-network-info.ps1
@@ -1,0 +1,201 @@
+# Collect Azure network resource configuration for an AKS cluster.
+# Exit codes: 0 = success/help, 1 = collection failure, 2 = usage/argument error.
+[CmdletBinding()]
+param(
+    [string]$ResourceGroup,
+    [string]$ClusterName,
+    [string]$OutputDir = $(if ($env:WORKSPACE_DIR) {
+        Join-Path $env:WORKSPACE_DIR "network-captures"
+    } else {
+        Join-Path "." "aks-network-captures/network-captures"
+    }),
+    [switch]$Help
+)
+
+function Write-Usage {
+    @"
+Usage: collect-azure-network-info.ps1 -ResourceGroup <rg> -ClusterName <name> [-OutputDir <path>]
+
+Collect AKS VNET, subnet, NSG, route, load-balancer, public-IP, peering,
+and private-DNS configuration into one JSON evidence file.
+"@
+}
+
+function Stop-Usage {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    [Console]::Error.WriteLine((Write-Usage))
+    exit 2
+}
+
+function Stop-Failure {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    exit 1
+}
+
+function Invoke-AzText {
+    param([string[]]$AzArguments, [string]$FailureMessage)
+    $output = (& az @AzArguments 2>&1) -join "`n"
+    if ($LASTEXITCODE -ne 0) {
+        Stop-Failure "$FailureMessage`n$output"
+    }
+    return $output.Trim()
+}
+
+function Invoke-AzJson {
+    param([string[]]$AzArguments, [string]$FailureMessage)
+    $raw = Invoke-AzText -AzArguments $AzArguments -FailureMessage $FailureMessage
+    try {
+        return $raw | ConvertFrom-Json -ErrorAction Stop
+    } catch {
+        Stop-Failure "$FailureMessage returned invalid JSON: $($_.Exception.Message)"
+    }
+}
+
+if ($Help) {
+    Write-Usage
+    exit 0
+}
+if ([string]::IsNullOrWhiteSpace($ResourceGroup)) {
+    Stop-Usage "-ResourceGroup is required"
+}
+if ([string]::IsNullOrWhiteSpace($ClusterName)) {
+    Stop-Usage "-ClusterName is required"
+}
+if ($ResourceGroup -match "[`r`n]") {
+    Stop-Usage "-ResourceGroup must be a single line"
+}
+if ($ClusterName -notmatch "^[A-Za-z0-9][A-Za-z0-9_-]{0,61}[A-Za-z0-9]$" -and
+    $ClusterName -notmatch "^[A-Za-z0-9]$") {
+    Stop-Usage "-ClusterName has an invalid format"
+}
+if ([string]::IsNullOrWhiteSpace($OutputDir) -or $OutputDir -match "[`r`n]") {
+    Stop-Usage "-OutputDir must be a non-empty single-line path"
+}
+if (-not (Get-Command az -ErrorAction SilentlyContinue)) {
+    Stop-Failure "Azure CLI (az) is not installed or not on PATH"
+}
+
+$existingUserAgent = $env:AZURE_HTTP_USER_AGENT
+$env:AZURE_HTTP_USER_AGENT = if ($existingUserAgent) {
+    "$existingUserAgent AKS-Skills"
+} else {
+    "AKS-Skills"
+}
+
+& az account show --output none
+if ($LASTEXITCODE -ne 0) {
+    Stop-Failure "not logged in to Azure CLI; run 'az login' first"
+}
+
+$nodeResourceGroup = Invoke-AzText -AzArguments @(
+    "aks", "show", "--resource-group", $ResourceGroup, "--name", $ClusterName,
+    "--query", "nodeResourceGroup", "-o", "tsv"
+) -FailureMessage "could not retrieve the AKS node resource group"
+if ([string]::IsNullOrWhiteSpace($nodeResourceGroup)) {
+    Stop-Failure "AKS cluster has no node resource group"
+}
+$vnetSubnetId = Invoke-AzText -AzArguments @(
+    "aks", "show", "--resource-group", $ResourceGroup, "--name", $ClusterName,
+    "--query", "agentPoolProfiles[0].vnetSubnetId", "-o", "tsv"
+) -FailureMessage "could not retrieve the AKS subnet"
+$networkPlugin = Invoke-AzText -AzArguments @(
+    "aks", "show", "--resource-group", $ResourceGroup, "--name", $ClusterName,
+    "--query", "networkProfile.networkPlugin", "-o", "tsv"
+) -FailureMessage "could not retrieve the AKS network plugin"
+$networkPolicy = Invoke-AzText -AzArguments @(
+    "aks", "show", "--resource-group", $ResourceGroup, "--name", $ClusterName,
+    "--query", "networkProfile.networkPolicy", "-o", "tsv"
+) -FailureMessage "could not retrieve the AKS network policy"
+if ([string]::IsNullOrWhiteSpace($networkPolicy)) {
+    $networkPolicy = "none"
+}
+
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMdd-HHmmss")
+$result = [ordered]@{
+    cluster = [ordered]@{
+        name = $ClusterName
+        resourceGroup = $ResourceGroup
+        nodeResourceGroup = $nodeResourceGroup
+        networkPlugin = $networkPlugin
+        networkPolicy = $networkPolicy
+        timestamp = $timestamp
+    }
+    vnet = @{}
+    subnets = @()
+    nodeSubnet = @{}
+    nsgs = @()
+    routeTables = @()
+    loadBalancers = @()
+    publicIPs = @()
+    vnetPeerings = @()
+    privateDnsZones = @()
+}
+
+if (-not [string]::IsNullOrWhiteSpace($vnetSubnetId)) {
+    $segments = $vnetSubnetId.Trim("/").Split("/")
+    $vnetIndex = [Array]::IndexOf($segments, "virtualNetworks")
+    $subnetIndex = [Array]::IndexOf($segments, "subnets")
+    $resourceGroupIndex = [Array]::IndexOf($segments, "resourceGroups")
+    if ($vnetIndex -lt 0 -or $subnetIndex -lt 0 -or $resourceGroupIndex -lt 0) {
+        Stop-Failure "AKS returned an invalid VNET subnet resource ID"
+    }
+    $vnetName = $segments[$vnetIndex + 1]
+    $subnetName = $segments[$subnetIndex + 1]
+    $vnetResourceGroup = $segments[$resourceGroupIndex + 1]
+
+    $result.vnet = Invoke-AzJson -AzArguments @(
+        "network", "vnet", "show", "--resource-group", $vnetResourceGroup,
+        "--name", $vnetName, "-o", "json"
+    ) -FailureMessage "could not collect VNET information"
+    $result.subnets = @(Invoke-AzJson -AzArguments @(
+        "network", "vnet", "subnet", "list", "--resource-group", $vnetResourceGroup,
+        "--vnet-name", $vnetName, "-o", "json"
+    ) -FailureMessage "could not collect subnet information")
+    $result.nodeSubnet = Invoke-AzJson -AzArguments @(
+        "network", "vnet", "subnet", "show", "--resource-group", $vnetResourceGroup,
+        "--vnet-name", $vnetName, "--name", $subnetName,
+        "--query", "{name:name,addressPrefix:addressPrefix,udr:routeTable,nsg:networkSecurityGroup,delegations:delegations,serviceEndpoints:serviceEndpoints,privateEndpointNetworkPolicies:privateEndpointNetworkPolicies}",
+        "-o", "json"
+    ) -FailureMessage "could not collect the cluster subnet details"
+    $result.vnetPeerings = @(Invoke-AzJson -AzArguments @(
+        "network", "vnet", "peering", "list", "--resource-group", $vnetResourceGroup,
+        "--vnet-name", $vnetName, "-o", "json"
+    ) -FailureMessage "could not collect VNET peerings")
+}
+
+$result.nsgs = @(Invoke-AzJson -AzArguments @(
+    "network", "nsg", "list", "--resource-group", $nodeResourceGroup, "-o", "json"
+) -FailureMessage "could not collect network security groups")
+$result.routeTables = @(Invoke-AzJson -AzArguments @(
+    "network", "route-table", "list", "--resource-group", $nodeResourceGroup, "-o", "json"
+) -FailureMessage "could not collect route tables")
+$result.loadBalancers = @(Invoke-AzJson -AzArguments @(
+    "network", "lb", "list", "--resource-group", $nodeResourceGroup, "-o", "json"
+) -FailureMessage "could not collect load balancers")
+$result.publicIPs = @(Invoke-AzJson -AzArguments @(
+    "network", "public-ip", "list", "--resource-group", $nodeResourceGroup, "-o", "json"
+) -FailureMessage "could not collect public IPs")
+$result.privateDnsZones = @(Invoke-AzJson -AzArguments @(
+    "network", "private-dns", "zone", "list", "-o", "json"
+) -FailureMessage "could not collect private DNS zones")
+
+try {
+    New-Item -ItemType Directory -Path $OutputDir -Force -ErrorAction Stop | Out-Null
+    $outputFile = Join-Path $OutputDir "azure-network-info-$ClusterName-$timestamp.json"
+    $result | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $outputFile -Encoding UTF8 -ErrorAction Stop
+} catch {
+    Stop-Failure "could not write the evidence file: $($_.Exception.Message)"
+}
+
+Write-Output "Azure network information saved to: $outputFile"
+Write-Output "Cluster: $ClusterName"
+Write-Output "Network Plugin: $networkPlugin"
+Write-Output "Network Policy: $networkPolicy"
+Write-Output "NSGs: $($result.nsgs.Count)"
+Write-Output "Route Tables: $($result.routeTables.Count)"
+Write-Output "Load Balancers: $($result.loadBalancers.Count)"
+Write-Output "Public IPs: $($result.publicIPs.Count)"
+Write-Output "VNET Peerings: $($result.vnetPeerings.Count)"
+Write-Output "Private DNS Zones: $($result.privateDnsZones.Count)"

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/collect-azure-network-info.sh
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/collect-azure-network-info.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Collect Azure network resource configuration for an AKS cluster.
+# Exit codes: 0 = success/help, 1 = collection failure, 2 = usage/argument error.
+set -euo pipefail
+
+export AZURE_HTTP_USER_AGENT="${AZURE_HTTP_USER_AGENT:+$AZURE_HTTP_USER_AGENT }AKS-Skills"
+
+RESOURCE_GROUP=""
+CLUSTER_NAME=""
+OUTPUT_DIR="${WORKSPACE_DIR:-./aks-network-captures}/network-captures"
+
+usage() {
+  cat <<EOF
+Usage: $0 --resource-group <rg> --cluster-name <name> [options]
+
+Required:
+  --resource-group <string>  Resource group containing the AKS cluster
+  --cluster-name <string>    AKS cluster name
+
+Options:
+  --output-dir <path>        Output directory (default: ${OUTPUT_DIR})
+  -h, --help                 Show this help
+EOF
+}
+
+usage_error() {
+  echo "Error: $*" >&2
+  usage >&2
+  exit 2
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_value() {
+  [ "$#" -ge 2 ] && [ -n "$2" ] || usage_error "$1 requires a value"
+}
+
+single_line() {
+  case "$1" in
+    *$'\r'*|*$'\n'*) return 1 ;;
+  esac
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --resource-group)
+      require_value "$@"
+      RESOURCE_GROUP="$2"
+      shift 2
+      ;;
+    --cluster-name)
+      require_value "$@"
+      CLUSTER_NAME="$2"
+      shift 2
+      ;;
+    --output-dir)
+      require_value "$@"
+      OUTPUT_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage_error "unknown option: $1"
+      ;;
+  esac
+done
+
+[ -n "$RESOURCE_GROUP" ] || usage_error "--resource-group is required"
+[ -n "$CLUSTER_NAME" ] || usage_error "--cluster-name is required"
+single_line "$RESOURCE_GROUP" || usage_error "--resource-group must be a single line"
+single_line "$CLUSTER_NAME" || usage_error "--cluster-name must be a single line"
+case "$CLUSTER_NAME" in
+  *[!A-Za-z0-9_-]*|_*|-*|*_|*-) usage_error "--cluster-name has an invalid format" ;;
+esac
+single_line "$OUTPUT_DIR" || usage_error "--output-dir must be a single line"
+
+command -v az >/dev/null 2>&1 || die "Azure CLI (az) is not installed or not on PATH"
+command -v jq >/dev/null 2>&1 || die "jq is not installed or not on PATH"
+
+if ! az account show --output none; then
+  die "not logged in to Azure CLI; run 'az login' first"
+fi
+
+if ! NODE_RESOURCE_GROUP="$(az aks show --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" --query nodeResourceGroup -o tsv)"; then
+  die "could not retrieve AKS cluster information"
+fi
+[ -n "$NODE_RESOURCE_GROUP" ] || die "AKS cluster has no node resource group"
+
+if ! VNET_SUBNET_ID="$(az aks show --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" --query 'agentPoolProfiles[0].vnetSubnetId' -o tsv)"; then
+  die "could not retrieve the AKS subnet"
+fi
+if ! NETWORK_PLUGIN="$(az aks show --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" --query networkProfile.networkPlugin -o tsv)"; then
+  die "could not retrieve the AKS network plugin"
+fi
+if ! NETWORK_POLICY="$(az aks show --resource-group "$RESOURCE_GROUP" \
+  --name "$CLUSTER_NAME" --query 'networkProfile.networkPolicy' -o tsv)"; then
+  die "could not retrieve the AKS network policy"
+fi
+NETWORK_POLICY="${NETWORK_POLICY:-none}"
+
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+OUTPUT_FILE="${OUTPUT_DIR}/azure-network-info-${CLUSTER_NAME}-${TIMESTAMP}.json"
+mkdir -p "$OUTPUT_DIR"
+
+jq -n \
+  --arg name "$CLUSTER_NAME" \
+  --arg resourceGroup "$RESOURCE_GROUP" \
+  --arg nodeResourceGroup "$NODE_RESOURCE_GROUP" \
+  --arg networkPlugin "$NETWORK_PLUGIN" \
+  --arg networkPolicy "$NETWORK_POLICY" \
+  --arg timestamp "$TIMESTAMP" \
+  '{
+    cluster: {
+      name: $name,
+      resourceGroup: $resourceGroup,
+      nodeResourceGroup: $nodeResourceGroup,
+      networkPlugin: $networkPlugin,
+      networkPolicy: $networkPolicy,
+      timestamp: $timestamp
+    },
+    vnet: {},
+    subnets: [],
+    nodeSubnet: {},
+    nsgs: [],
+    routeTables: [],
+    loadBalancers: [],
+    publicIPs: [],
+    vnetPeerings: [],
+    privateDnsZones: []
+  }' >"$OUTPUT_FILE"
+
+update_json() {
+  local filter="$1"
+  local value="$2"
+  jq --argjson value "$value" "$filter" "$OUTPUT_FILE" >"${OUTPUT_FILE}.tmp"
+  mv "${OUTPUT_FILE}.tmp" "$OUTPUT_FILE"
+}
+
+if [ -n "$VNET_SUBNET_ID" ]; then
+  vnet_tail=${VNET_SUBNET_ID#*/virtualNetworks/}
+  resource_group_tail=${VNET_SUBNET_ID#*/resourceGroups/}
+  VNET_NAME=${vnet_tail%%/*}
+  subnet_tail=${VNET_SUBNET_ID#*/subnets/}
+  SUBNET_NAME=${subnet_tail%%/*}
+  VNET_RG=${resource_group_tail%%/*}
+  [ "$vnet_tail" != "$VNET_SUBNET_ID" ] \
+    && [ "$subnet_tail" != "$VNET_SUBNET_ID" ] \
+    && [ "$resource_group_tail" != "$VNET_SUBNET_ID" ] \
+    || die "AKS returned an invalid VNET subnet resource ID"
+
+  if ! VNET_INFO="$(az network vnet show --resource-group "$VNET_RG" \
+    --name "$VNET_NAME" -o json)"; then
+    die "could not collect VNET information"
+  fi
+  if ! SUBNETS="$(az network vnet subnet list --resource-group "$VNET_RG" \
+    --vnet-name "$VNET_NAME" -o json)"; then
+    die "could not collect subnet information"
+  fi
+  if ! NODE_SUBNET="$(az network vnet subnet show --resource-group "$VNET_RG" \
+    --vnet-name "$VNET_NAME" --name "$SUBNET_NAME" \
+    --query '{name:name,addressPrefix:addressPrefix,udr:routeTable,nsg:networkSecurityGroup,delegations:delegations,serviceEndpoints:serviceEndpoints,privateEndpointNetworkPolicies:privateEndpointNetworkPolicies}' \
+    -o json)"; then
+    die "could not collect the cluster subnet details"
+  fi
+  if ! PEERINGS="$(az network vnet peering list --resource-group "$VNET_RG" \
+    --vnet-name "$VNET_NAME" -o json)"; then
+    die "could not collect VNET peerings"
+  fi
+
+  update_json ".vnet = \$value" "$VNET_INFO"
+  update_json ".subnets = \$value" "$SUBNETS"
+  update_json ".nodeSubnet = \$value" "$NODE_SUBNET"
+  update_json ".vnetPeerings = \$value" "$PEERINGS"
+fi
+
+if ! NSGS="$(az network nsg list --resource-group "$NODE_RESOURCE_GROUP" -o json)"; then
+  die "could not collect network security groups"
+fi
+if ! ROUTE_TABLES="$(az network route-table list --resource-group "$NODE_RESOURCE_GROUP" -o json)"; then
+  die "could not collect route tables"
+fi
+if ! LOAD_BALANCERS="$(az network lb list --resource-group "$NODE_RESOURCE_GROUP" -o json)"; then
+  die "could not collect load balancers"
+fi
+if ! PUBLIC_IPS="$(az network public-ip list --resource-group "$NODE_RESOURCE_GROUP" -o json)"; then
+  die "could not collect public IPs"
+fi
+if ! PRIVATE_DNS_ZONES="$(az network private-dns zone list -o json)"; then
+  die "could not collect private DNS zones"
+fi
+
+update_json ".nsgs = \$value" "$NSGS"
+update_json ".routeTables = \$value" "$ROUTE_TABLES"
+update_json ".loadBalancers = \$value" "$LOAD_BALANCERS"
+update_json ".publicIPs = \$value" "$PUBLIC_IPS"
+update_json ".privateDnsZones = \$value" "$PRIVATE_DNS_ZONES"
+
+echo "Azure network information saved to: $OUTPUT_FILE"
+jq -r '
+  "Cluster: \(.cluster.name)",
+  "Network Plugin: \(.cluster.networkPlugin)",
+  "Network Policy: \(.cluster.networkPolicy)",
+  "NSGs: \(.nsgs | length)",
+  "Route Tables: \(.routeTables | length)",
+  "Load Balancers: \(.loadBalancers | length)",
+  "Public IPs: \(.publicIPs | length)",
+  "VNET Peerings: \(.vnetPeerings | length)",
+  "Private DNS Zones: \(.privateDnsZones | length)"
+' "$OUTPUT_FILE"

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/create-capture.ps1
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/create-capture.ps1
@@ -1,0 +1,326 @@
+# Create bounded packet-capture Jobs on selected AKS nodes.
+# Exit codes: 0 = success/help, 1 = execution failure, 2 = usage/argument error.
+[CmdletBinding()]
+param(
+    [string]$Name,
+    [string]$Duration = "60s",
+    [string]$NodeSelector = "kubernetes.io/os=linux",
+    [string]$NodeNames,
+    [string]$PodSelector,
+    [string]$PodNames,
+    [string]$Namespace = "default",
+    [string]$TcpdumpFilter = "",
+    [string]$PacketSize = "0",
+    [switch]$Help
+)
+
+$CaptureImage = "mcr.microsoft.com/containernetworking/retina-shell:v1.2.3@sha256:c7dfe8e0c0dc7fa28e4cfbad04ade270c3051c42a5495488d4d897b49fb3366f"
+$ConfigMapName = "network-capture-scripts"
+$OutputBase = "/var/log/aks-network-captures"
+$CaptureMountPath = "/capture-output"
+$MaxDurationSeconds = 1800
+
+function Write-Usage {
+    @"
+Usage: create-capture.ps1 -Name <capture-name> [options]
+
+Target options:
+  -NodeSelector <key=val>  Node selector (default: kubernetes.io/os=linux)
+  -NodeNames <n1,n2>       Comma-separated node names
+  -PodSelector <key=val>   Pod selector; resolves pods to nodes and IPs
+  -PodNames <p1,p2>        Comma-separated pod names
+  -Namespace <name>        Pod, ConfigMap, and Job namespace
+
+Capture options:
+  -Duration <Ns|Nm|Nh>     Duration (default: 60s; maximum: 1800s)
+  -PacketSize <bytes>      Snapshot length (default: 0, full packet)
+  -TcpdumpFilter <expr>    Plain BPF expression; no flags or metacharacters
+"@
+}
+
+function Stop-Usage {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    [Console]::Error.WriteLine((Write-Usage))
+    exit 2
+}
+
+function Stop-Failure {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    exit 1
+}
+
+function Test-Rfc1123Label {
+    param([string]$Value)
+    return $Value.Length -le 63 -and
+        $Value -cmatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+}
+
+function Test-DnsSubdomain {
+    param([string]$Value)
+    return $Value.Length -le 253 -and
+        $Value -cmatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+}
+
+function Invoke-KubectlText {
+    param([string[]]$KubectlArguments, [string]$FailureMessage)
+    $output = (& kubectl @KubectlArguments 2>&1) -join "`n"
+    if ($LASTEXITCODE -ne 0) {
+        Stop-Failure "$FailureMessage`n$output"
+    }
+    return $output.Trim()
+}
+
+if ($Help) {
+    Write-Usage
+    exit 0
+}
+if ([string]::IsNullOrWhiteSpace($Name)) {
+    Stop-Usage "-Name is required"
+}
+if (-not (Test-Rfc1123Label $Name)) {
+    Stop-Usage "-Name must be an RFC 1123 label"
+}
+if (-not (Test-Rfc1123Label $Namespace)) {
+    Stop-Usage "-Namespace must be an RFC 1123 label"
+}
+if ($Duration -cnotmatch "^([0-9]+)([smh])$") {
+    Stop-Usage "-Duration must look like 30s, 5m, or 1h"
+}
+$durationNumber = [int64]$Matches[1]
+$durationSeconds = switch ($Matches[2]) {
+    "s" { $durationNumber }
+    "m" { $durationNumber * 60 }
+    "h" { $durationNumber * 3600 }
+}
+if ($durationSeconds -lt 1 -or $durationSeconds -gt $MaxDurationSeconds) {
+    Stop-Usage "-Duration must be between 1s and ${MaxDurationSeconds}s"
+}
+if ($PacketSize -notmatch "^[0-9]+$") {
+    Stop-Usage "-PacketSize must be a non-negative integer"
+}
+$packetSizeValue = [int64]$PacketSize
+if ($packetSizeValue -gt 262144) {
+    Stop-Usage "-PacketSize exceeds 262144 bytes"
+}
+if ($NodeSelector -notmatch "^[A-Za-z0-9._/=,!()-]+$") {
+    Stop-Usage "-NodeSelector has invalid characters"
+}
+if ($PodSelector -and $PodSelector -notmatch "^[A-Za-z0-9._/=,!()-]+$") {
+    Stop-Usage "-PodSelector has invalid characters"
+}
+if ($TcpdumpFilter.Length -gt 1024 -or $TcpdumpFilter -match "[`r`n]") {
+    Stop-Usage "-TcpdumpFilter must be one line and no more than 1024 characters"
+}
+if ($TcpdumpFilter -and $TcpdumpFilter -notmatch "^[A-Za-z0-9 ._:/()&|<>=!-]+$") {
+    Stop-Usage "-TcpdumpFilter contains disallowed characters"
+}
+foreach ($token in ($TcpdumpFilter -split "\s+")) {
+    if ($token.StartsWith("-")) {
+        Stop-Usage "-TcpdumpFilter may not contain flag tokens"
+    }
+}
+
+$selectionCount = 0
+foreach ($selection in @($NodeNames, $PodSelector, $PodNames)) {
+    if (-not [string]::IsNullOrWhiteSpace($selection)) {
+        $selectionCount++
+    }
+}
+if ($selectionCount -gt 1) {
+    Stop-Usage "choose only one of -NodeNames, -PodSelector, or -PodNames"
+}
+if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+    Stop-Failure "kubectl is not installed or not on PATH"
+}
+
+$deployedRunner = Invoke-KubectlText -KubectlArguments @(
+    "get", "configmap", $ConfigMapName, "-n", $Namespace,
+    "-o", "go-template={{ index .data `"run-capture.sh`" }}"
+) -FailureMessage "ConfigMap '$ConfigMapName' was not found; run setup-capture-configmap first"
+$runnerPath = Join-Path $PSScriptRoot "run-capture.sh"
+try {
+    $localRunner = Get-Content -LiteralPath $runnerPath -Raw -ErrorAction Stop
+} catch {
+    Stop-Failure "could not read the local capture runner: $($_.Exception.Message)"
+}
+if ($deployedRunner.TrimEnd("`r", "`n") -ne $localRunner.TrimEnd("`r", "`n")) {
+    Stop-Failure "ConfigMap '$ConfigMapName' is stale; run setup-capture-configmap again"
+}
+
+$targetNodes = New-Object System.Collections.Generic.List[string]
+$podIpTerms = New-Object System.Collections.Generic.List[string]
+$podJsonPath = '{range .items[*]}{.metadata.name}{"|"}{.spec.nodeName}{"|"}{range .status.podIPs[*]}{.ip}{","}{end}{"\n"}{end}'
+
+if ($PodNames -or $PodSelector) {
+    if ($PodNames) {
+        $pods = @($PodNames.Split(","))
+        foreach ($pod in $pods) {
+            if (-not (Test-Rfc1123Label $pod)) {
+                Stop-Usage "pod name '$pod' is not an RFC 1123 label"
+            }
+        }
+        $podOutput = Invoke-KubectlText -KubectlArguments (@(
+            "get", "pods", "-n", $Namespace
+        ) + $pods + @("-o", "jsonpath=$podJsonPath")) -FailureMessage "could not resolve the selected pods"
+    } else {
+        $podOutput = Invoke-KubectlText -KubectlArguments @(
+            "get", "pods", "-n", $Namespace, "-l", $PodSelector,
+            "-o", "jsonpath=$podJsonPath"
+        ) -FailureMessage "could not resolve the pod selector"
+    }
+
+    foreach ($record in @($podOutput -split "`n")) {
+        if ([string]::IsNullOrWhiteSpace($record)) {
+            continue
+        }
+        $parts = $record.TrimEnd("`r").Split("|")
+        if ($parts.Count -ne 3 -or [string]::IsNullOrWhiteSpace($parts[1])) {
+            Stop-Failure "Kubernetes returned an invalid pod placement record"
+        }
+        $targetNodes.Add($parts[1])
+        $ips = @($parts[2].Split(",") | Where-Object { $_ })
+        if ($ips.Count -eq 0) {
+            Stop-Failure "selected pod '$($parts[0])' has no assigned IP"
+        }
+        foreach ($ip in $ips) {
+            if ($ip -notmatch "^[A-Fa-f0-9.:]+$") {
+                Stop-Failure "selected pod '$($parts[0])' returned an invalid IP"
+            }
+            $podIpTerms.Add("host $ip")
+        }
+    }
+} elseif ($NodeNames) {
+    foreach ($node in $NodeNames.Split(",")) {
+        $targetNodes.Add($node)
+    }
+} else {
+    $nodeOutput = Invoke-KubectlText -KubectlArguments @(
+        "get", "nodes", "-l", $NodeSelector,
+        "-o", 'jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}'
+    ) -FailureMessage "could not resolve the node selector"
+    foreach ($node in @($nodeOutput -split "`n")) {
+        if (-not [string]::IsNullOrWhiteSpace($node)) {
+            $targetNodes.Add($node.TrimEnd("`r"))
+        }
+    }
+}
+if ($targetNodes.Count -eq 0) {
+    Stop-Failure "no nodes matched the selection"
+}
+
+$uniqueNodes = New-Object System.Collections.Generic.List[string]
+foreach ($node in $targetNodes) {
+    if (-not (Test-DnsSubdomain $node)) {
+        Stop-Usage "node name '$node' is invalid"
+    }
+    if (-not $uniqueNodes.Contains($node)) {
+        $uniqueNodes.Add($node)
+    }
+}
+
+$effectiveFilter = $TcpdumpFilter
+if ($podIpTerms.Count -gt 0) {
+    $podFilter = "(" + ($podIpTerms -join " or ") + ")"
+    $effectiveFilter = if ($effectiveFilter) {
+        "($effectiveFilter) and $podFilter"
+    } else {
+        $podFilter
+    }
+}
+
+$randomBytes = New-Object byte[] 12
+$rng = New-Object System.Security.Cryptography.RNGCryptoServiceProvider
+try {
+    $rng.GetBytes($randomBytes)
+} finally {
+    $rng.Dispose()
+}
+$runToken = -join ($randomBytes | ForEach-Object { $_.ToString("x2") })
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMdd-HHmmss")
+$runId = "$timestamp-$runToken"
+$captureOutputPath = "$OutputBase/$Name/$runId"
+$createdJobs = New-Object System.Collections.Generic.List[string]
+
+function Remove-PartialJobs {
+    if ($createdJobs.Count -eq 0) {
+        return $true
+    }
+    & kubectl delete jobs -n $Namespace @($createdJobs) --ignore-not-found | Out-Null
+    return $LASTEXITCODE -eq 0
+}
+
+Write-Output "Creating capture '$Name' on $($uniqueNodes.Count) node(s)"
+foreach ($node in $uniqueNodes) {
+    $nodeSlug = (($node -replace "[._]", "-").Substring(0, [Math]::Min(40, $node.Length))).TrimEnd("-")
+    $captureSlug = $Name.Substring(0, [Math]::Min(15, $Name.Length)).TrimEnd("-")
+    $nodePrefix = $nodeSlug.Substring(0, [Math]::Min(8, $nodeSlug.Length)).TrimEnd("-")
+    $jobPrefix = "$captureSlug-$nodePrefix-$runToken-"
+    $jobYaml = @"
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: $jobPrefix
+  namespace: $Namespace
+  labels: { app: aks-network-capture, capture-id: "$Name", capture-node: "$nodeSlug", capture-run: "$runId" }
+spec:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels: { app: aks-network-capture, capture-id: "$Name", capture-run: "$runId" }
+    spec:
+      hostNetwork: true
+      nodeName: "$node"
+      restartPolicy: Never
+      terminationGracePeriodSeconds: $MaxDurationSeconds
+      containers:
+      - name: capture
+        image: "$CaptureImage"
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 0
+          capabilities:
+            drop: ["ALL"]
+            add: ["NET_ADMIN", "NET_RAW"]
+        env:
+        - { name: PCAP_FILTER, value: "$effectiveFilter" }
+        - { name: CAPTURE_DURATION, value: "$durationSeconds" }
+        - { name: PACKET_SIZE, value: "$packetSizeValue" }
+        - { name: OUT_DIR, value: "$CaptureMountPath" }
+        - { name: CAPTURE_ID, value: "$Name" }
+        - { name: RUN_ID, value: "$runId" }
+        - { name: NODE_NAME, valueFrom: { fieldRef: { fieldPath: spec.nodeName } } }
+        command: ["/bin/sh", "/capture-scripts/run-capture.sh"]
+        volumeMounts:
+        - { name: capture-output, mountPath: "$CaptureMountPath" }
+        - { name: capture-scripts, mountPath: /capture-scripts, readOnly: true }
+      volumes:
+      - name: capture-output
+        hostPath: { path: "$captureOutputPath", type: DirectoryOrCreate }
+      - name: capture-scripts
+        configMap:
+          name: $ConfigMapName
+          defaultMode: 0555
+"@
+    $createdJobOutput = ($jobYaml | & kubectl create -f - -o 'jsonpath={.metadata.name}' 2>&1) -join "`n"
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($createdJobOutput)) {
+        $cleanupSucceeded = Remove-PartialJobs
+        if (-not $cleanupSucceeded) {
+            Stop-Failure "failed to create a Job for '$node' and failed to remove partial Jobs"
+        }
+        Stop-Failure "failed to create a capture Job for '$node': $createdJobOutput"
+    }
+    $createdJobs.Add($createdJobOutput.Trim())
+    Write-Output "Job created for node: $node ($($createdJobOutput.Trim()))"
+}
+
+Write-Output ""
+Write-Output "Capture started."
+Write-Output "Run ID: $runId"
+Write-Output "Monitor: kubectl get jobs -n $Namespace -l capture-id=$Name -w"
+Write-Output "Retrieve: ./scripts/retrieve-captures.ps1 -Name $Name -RunId $runId -Namespace $Namespace"
+Write-Output "Bundles: $captureOutputPath"

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/create-capture.sh
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/create-capture.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# Create bounded packet-capture Jobs on selected AKS nodes.
+# Exit codes: 0 = success/help, 1 = execution failure, 2 = usage/argument error.
+set -euo pipefail
+
+CAPTURE_IMAGE="mcr.microsoft.com/containernetworking/retina-shell:v1.2.3@sha256:c7dfe8e0c0dc7fa28e4cfbad04ade270c3051c42a5495488d4d897b49fb3366f"
+CONFIGMAP_NAME="network-capture-scripts"
+OUTPUT_BASE="/var/log/aks-network-captures"
+CAPTURE_MOUNT_PATH="/capture-output"
+MAX_DURATION_SECONDS=1800
+
+CAPTURE_NAME=""
+DURATION="60s"
+NODE_SELECTOR="kubernetes.io/os=linux"
+NODE_NAMES=""
+POD_SELECTOR=""
+POD_NAMES=""
+POD_SELECTOR_SET=0
+POD_NAMES_SET=0
+NAMESPACE="default"
+TCPDUMP_FILTER=""
+PACKET_SIZE="0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat <<EOF
+Usage: $0 --name <capture-name> [options]
+
+Required:
+  --name <string>              Capture name (RFC 1123 label)
+
+Target selection:
+  --node-selector <key=val>    Node selector (default: kubernetes.io/os=linux)
+  --node-names <n1,n2>         Comma-separated node names
+  --pod-selector <key=val>     Pod selector; resolves pods to nodes and IPs
+  --pod-names <p1,p2>          Comma-separated pod names
+  --namespace <string>         Pod, ConfigMap, and Job namespace (default: default)
+
+Capture configuration:
+  --duration <Ns|Nm|Nh>        Duration (default: 60s; maximum: 1800s)
+  --packet-size <bytes>        Snapshot length (default: 0, full packet)
+  --tcpdump-filter <expr>      Plain BPF expression; no flags or metacharacters
+  -h, --help                   Show this help
+EOF
+}
+
+usage_error() {
+  echo "Error: $*" >&2
+  usage >&2
+  exit 2
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_value() {
+  [ "$#" -ge 2 ] && [ -n "$2" ] || usage_error "$1 requires a value"
+}
+
+valid_single_line() {
+  case "$1" in
+    *$'\r'*|*$'\n'*) return 1 ;;
+  esac
+}
+
+valid_rfc1123() {
+  valid_single_line "$1" && [ "${#1}" -le 63 ] \
+    && printf '%s' "$1" | grep -Eq '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+}
+
+valid_node_name() {
+  valid_single_line "$1" && [ "${#1}" -le 253 ] \
+    && printf '%s' "$1" \
+      | grep -Eq '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+}
+
+valid_label_selector() {
+  valid_single_line "$1" \
+    && printf '%s' "$1" | grep -Eq '^[A-Za-z0-9._/=,!()-]+$'
+}
+
+valid_duration() {
+  valid_single_line "$1" && printf '%s' "$1" | grep -Eq '^[0-9]+[smh]$'
+}
+
+valid_uint() {
+  valid_single_line "$1" && printf '%s' "$1" | grep -Eq '^[0-9]+$'
+}
+
+duration_to_seconds() {
+  local duration="$1"
+  local number="${duration%[smh]}"
+  local unit="${duration##*[0-9]}"
+  number=$((10#$number))
+  case "$unit" in
+    s) printf '%s\n' "$number" ;;
+    m) printf '%s\n' "$((number * 60))" ;;
+    h) printf '%s\n' "$((number * 3600))" ;;
+  esac
+}
+
+validate_filter() {
+  local filter="$1"
+  local token
+  [ -z "$filter" ] && return 0
+  [ "${#filter}" -le 1024 ] || usage_error "--tcpdump-filter exceeds 1024 characters"
+  valid_single_line "$filter" || usage_error "--tcpdump-filter must be a single line"
+  printf '%s' "$filter" | grep -Eq '^[A-Za-z0-9 ._:/()&|<>=!-]+$' \
+    || usage_error "--tcpdump-filter contains disallowed characters"
+  for token in $filter; do
+    case "$token" in
+      -*) usage_error "--tcpdump-filter may not contain flag tokens" ;;
+    esac
+  done
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name)
+      require_value "$@"; CAPTURE_NAME="$2"; shift 2 ;;
+    --duration)
+      require_value "$@"; DURATION="$2"; shift 2 ;;
+    --node-selector)
+      require_value "$@"; NODE_SELECTOR="$2"; shift 2 ;;
+    --node-names)
+      require_value "$@"; NODE_NAMES="$2"; shift 2 ;;
+    --pod-selector)
+      require_value "$@"; POD_SELECTOR_SET=1; POD_SELECTOR="$2"; shift 2 ;;
+    --pod-names)
+      require_value "$@"; POD_NAMES_SET=1; POD_NAMES="$2"; shift 2 ;;
+    --namespace)
+      require_value "$@"; NAMESPACE="$2"; shift 2 ;;
+    --tcpdump-filter)
+      require_value "$@"; TCPDUMP_FILTER="$2"; shift 2 ;;
+    --packet-size)
+      require_value "$@"; PACKET_SIZE="$2"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      usage_error "unknown option: $1" ;;
+  esac
+done
+
+[ -n "$CAPTURE_NAME" ] || usage_error "--name is required"
+valid_rfc1123 "$CAPTURE_NAME" || usage_error "--name must be an RFC 1123 label"
+valid_duration "$DURATION" || usage_error "--duration must look like 30s, 5m, or 1h"
+DURATION_SECONDS="$(duration_to_seconds "$DURATION")"
+[ "$DURATION_SECONDS" -ge 1 ] && [ "$DURATION_SECONDS" -le "$MAX_DURATION_SECONDS" ] \
+  || usage_error "--duration must be between 1s and ${MAX_DURATION_SECONDS}s"
+valid_uint "$PACKET_SIZE" || usage_error "--packet-size must be a non-negative integer"
+[ "$PACKET_SIZE" -le 262144 ] || usage_error "--packet-size exceeds 262144 bytes"
+valid_label_selector "$NODE_SELECTOR" || usage_error "--node-selector has invalid characters"
+[ "$POD_SELECTOR_SET" -eq 0 ] || valid_label_selector "$POD_SELECTOR" \
+  || usage_error "--pod-selector has invalid characters"
+[ "$POD_NAMES_SET" -eq 0 ] || [ -n "$POD_NAMES" ] \
+  || usage_error "--pod-names must not be empty"
+valid_rfc1123 "$NAMESPACE" || usage_error "--namespace must be an RFC 1123 label"
+validate_filter "$TCPDUMP_FILTER"
+
+selection_count=0
+[ -n "$NODE_NAMES" ] && selection_count=$((selection_count + 1))
+[ "$POD_SELECTOR_SET" -eq 1 ] && selection_count=$((selection_count + 1))
+[ "$POD_NAMES_SET" -eq 1 ] && selection_count=$((selection_count + 1))
+[ "$selection_count" -le 1 ] \
+  || usage_error "choose only one of --node-names, --pod-selector, or --pod-names"
+
+command -v kubectl >/dev/null 2>&1 || die "kubectl is not installed or not on PATH"
+command -v od >/dev/null 2>&1 || die "od is not installed or not on PATH"
+
+if ! DEPLOYED_RUNNER="$(kubectl get configmap "$CONFIGMAP_NAME" -n "$NAMESPACE" \
+  -o go-template='{{ index .data "run-capture.sh" }}')"; then
+  die "ConfigMap '$CONFIGMAP_NAME' was not found; run setup-capture-configmap first"
+fi
+if ! LOCAL_RUNNER="$(cat "${SCRIPT_DIR}/run-capture.sh")"; then
+  die "could not read the local capture runner"
+fi
+[ -n "$DEPLOYED_RUNNER" ] && [ "$DEPLOYED_RUNNER" = "$LOCAL_RUNNER" ] \
+  || die "ConfigMap '$CONFIGMAP_NAME' is stale; run setup-capture-configmap again"
+
+POD_IP_FILTER=""
+TARGET_NODES=()
+
+resolve_pod_targets() {
+  local jsonpath
+  local output
+  local pod
+  local node
+  local ip_list
+  local ip
+  local ip_count
+  local ips=""
+  local pods=()
+  jsonpath='{range .items[*]}{.metadata.name}{"|"}{.spec.nodeName}{"|"}{range .status.podIPs[*]}{.ip}{","}{end}{"\n"}{end}'
+
+  if [ "$POD_NAMES_SET" -eq 1 ]; then
+    IFS=',' read -r -a pods <<<"$POD_NAMES"
+    for pod in "${pods[@]}"; do
+      valid_rfc1123 "$pod" || usage_error "pod name '$pod' is not an RFC 1123 label"
+    done
+    if ! output="$(kubectl get pods -n "$NAMESPACE" "${pods[@]}" -o jsonpath="$jsonpath")"; then
+      die "could not resolve the selected pods"
+    fi
+  else
+    if ! output="$(kubectl get pods -n "$NAMESPACE" -l "$POD_SELECTOR" \
+      -o jsonpath="$jsonpath")"; then
+      die "could not resolve the pod selector"
+    fi
+  fi
+
+  while IFS='|' read -r pod node ip_list; do
+    [ -n "$pod" ] || continue
+    [ -n "$node" ] || die "selected pod '$pod' is not scheduled"
+    [ -n "$ip_list" ] || die "selected pod '$pod' has no assigned IP"
+    TARGET_NODES+=("$node")
+    IFS=',' read -r -a pod_ips <<<"$ip_list"
+    ip_count=0
+    for ip in "${pod_ips[@]}"; do
+      [ -n "$ip" ] || continue
+      case "$ip" in
+        *[!A-Fa-f0-9.:]*) die "pod '$pod' returned an invalid IP address" ;;
+      esac
+      ips="${ips:+$ips or }host $ip"
+      ip_count=$((ip_count + 1))
+    done
+    [ "$ip_count" -gt 0 ] || die "selected pod '$pod' has no assigned IP"
+  done <<<"$output"
+
+  [ "${#TARGET_NODES[@]}" -gt 0 ] || die "no pods matched the selection"
+  POD_IP_FILTER="($ips)"
+}
+
+if [ "$POD_SELECTOR_SET" -eq 1 ] || [ "$POD_NAMES_SET" -eq 1 ]; then
+  resolve_pod_targets
+elif [ -n "$NODE_NAMES" ]; then
+  IFS=',' read -r -a TARGET_NODES <<<"$NODE_NAMES"
+else
+  if ! node_output="$(kubectl get nodes -l "$NODE_SELECTOR" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')"; then
+    die "could not resolve the node selector"
+  fi
+  while IFS= read -r node; do
+    [ -n "$node" ] && TARGET_NODES+=("$node")
+  done <<<"$node_output"
+fi
+
+[ "${#TARGET_NODES[@]}" -gt 0 ] || die "no nodes matched the selection"
+UNIQUE_TARGET_NODES=()
+for node in "${TARGET_NODES[@]}"; do
+  [ -n "$node" ] || die "node selection returned an empty node name"
+  valid_node_name "$node" || usage_error "node name '$node' is invalid"
+  seen=0
+  if [ "${#UNIQUE_TARGET_NODES[@]}" -gt 0 ]; then
+    for existing in "${UNIQUE_TARGET_NODES[@]}"; do
+      if [ "$node" = "$existing" ]; then
+        seen=1
+        break
+      fi
+    done
+  fi
+  [ "$seen" -eq 1 ] || UNIQUE_TARGET_NODES+=("$node")
+done
+TARGET_NODES=("${UNIQUE_TARGET_NODES[@]}")
+
+EFFECTIVE_FILTER="$TCPDUMP_FILTER"
+if [ -n "$POD_IP_FILTER" ]; then
+  if [ -n "$EFFECTIVE_FILTER" ]; then
+    EFFECTIVE_FILTER="($EFFECTIVE_FILTER) and $POD_IP_FILTER"
+  else
+    EFFECTIVE_FILTER="$POD_IP_FILTER"
+  fi
+fi
+
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+if ! RUN_TOKEN="$(LC_ALL=C od -An -N12 -tx1 /dev/urandom | tr -d ' \n')"; then
+  die "failed to generate the capture run identity"
+fi
+[ "${#RUN_TOKEN}" -eq 24 ] || die "failed to generate the capture run identity"
+RUN_ID="${TIMESTAMP}-${RUN_TOKEN}"
+CAPTURE_OUTPUT_PATH="${OUTPUT_BASE}/${CAPTURE_NAME}/${RUN_ID}"
+CREATED_JOBS=()
+
+cleanup_partial_jobs() {
+  local status=$?
+  trap - EXIT
+  if [ "$status" -ne 0 ] && [ "${#CREATED_JOBS[@]}" -gt 0 ]; then
+    echo "Capture creation failed; removing partially created Jobs" >&2
+    if ! kubectl delete jobs -n "$NAMESPACE" "${CREATED_JOBS[@]}" \
+      --ignore-not-found >/dev/null; then
+      echo "Error: failed to remove one or more partially created Jobs" >&2
+      status=1
+    fi
+  fi
+  exit "$status"
+}
+trap cleanup_partial_jobs EXIT
+
+echo "Creating capture '$CAPTURE_NAME' on ${#TARGET_NODES[@]} node(s)"
+for node in "${TARGET_NODES[@]}"; do
+  node_slug="$(printf '%s' "$node" | tr '._' '--' | cut -c1-40 | sed 's/-*$//')"
+  capture_slug="$(printf '%s' "$CAPTURE_NAME" | cut -c1-15 | sed 's/-*$//')"
+  node_prefix="$(printf '%s' "$node_slug" | cut -c1-8 | sed 's/-*$//')"
+  job_prefix="${capture_slug}-${node_prefix}-${RUN_TOKEN}-"
+
+  if ! created_job="$(kubectl create -f - -o jsonpath='{.metadata.name}' <<EOF
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: ${job_prefix}
+  namespace: ${NAMESPACE}
+  labels: { app: aks-network-capture, capture-id: "${CAPTURE_NAME}", capture-node: "${node_slug}", capture-run: "${RUN_ID}" }
+spec:
+  ttlSecondsAfterFinished: 3600
+  backoffLimit: 0
+  template:
+    metadata:
+      labels: { app: aks-network-capture, capture-id: "${CAPTURE_NAME}", capture-run: "${RUN_ID}" }
+    spec:
+      hostNetwork: true
+      nodeName: "${node}"
+      restartPolicy: Never
+      terminationGracePeriodSeconds: ${MAX_DURATION_SECONDS}
+      containers:
+      - name: capture
+        image: "${CAPTURE_IMAGE}"
+        securityContext:
+          privileged: false
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsUser: 0
+          capabilities:
+            drop: ["ALL"]
+            add: ["NET_ADMIN", "NET_RAW"]
+        env:
+        - { name: PCAP_FILTER, value: "${EFFECTIVE_FILTER}" }
+        - { name: CAPTURE_DURATION, value: "${DURATION_SECONDS}" }
+        - { name: PACKET_SIZE, value: "${PACKET_SIZE}" }
+        - { name: OUT_DIR, value: "${CAPTURE_MOUNT_PATH}" }
+        - { name: CAPTURE_ID, value: "${CAPTURE_NAME}" }
+        - { name: RUN_ID, value: "${RUN_ID}" }
+        - { name: NODE_NAME, valueFrom: { fieldRef: { fieldPath: spec.nodeName } } }
+        command: ["/bin/sh", "/capture-scripts/run-capture.sh"]
+        volumeMounts:
+        - { name: capture-output, mountPath: "${CAPTURE_MOUNT_PATH}" }
+        - { name: capture-scripts, mountPath: /capture-scripts, readOnly: true }
+      volumes:
+      - name: capture-output
+        hostPath: { path: "${CAPTURE_OUTPUT_PATH}", type: DirectoryOrCreate }
+      - name: capture-scripts
+        configMap:
+          name: ${CONFIGMAP_NAME}
+          defaultMode: 0555
+EOF
+)"; then
+    die "failed to create a capture Job for node '$node'"
+  fi
+  [ -n "$created_job" ] || die "Kubernetes did not return the created Job name"
+  CREATED_JOBS+=("$created_job")
+  echo "Job created for node: $node ($created_job)"
+done
+
+trap - EXIT
+cat <<EOF
+
+Capture started.
+Run ID: ${RUN_ID}
+Monitor: kubectl get jobs -n ${NAMESPACE} -l capture-id=${CAPTURE_NAME} -w
+Retrieve: ./scripts/retrieve-captures.sh --name ${CAPTURE_NAME} --run-id ${RUN_ID} --namespace ${NAMESPACE}
+Bundles: ${CAPTURE_OUTPUT_PATH}
+EOF

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/generate-test-traffic.ps1
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/generate-test-traffic.ps1
@@ -1,0 +1,144 @@
+# Generate bounded test traffic from a pod network namespace.
+# Exit codes: 0 = success/help, 1 = execution failure, 2 = usage/argument error.
+[CmdletBinding()]
+param(
+    [string]$SourcePod,
+    [string]$Target,
+    [string]$Type = "http",
+    [string]$TargetPort,
+    [string]$SourceNamespace = "default",
+    [string]$Duration = "30s",
+    [string]$Interval = "1",
+    [switch]$Help
+)
+
+$DebugImage = "mcr.microsoft.com/cbl-mariner/busybox:2.0@sha256:e4fb4d51fc9b70d6cdc1ce66a0af02ab40554d2ca632e1d188fabc760e432fdd"
+
+function Write-Usage {
+    @"
+Usage: generate-test-traffic.ps1 -SourcePod <pod> -Target <host> [options]
+
+Options:
+  -Type <type>            http, https, dns, tcp, or ping (default: http)
+  -TargetPort <1-65535>   Target port; required for tcp
+  -SourceNamespace <ns>   Source namespace (default: default)
+  -Duration <Ns|Nm|Nh>    Duration (default: 30s; maximum: 1h)
+  -Interval <seconds>     Whole seconds between attempts (default: 1)
+"@
+}
+
+function Stop-Usage {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    [Console]::Error.WriteLine((Write-Usage))
+    exit 2
+}
+
+function Stop-Failure {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    exit 1
+}
+
+function Test-DnsSubdomain {
+    param([string]$Value)
+    return $Value.Length -le 253 -and
+        $Value -cmatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+}
+
+if ($Help) {
+    Write-Usage
+    exit 0
+}
+if ([string]::IsNullOrWhiteSpace($SourcePod)) {
+    Stop-Usage "-SourcePod is required"
+}
+if ([string]::IsNullOrWhiteSpace($Target)) {
+    Stop-Usage "-Target is required"
+}
+if (-not (Test-DnsSubdomain $SourcePod)) {
+    Stop-Usage "-SourcePod must be a DNS subdomain"
+}
+if (-not (Test-DnsSubdomain $SourceNamespace)) {
+    Stop-Usage "-SourceNamespace must be a DNS subdomain"
+}
+if ($Target.Length -gt 253 -or $Target -notmatch "^[A-Za-z0-9._:-]+$") {
+    Stop-Usage "-Target has invalid characters"
+}
+if ($Duration -cnotmatch "^([0-9]+)([smh])$") {
+    Stop-Usage "-Duration must look like 30s, 5m, or 1h"
+}
+$durationNumber = [int64]$Matches[1]
+$durationSeconds = switch ($Matches[2]) {
+    "s" { $durationNumber }
+    "m" { $durationNumber * 60 }
+    "h" { $durationNumber * 3600 }
+}
+if ($durationSeconds -lt 1 -or $durationSeconds -gt 3600) {
+    Stop-Usage "-Duration must be between 1s and 1h"
+}
+if ($Interval -notmatch "^[0-9]+$") {
+    Stop-Usage "-Interval must be a non-negative integer"
+}
+
+switch -CaseSensitive ($Type) {
+    "dns" { if (-not $TargetPort) { $TargetPort = "53" } }
+    "https" { if (-not $TargetPort) { $TargetPort = "443" } }
+    "http" { if (-not $TargetPort) { $TargetPort = "80" } }
+    "tcp" { if (-not $TargetPort) { Stop-Usage "-TargetPort is required for tcp" } }
+    "ping" { $TargetPort = "0" }
+    default { Stop-Usage "-Type must be one of: http https dns tcp ping" }
+}
+if ($TargetPort -notmatch "^[0-9]+$") {
+    Stop-Usage "-TargetPort must be an integer"
+}
+$targetPortValue = [int64]$TargetPort
+if ($Type -ne "ping" -and ($targetPortValue -lt 1 -or $targetPortValue -gt 65535)) {
+    Stop-Usage "-TargetPort must be between 1 and 65535"
+}
+if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+    Stop-Failure "kubectl is not installed or not on PATH"
+}
+
+$PodScript = @'
+set -u
+target="$1"; port="$2"; duration="$3"; interval="$4"; traffic_type="$5"
+case "$target" in *:*) url_host="[$target]";; *) url_host="$target";; esac
+end=$(( $(date +%s) + duration ))
+while [ "$(date +%s)" -lt "$end" ]; do
+  case "$traffic_type" in
+    http)  wget -q -O /dev/null -T 5 "http://$url_host:$port/" && echo "http ok" || echo "http fail" ;;
+    https) wget -q -O /dev/null -T 5 --no-check-certificate "https://$url_host:$port/" && echo "https ok" || echo "https fail" ;;
+    dns)   nslookup "$target" >/dev/null 2>&1 && echo "dns ok" || echo "dns fail" ;;
+    tcp)   nc -z -w 5 "$target" "$port" && echo "tcp ok" || echo "tcp fail" ;;
+    ping)  ping -c 1 -W 5 "$target" >/dev/null 2>&1 && echo "ping ok" || echo "ping fail" ;;
+  esac
+  [ "$interval" -eq 0 ] || sleep "$interval"
+done
+'@
+
+Write-Output "Generating $Type traffic from $SourcePod to $Target for ${durationSeconds}s"
+& kubectl exec -n $SourceNamespace $SourcePod -- sh -c "exit 0" 2>$null
+$directExecAvailable = $LASTEXITCODE -eq 0
+
+if ($directExecAvailable) {
+    & kubectl exec -n $SourceNamespace $SourcePod -- sh -c $PodScript _ `
+        $Target $targetPortValue $durationSeconds $Interval $Type
+    if ($LASTEXITCODE -ne 0) {
+        Stop-Failure "traffic generation failed in the source pod"
+    }
+} else {
+    $targetContainer = (& kubectl get pod -n $SourceNamespace $SourcePod `
+        -o 'jsonpath={.spec.containers[0].name}' 2>&1) -join "`n"
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($targetContainer)) {
+        Stop-Failure "could not resolve the source pod container: $targetContainer"
+    }
+    & kubectl debug -n $SourceNamespace $SourcePod --image=$DebugImage `
+        --target=$($targetContainer.Trim()) -q -- sh -c $PodScript _ `
+        $Target $targetPortValue $durationSeconds $Interval $Type
+    if ($LASTEXITCODE -ne 0) {
+        Stop-Failure "traffic generation failed in the ephemeral debug container"
+    }
+}
+
+Write-Output "Traffic generation complete"

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/generate-test-traffic.sh
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/generate-test-traffic.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# Generate bounded test traffic from a pod network namespace.
+# Exit codes: 0 = success/help, 1 = execution failure, 2 = usage/argument error.
+set -euo pipefail
+
+DEBUG_IMAGE="mcr.microsoft.com/cbl-mariner/busybox:2.0@sha256:e4fb4d51fc9b70d6cdc1ce66a0af02ab40554d2ca632e1d188fabc760e432fdd"
+
+TRAFFIC_TYPE="http"
+TARGET=""
+TARGET_PORT=""
+SOURCE_POD=""
+SOURCE_NAMESPACE="default"
+DURATION="30s"
+INTERVAL="1"
+
+usage() {
+  cat <<EOF
+Usage: $0 --source-pod <pod> --target <ip-or-hostname> [options]
+
+Required:
+  --source-pod <name>       Source pod
+  --target <host>           Target IP address or hostname
+
+Options:
+  --type <type>             http, https, dns, tcp, or ping (default: http)
+  --target-port <1-65535>   Target port; required for tcp
+  --source-namespace <ns>   Source namespace (default: default)
+  --duration <Ns|Nm|Nh>     Duration (default: 30s; maximum: 1h)
+  --interval <seconds>      Whole seconds between attempts (default: 1)
+  -h, --help                Show this help
+EOF
+}
+
+usage_error() {
+  echo "Error: $*" >&2
+  usage >&2
+  exit 2
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_value() {
+  [ "$#" -ge 2 ] && [ -n "$2" ] || usage_error "$1 requires a value"
+}
+
+valid_single_line() {
+  case "$1" in
+    *$'\r'*|*$'\n'*) return 1 ;;
+  esac
+}
+
+valid_rfc1123() {
+  valid_single_line "$1" && [ "${#1}" -le 253 ] \
+    && printf '%s' "$1" \
+      | grep -Eq '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+}
+
+valid_host() {
+  valid_single_line "$1" && [ "${#1}" -le 253 ] \
+    && printf '%s' "$1" | grep -Eq '^[A-Za-z0-9._:-]+$'
+}
+
+valid_uint() {
+  valid_single_line "$1" && printf '%s' "$1" | grep -Eq '^[0-9]+$'
+}
+
+valid_duration() {
+  valid_single_line "$1" && printf '%s' "$1" | grep -Eq '^[0-9]+[smh]$'
+}
+
+duration_to_seconds() {
+  local duration="$1"
+  local number="${duration%[smh]}"
+  local unit="${duration##*[0-9]}"
+  number=$((10#$number))
+  case "$unit" in
+    s) printf '%s\n' "$number" ;;
+    m) printf '%s\n' "$((number * 60))" ;;
+    h) printf '%s\n' "$((number * 3600))" ;;
+  esac
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --source-pod)
+      require_value "$@"; SOURCE_POD="$2"; shift 2 ;;
+    --source-namespace)
+      require_value "$@"; SOURCE_NAMESPACE="$2"; shift 2 ;;
+    --target)
+      require_value "$@"; TARGET="$2"; shift 2 ;;
+    --target-port)
+      require_value "$@"; TARGET_PORT="$2"; shift 2 ;;
+    --type)
+      require_value "$@"; TRAFFIC_TYPE="$2"; shift 2 ;;
+    --duration)
+      require_value "$@"; DURATION="$2"; shift 2 ;;
+    --interval)
+      require_value "$@"; INTERVAL="$2"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      usage_error "unknown option: $1" ;;
+  esac
+done
+
+[ -n "$SOURCE_POD" ] || usage_error "--source-pod is required"
+[ -n "$TARGET" ] || usage_error "--target is required"
+valid_rfc1123 "$SOURCE_POD" || usage_error "--source-pod must be a DNS subdomain"
+valid_rfc1123 "$SOURCE_NAMESPACE" || usage_error "--source-namespace must be a DNS subdomain"
+valid_host "$TARGET" || usage_error "--target has invalid characters"
+valid_duration "$DURATION" || usage_error "--duration must look like 30s, 5m, or 1h"
+DURATION_SECONDS="$(duration_to_seconds "$DURATION")"
+[ "$DURATION_SECONDS" -ge 1 ] && [ "$DURATION_SECONDS" -le 3600 ] \
+  || usage_error "--duration must be between 1s and 1h"
+valid_uint "$INTERVAL" || usage_error "--interval must be a non-negative integer"
+
+case "$TRAFFIC_TYPE" in
+  dns) TARGET_PORT="${TARGET_PORT:-53}" ;;
+  https) TARGET_PORT="${TARGET_PORT:-443}" ;;
+  http) TARGET_PORT="${TARGET_PORT:-80}" ;;
+  tcp) [ -n "$TARGET_PORT" ] || usage_error "--target-port is required for tcp" ;;
+  ping) TARGET_PORT="0" ;;
+  *) usage_error "--type must be one of: http https dns tcp ping" ;;
+esac
+valid_uint "$TARGET_PORT" || usage_error "--target-port must be an integer"
+if [ "$TRAFFIC_TYPE" != "ping" ]; then
+  [ "$TARGET_PORT" -ge 1 ] && [ "$TARGET_PORT" -le 65535 ] \
+    || usage_error "--target-port must be between 1 and 65535"
+fi
+
+command -v kubectl >/dev/null 2>&1 || die "kubectl is not installed or not on PATH"
+
+# This fixed script must expand only inside the target pod.
+# shellcheck disable=SC2016
+POD_SCRIPT='
+set -u
+target="$1"; port="$2"; duration="$3"; interval="$4"; traffic_type="$5"
+case "$target" in *:*) url_host="[$target]";; *) url_host="$target";; esac
+end=$(( $(date +%s) + duration ))
+while [ "$(date +%s)" -lt "$end" ]; do
+  case "$traffic_type" in
+    http)  wget -q -O /dev/null -T 5 "http://$url_host:$port/" && echo "http ok" || echo "http fail" ;;
+    https) wget -q -O /dev/null -T 5 --no-check-certificate "https://$url_host:$port/" && echo "https ok" || echo "https fail" ;;
+    dns)   nslookup "$target" >/dev/null 2>&1 && echo "dns ok" || echo "dns fail" ;;
+    tcp)   nc -z -w 5 "$target" "$port" && echo "tcp ok" || echo "tcp fail" ;;
+    ping)  ping -c 1 -W 5 "$target" >/dev/null 2>&1 && echo "ping ok" || echo "ping fail" ;;
+  esac
+  [ "$interval" -eq 0 ] || sleep "$interval"
+done
+'
+
+echo "Generating $TRAFFIC_TYPE traffic from $SOURCE_POD to $TARGET for ${DURATION_SECONDS}s"
+if kubectl exec -n "$SOURCE_NAMESPACE" "$SOURCE_POD" -- sh -c 'exit 0' >/dev/null 2>&1; then
+  kubectl exec -n "$SOURCE_NAMESPACE" "$SOURCE_POD" -- \
+    sh -c "$POD_SCRIPT" _ "$TARGET" "$TARGET_PORT" "$DURATION_SECONDS" "$INTERVAL" "$TRAFFIC_TYPE"
+else
+  if ! target_container="$(kubectl get pod -n "$SOURCE_NAMESPACE" "$SOURCE_POD" \
+    -o jsonpath='{.spec.containers[0].name}')"; then
+    die "could not resolve the source pod container"
+  fi
+  [ -n "$target_container" ] || die "source pod has no application container"
+  kubectl debug -n "$SOURCE_NAMESPACE" "$SOURCE_POD" \
+    --image="$DEBUG_IMAGE" --target="$target_container" -q -- \
+    sh -c "$POD_SCRIPT" _ "$TARGET" "$TARGET_PORT" "$DURATION_SECONDS" "$INTERVAL" "$TRAFFIC_TYPE"
+fi
+
+echo "Traffic generation complete"

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/retrieve-captures.ps1
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/retrieve-captures.ps1
@@ -1,0 +1,264 @@
+# Retrieve exact-run capture bundles from nodes and clean up capture resources.
+# Exit codes: 0 = success/help, 1 = retrieval/cleanup failure, 2 = usage/argument error.
+[CmdletBinding()]
+param(
+    [string]$Name,
+    [string]$OutputPath = "/var/log/aks-network-captures",
+    [string]$WorkspaceDir = $(if ($env:WORKSPACE_DIR) {
+        $env:WORKSPACE_DIR
+    } else {
+        Join-Path "." "aks-network-captures"
+    }),
+    [string]$Namespace = "default",
+    [string]$RunId,
+    [switch]$Help
+)
+
+function Write-Usage {
+    @"
+Usage: retrieve-captures.ps1 -Name <capture-name> [options]
+
+Options:
+  -OutputPath <path>      Node hostPath base
+  -WorkspaceDir <path>    Local workspace directory
+  -Namespace <name>       Capture Job namespace (default: default)
+  -RunId <id>             Exact run ID; required when multiple runs exist
+"@
+}
+
+function Stop-Usage {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    [Console]::Error.WriteLine((Write-Usage))
+    exit 2
+}
+
+function Stop-Failure {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    exit 1
+}
+
+function Test-Rfc1123Label {
+    param([string]$Value)
+    return $Value.Length -le 63 -and
+        $Value -cmatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+}
+
+function Test-DnsSubdomain {
+    param([string]$Value)
+    return $Value.Length -le 253 -and
+        $Value -cmatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+}
+
+function Test-RunId {
+    param([string]$Value)
+    return $Value -cmatch "^[0-9]{8}-[0-9]{6}-[0-9a-f]{24}$"
+}
+
+function Invoke-KubectlChecked {
+    param([string[]]$KubectlArguments, [string]$FailureMessage)
+    $output = (& kubectl @KubectlArguments 2>&1) -join "`n"
+    if ($LASTEXITCODE -ne 0) {
+        throw "$FailureMessage`n$output"
+    }
+    return $output.Trim()
+}
+
+if ($Help) {
+    Write-Usage
+    exit 0
+}
+if ([string]::IsNullOrWhiteSpace($Name)) {
+    Stop-Usage "-Name is required"
+}
+if (-not (Test-Rfc1123Label $Name)) {
+    Stop-Usage "-Name must be an RFC 1123 label"
+}
+if (-not (Test-Rfc1123Label $Namespace)) {
+    Stop-Usage "-Namespace must be an RFC 1123 label"
+}
+if ($OutputPath -notmatch "^/[A-Za-z0-9/_.-]+$" -or $OutputPath.Contains("..")) {
+    Stop-Usage "-OutputPath must be absolute and contain only letters, digits, '/', '_', '.', or '-'"
+}
+if ([string]::IsNullOrWhiteSpace($WorkspaceDir) -or $WorkspaceDir -match "[`r`n]") {
+    Stop-Usage "-WorkspaceDir must be a non-empty single-line path"
+}
+if ($RunId -and -not (Test-RunId $RunId)) {
+    Stop-Usage "-RunId has an invalid format"
+}
+if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+    Stop-Failure "kubectl is not installed or not on PATH"
+}
+
+try {
+    if (-not $RunId) {
+        $runsOutput = Invoke-KubectlChecked -KubectlArguments @(
+            "get", "jobs", "-n", $Namespace, "-l", "capture-id=$Name",
+            "-o", 'jsonpath={range .items[*]}{.metadata.labels.capture-run}{"\n"}{end}'
+        ) -FailureMessage "could not list capture runs"
+        $runs = @($runsOutput -split "`n" |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ } |
+            Sort-Object -Unique)
+        if ($runs.Count -eq 0) {
+            throw "no capture runs found for '$Name'"
+        }
+        if ($runs.Count -gt 1) {
+            throw "multiple capture runs found; specify -RunId"
+        }
+        $RunId = $runs[0]
+    }
+    if (-not (Test-RunId $RunId)) {
+        throw "Kubernetes returned an invalid capture run identity"
+    }
+
+    $jobsOutput = Invoke-KubectlChecked -KubectlArguments @(
+        "get", "jobs", "-n", $Namespace,
+        "-l", "capture-id=$Name,capture-run=$RunId",
+        "-o", "jsonpath={.items[*].metadata.name}"
+    ) -FailureMessage "could not list capture Jobs"
+    $captureJobs = @($jobsOutput -split "\s+" | Where-Object { $_ })
+    if ($captureJobs.Count -eq 0) {
+        throw "no Jobs found for the requested capture run"
+    }
+} catch {
+    Stop-Failure $_.Exception.Message
+}
+
+$timestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMdd-HHmmss")
+$captureOutputDir = Join-Path (Join-Path $WorkspaceDir "network-captures") "$Name-$RunId-$timestamp"
+try {
+    New-Item -ItemType Directory -Path $captureOutputDir -Force -ErrorAction Stop | Out-Null
+} catch {
+    Stop-Failure "could not create the local capture directory: $($_.Exception.Message)"
+}
+
+$tempPods = New-Object System.Collections.Generic.List[string]
+$operationError = $null
+$cleanupErrors = New-Object System.Collections.Generic.List[string]
+
+try {
+    foreach ($job in $captureJobs) {
+        $nodeName = Invoke-KubectlChecked -KubectlArguments @(
+            "get", "job", $job, "-n", $Namespace,
+            "-o", "jsonpath={.spec.template.spec.nodeName}"
+        ) -FailureMessage "could not read the node for Job '$job'"
+        $jobRunId = Invoke-KubectlChecked -KubectlArguments @(
+            "get", "job", $job, "-n", $Namespace,
+            "-o", 'jsonpath={.spec.template.spec.containers[0].env[?(@.name=="RUN_ID")].value}'
+        ) -FailureMessage "could not read the run identity for Job '$job'"
+        if (-not (Test-DnsSubdomain $nodeName)) {
+            throw "Job '$job' returned an invalid node name"
+        }
+        if (-not (Test-RunId $jobRunId) -or $jobRunId -ne $RunId) {
+            throw "Job '$job' does not match the requested run"
+        }
+
+        $podName = Invoke-KubectlChecked -KubectlArguments @(
+            "get", "pods", "-n", $Namespace, "-l", "job-name=$job",
+            "-o", "jsonpath={.items[0].metadata.name}"
+        ) -FailureMessage "could not find the capture pod for Job '$job'"
+        if ([string]::IsNullOrWhiteSpace($podName)) {
+            throw "no capture pod found for Job '$job'"
+        }
+        $podStatus = Invoke-KubectlChecked -KubectlArguments @(
+            "get", "pod", $podName, "-n", $Namespace,
+            "-o", "jsonpath={.status.phase}"
+        ) -FailureMessage "could not read capture pod status"
+        if ($podStatus -ne "Succeeded") {
+            throw "capture pod '$podName' did not succeed; inspect its logs before retrying"
+        }
+
+        $captureSlug = $Name.Substring(0, [Math]::Min(20, $Name.Length))
+        $normalizedNode = $nodeName -replace "[._]", "-"
+        $nodeSlug = $normalizedNode.Substring(0, [Math]::Min(20, $normalizedNode.Length))
+        $retrievalYaml = @"
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: retrieve-$captureSlug-$nodeSlug-
+  namespace: $Namespace
+  labels: { app: aks-network-capture, capture-id: "$Name", role: retrieval }
+spec:
+  hostNetwork: true
+  nodeName: "$nodeName"
+  restartPolicy: Never
+  containers:
+  - name: retrieve
+    image: mcr.microsoft.com/cbl-mariner/busybox:2.0@sha256:e4fb4d51fc9b70d6cdc1ce66a0af02ab40554d2ca632e1d188fabc760e432fdd
+    command: ["sh", "-c", "sleep 300"]
+    volumeMounts:
+    - name: capture-output
+      mountPath: /capture-root
+  volumes:
+  - name: capture-output
+    hostPath:
+      path: $OutputPath/$Name
+      type: Directory
+"@
+        $tempPodName = ($retrievalYaml |
+            & kubectl create -f - -o "jsonpath={.metadata.name}" 2>&1) -join "`n"
+        if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($tempPodName)) {
+            throw "failed to create a retrieval pod on '$nodeName': $tempPodName"
+        }
+        $tempPodName = $tempPodName.Trim()
+        $tempPods.Add($tempPodName)
+
+        & kubectl wait -n $Namespace --for=condition=Ready `
+            "pod/$tempPodName" --timeout=60s
+        if ($LASTEXITCODE -ne 0) {
+            throw "retrieval pod '$tempPodName' did not become ready"
+        }
+
+        $bundleName = "capture-$Name-$nodeName-$jobRunId.tar.gz"
+        $runDir = "/capture-root/$jobRunId"
+        $localBundle = Join-Path $captureOutputDir $bundleName
+        & kubectl cp -n $Namespace "${tempPodName}:${runDir}/${bundleName}" `
+            $localBundle -c retrieve
+        if ($LASTEXITCODE -ne 0) {
+            throw "failed to copy '$bundleName' from node '$nodeName'"
+        }
+        if (-not (Test-Path -LiteralPath $localBundle -PathType Leaf) -or
+            (Get-Item -LiteralPath $localBundle).Length -eq 0) {
+            throw "the copied capture bundle '$bundleName' is empty"
+        }
+
+        & kubectl exec -n $Namespace $tempPodName -c retrieve -- sh -c `
+            'rm -f "$1/$2" "$1/$3" && rmdir "$1"' sh `
+            $runDir $bundleName "capture-$Name-$nodeName-$jobRunId.pcap"
+        if ($LASTEXITCODE -ne 0) {
+            throw "failed to remove the retrieved node artifacts"
+        }
+        & kubectl delete pod $tempPodName -n $Namespace --ignore-not-found
+        if ($LASTEXITCODE -ne 0) {
+            throw "failed to delete retrieval pod '$tempPodName'"
+        }
+    }
+} catch {
+    $operationError = $_.Exception.Message
+} finally {
+    foreach ($tempPod in $tempPods) {
+        & kubectl delete pod $tempPod -n $Namespace --ignore-not-found 2>$null | Out-Null
+        if ($LASTEXITCODE -ne 0) {
+            $cleanupErrors.Add("failed to delete retrieval pod '$tempPod'")
+        }
+    }
+    & kubectl delete jobs -n $Namespace @($captureJobs) --ignore-not-found 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        $cleanupErrors.Add("failed to delete capture Jobs")
+    }
+}
+
+if ($operationError) {
+    if ($cleanupErrors.Count -gt 0) {
+        Stop-Failure "$operationError; cleanup also failed: $($cleanupErrors -join '; ')"
+    }
+    Stop-Failure $operationError
+}
+if ($cleanupErrors.Count -gt 0) {
+    Stop-Failure ($cleanupErrors -join "; ")
+}
+
+Write-Output "Capture bundles saved to: $captureOutputDir"
+Get-ChildItem -LiteralPath $captureOutputDir

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/retrieve-captures.sh
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/retrieve-captures.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+# Retrieve exact-run capture bundles from nodes and clean up capture resources.
+# Exit codes: 0 = success/help, 1 = retrieval/cleanup failure, 2 = usage/argument error.
+set -euo pipefail
+
+CAPTURE_NAME=""
+OUTPUT_PATH="/var/log/aks-network-captures"
+WORKSPACE_DIR="${WORKSPACE_DIR:-./aks-network-captures}"
+NAMESPACE="default"
+RETRIEVE_RUN_ID=""
+
+usage() {
+  cat <<EOF
+Usage: $0 --name <capture-name> [options]
+
+Required:
+  --name <string>          Capture name used during creation
+
+Options:
+  --output-path <path>     Node hostPath base (default: ${OUTPUT_PATH})
+  --workspace-dir <path>   Local workspace directory (default: ${WORKSPACE_DIR})
+  --namespace <string>     Capture Job namespace (default: default)
+  --run-id <string>        Exact run ID; required when multiple runs exist
+  -h, --help               Show this help
+EOF
+}
+
+usage_error() {
+  echo "Error: $*" >&2
+  usage >&2
+  exit 2
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+require_value() {
+  [ "$#" -ge 2 ] && [ -n "$2" ] || usage_error "$1 requires a value"
+}
+
+valid_single_line() {
+  case "$1" in
+    *$'\r'*|*$'\n'*) return 1 ;;
+  esac
+}
+
+valid_rfc1123() {
+  valid_single_line "$1" && [ "${#1}" -le 63 ] \
+    && printf '%s' "$1" | grep -Eq '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'
+}
+
+valid_node_name() {
+  valid_single_line "$1" && [ "${#1}" -le 253 ] \
+    && printf '%s' "$1" \
+      | grep -Eq '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$'
+}
+
+valid_hostpath() {
+  case "$1" in
+    /*) ;;
+    *) return 1 ;;
+  esac
+  case "$1" in
+    *..*|*[!A-Za-z0-9/_.-]*) return 1 ;;
+  esac
+}
+
+valid_run_id() {
+  local run_date="${1%%-*}"
+  local remainder="${1#*-}"
+  local run_time="${remainder%%-*}"
+  local run_token="${remainder#*-}"
+  case "$1" in
+    *[!0-9a-f-]*) return 1 ;;
+  esac
+  [ "${#run_date}" -eq 8 ] && [ "${#run_time}" -eq 6 ] \
+    && [ "${#run_token}" -eq 24 ] || return 1
+  case "${run_date}${run_time}${run_token}" in
+    *[!0-9a-f]*) return 1 ;;
+  esac
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --name)
+      require_value "$@"; CAPTURE_NAME="$2"; shift 2 ;;
+    --output-path)
+      require_value "$@"; OUTPUT_PATH="$2"; shift 2 ;;
+    --workspace-dir)
+      require_value "$@"; WORKSPACE_DIR="$2"; shift 2 ;;
+    --namespace)
+      require_value "$@"; NAMESPACE="$2"; shift 2 ;;
+    --run-id)
+      require_value "$@"; RETRIEVE_RUN_ID="$2"; shift 2 ;;
+    -h|--help)
+      usage; exit 0 ;;
+    *)
+      usage_error "unknown option: $1" ;;
+  esac
+done
+
+[ -n "$CAPTURE_NAME" ] || usage_error "--name is required"
+valid_rfc1123 "$CAPTURE_NAME" || usage_error "--name must be an RFC 1123 label"
+valid_hostpath "$OUTPUT_PATH" \
+  || usage_error "--output-path must be absolute and contain only letters, digits, '/', '_', '.', or '-'"
+valid_single_line "$WORKSPACE_DIR" || usage_error "--workspace-dir must be a single line"
+valid_rfc1123 "$NAMESPACE" || usage_error "--namespace must be an RFC 1123 label"
+[ -z "$RETRIEVE_RUN_ID" ] || valid_run_id "$RETRIEVE_RUN_ID" \
+  || usage_error "--run-id has an invalid format"
+
+command -v kubectl >/dev/null 2>&1 || die "kubectl is not installed or not on PATH"
+
+if [ -z "$RETRIEVE_RUN_ID" ]; then
+  if ! CAPTURE_RUNS="$(kubectl get jobs -n "$NAMESPACE" \
+    -l "capture-id=${CAPTURE_NAME}" \
+    -o jsonpath='{range .items[*]}{.metadata.labels.capture-run}{"\n"}{end}' \
+    | sed '/^$/d' | sort -u)"; then
+    die "could not list capture runs"
+  fi
+  RUN_COUNT="$(printf '%s\n' "$CAPTURE_RUNS" | sed '/^$/d' | wc -l | tr -d '[:space:]')"
+  case "$RUN_COUNT" in
+    0) die "no capture runs found for '$CAPTURE_NAME'" ;;
+    1) RETRIEVE_RUN_ID="$CAPTURE_RUNS" ;;
+    *) die "multiple capture runs found; specify --run-id" ;;
+  esac
+fi
+valid_run_id "$RETRIEVE_RUN_ID" || die "Kubernetes returned an invalid capture run identity"
+
+if ! CAPTURE_JOBS="$(kubectl get jobs -n "$NAMESPACE" \
+  -l "capture-id=${CAPTURE_NAME},capture-run=${RETRIEVE_RUN_ID}" \
+  -o jsonpath='{.items[*].metadata.name}')"; then
+  die "could not list capture Jobs"
+fi
+[ -n "$CAPTURE_JOBS" ] || die "no Jobs found for the requested capture run"
+read -r -a CAPTURE_JOB_NAMES <<<"$CAPTURE_JOBS"
+
+CAPTURES_DIR="${WORKSPACE_DIR}/network-captures"
+TIMESTAMP="$(date -u +%Y%m%d-%H%M%S)"
+CAPTURE_OUTPUT_DIR="${CAPTURES_DIR}/${CAPTURE_NAME}-${RETRIEVE_RUN_ID}-${TIMESTAMP}"
+mkdir -p "$CAPTURE_OUTPUT_DIR"
+
+TEMP_PODS=()
+cleanup_resources() {
+  local failed=0
+  local pod
+  if [ "${#TEMP_PODS[@]}" -gt 0 ]; then
+    for pod in "${TEMP_PODS[@]}"; do
+      if ! kubectl delete pod "$pod" -n "$NAMESPACE" --ignore-not-found >/dev/null; then
+        echo "Error: failed to delete retrieval pod '$pod'" >&2
+        failed=1
+      fi
+    done
+  fi
+  if ! kubectl delete jobs -n "$NAMESPACE" "${CAPTURE_JOB_NAMES[@]}" \
+    --ignore-not-found >/dev/null; then
+    echo "Error: failed to delete capture Jobs" >&2
+    failed=1
+  fi
+  return "$failed"
+}
+
+cleanup_on_exit() {
+  local status=$?
+  trap - EXIT
+  if ! cleanup_resources; then
+    status=1
+  fi
+  exit "$status"
+}
+trap cleanup_on_exit EXIT
+
+for job in "${CAPTURE_JOB_NAMES[@]}"; do
+  if ! NODE_NAME="$(kubectl get job "$job" -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.nodeName}')"; then
+    die "could not read the node for Job '$job'"
+  fi
+  if ! RUN_ID="$(kubectl get job "$job" -n "$NAMESPACE" \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="RUN_ID")].value}')"; then
+    die "could not read the run identity for Job '$job'"
+  fi
+  valid_node_name "$NODE_NAME" || die "Job '$job' returned an invalid node name"
+  valid_run_id "$RUN_ID" || die "Job '$job' returned an invalid run identity"
+  [ "$RUN_ID" = "$RETRIEVE_RUN_ID" ] || die "Job '$job' does not match the requested run"
+
+  if ! POD_NAME="$(kubectl get pods -n "$NAMESPACE" -l "job-name=${job}" \
+    -o jsonpath='{.items[0].metadata.name}')"; then
+    die "could not find the capture pod for Job '$job'"
+  fi
+  [ -n "$POD_NAME" ] || die "no capture pod found for Job '$job'"
+  if ! POD_STATUS="$(kubectl get pod "$POD_NAME" -n "$NAMESPACE" \
+    -o jsonpath='{.status.phase}')"; then
+    die "could not read capture pod status"
+  fi
+  [ "$POD_STATUS" = "Succeeded" ] \
+    || die "capture pod '$POD_NAME' did not succeed; inspect its logs before retrying"
+
+  capture_slug="$(printf '%s' "$CAPTURE_NAME" | cut -c1-20)"
+  node_slug="$(printf '%s' "$NODE_NAME" | tr '._' '--' | cut -c1-20)"
+  if ! TEMP_POD_NAME="$(kubectl create -f - -o jsonpath='{.metadata.name}' <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: retrieve-${capture_slug}-${node_slug}-
+  namespace: ${NAMESPACE}
+  labels: { app: aks-network-capture, capture-id: "${CAPTURE_NAME}", role: retrieval }
+spec:
+  hostNetwork: true
+  nodeName: "${NODE_NAME}"
+  restartPolicy: Never
+  containers:
+  - name: retrieve
+    image: mcr.microsoft.com/cbl-mariner/busybox:2.0@sha256:e4fb4d51fc9b70d6cdc1ce66a0af02ab40554d2ca632e1d188fabc760e432fdd
+    command: ["sh", "-c", "sleep 300"]
+    volumeMounts:
+    - name: capture-output
+      mountPath: /capture-root
+  volumes:
+  - name: capture-output
+    hostPath:
+      path: ${OUTPUT_PATH}/${CAPTURE_NAME}
+      type: Directory
+EOF
+)"; then
+    die "failed to create a retrieval pod on node '$NODE_NAME'"
+  fi
+  [ -n "$TEMP_POD_NAME" ] || die "Kubernetes did not return a retrieval pod name"
+  TEMP_PODS+=("$TEMP_POD_NAME")
+
+  kubectl wait -n "$NAMESPACE" --for=condition=Ready \
+    "pod/${TEMP_POD_NAME}" --timeout=60s
+
+  BUNDLE_NAME="capture-${CAPTURE_NAME}-${NODE_NAME}-${RUN_ID}.tar.gz"
+  RUN_DIR="/capture-root/${RUN_ID}"
+  kubectl cp -n "$NAMESPACE" "${TEMP_POD_NAME}:${RUN_DIR}/${BUNDLE_NAME}" \
+    "${CAPTURE_OUTPUT_DIR}/${BUNDLE_NAME}" -c retrieve
+  [ -s "${CAPTURE_OUTPUT_DIR}/${BUNDLE_NAME}" ] \
+    || die "the copied capture bundle '$BUNDLE_NAME' is empty"
+
+  # Positional arguments keep validated values out of the fixed remote command.
+  # shellcheck disable=SC2016
+  kubectl exec -n "$NAMESPACE" "$TEMP_POD_NAME" -c retrieve -- sh -c \
+    'rm -f "$1/$2" "$1/$3" && rmdir "$1"' sh \
+    "$RUN_DIR" "$BUNDLE_NAME" "capture-${CAPTURE_NAME}-${NODE_NAME}-${RUN_ID}.pcap"
+  kubectl delete pod "$TEMP_POD_NAME" -n "$NAMESPACE" --ignore-not-found
+done
+
+cleanup_resources || die "failed to clean up one or more capture resources"
+trap - EXIT
+
+echo "Capture bundles saved to: $CAPTURE_OUTPUT_DIR"
+ls -lh "$CAPTURE_OUTPUT_DIR"

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/run-capture.sh
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/run-capture.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Execute one bounded capture inside the pinned Linux capture image.
+# Exit codes: 0 = success, 1 = capture/archive failure, 2 = invalid configuration.
+set -eu
+
+: "${OUT_DIR:?OUT_DIR is required}"
+: "${CAPTURE_ID:?CAPTURE_ID is required}"
+: "${NODE_NAME:?NODE_NAME is required}"
+: "${RUN_ID:?RUN_ID is required}"
+: "${CAPTURE_DURATION:?CAPTURE_DURATION is required}"
+: "${PACKET_SIZE:?PACKET_SIZE is required}"
+: "${PCAP_FILTER:=}"
+
+case "$CAPTURE_ID" in
+  ""|-*|*-|*[!a-z0-9-]*) echo "invalid CAPTURE_ID" >&2; exit 2 ;;
+esac
+[ "${#CAPTURE_ID}" -le 63 ] || {
+  echo "invalid CAPTURE_ID" >&2
+  exit 2
+}
+case "$NODE_NAME" in
+  ""|*[!A-Za-z0-9._-]*) echo "invalid NODE_NAME" >&2; exit 2 ;;
+esac
+case "$CAPTURE_DURATION" in
+  ""|*[!0-9]*) echo "invalid CAPTURE_DURATION" >&2; exit 2 ;;
+esac
+[ "$CAPTURE_DURATION" -ge 1 ] && [ "$CAPTURE_DURATION" -le 1800 ] || {
+  echo "invalid CAPTURE_DURATION" >&2
+  exit 2
+}
+case "$PACKET_SIZE" in
+  ""|*[!0-9]*) echo "invalid PACKET_SIZE" >&2; exit 2 ;;
+esac
+[ "$PACKET_SIZE" -le 262144 ] || {
+  echo "invalid PACKET_SIZE" >&2
+  exit 2
+}
+
+run_date=${RUN_ID%%-*}
+run_remainder=${RUN_ID#*-}
+run_time=${run_remainder%%-*}
+run_token=${run_remainder#*-}
+[ "${#run_date}" -eq 8 ] && [ "${#run_time}" -eq 6 ] \
+  && [ "${#run_token}" -eq 24 ] || {
+    echo "invalid RUN_ID" >&2
+    exit 2
+  }
+case "${run_date}${run_time}" in
+  *[!0-9]*) echo "invalid RUN_ID" >&2; exit 2 ;;
+esac
+case "$run_token" in
+  *[!0-9a-f]*) echo "invalid RUN_ID" >&2; exit 2 ;;
+esac
+
+PCAP_NAME="capture-${CAPTURE_ID}-${NODE_NAME}-${RUN_ID}.pcap"
+BUNDLE_NAME="capture-${CAPTURE_ID}-${NODE_NAME}-${RUN_ID}.tar.gz"
+PCAP_PATH="${OUT_DIR}/${PCAP_NAME}"
+BUNDLE_PATH="${OUT_DIR}/${BUNDLE_NAME}"
+mkdir -p "$OUT_DIR"
+
+if [ -n "$PCAP_FILTER" ]; then
+  tcpdump -d "$PCAP_FILTER" >/dev/null || {
+    echo "invalid BPF filter" >&2
+    exit 2
+  }
+fi
+
+set -- tcpdump -i any -w "$PCAP_PATH"
+[ "$PACKET_SIZE" -eq 0 ] || set -- "$@" -s "$PACKET_SIZE"
+[ -z "$PCAP_FILTER" ] || set -- "$@" "$PCAP_FILTER"
+
+echo "Capturing for ${CAPTURE_DURATION}s on ${NODE_NAME}"
+if timeout "$CAPTURE_DURATION" "$@"; then
+  capture_status=0
+else
+  capture_status=$?
+fi
+if [ "$capture_status" -ne 0 ] && [ "$capture_status" -ne 124 ]; then
+  echo "tcpdump failed with exit ${capture_status}" >&2
+  exit 1
+fi
+[ -s "$PCAP_PATH" ] || {
+  echo "tcpdump produced no capture file" >&2
+  exit 1
+}
+
+tar -C "$OUT_DIR" -czf "$BUNDLE_PATH" "$PCAP_NAME"
+rm -f "$PCAP_PATH"
+echo "bundle: $BUNDLE_PATH"

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/setup-capture-configmap.ps1
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/setup-capture-configmap.ps1
@@ -1,0 +1,60 @@
+# Deploy the fixed Linux capture runner as a ConfigMap.
+# Exit codes: 0 = success/help, 1 = kubectl/read failure, 2 = usage/argument error.
+[CmdletBinding()]
+param(
+    [string]$Namespace = "default",
+    [switch]$Help
+)
+
+function Write-Usage {
+    @"
+Usage: setup-capture-configmap.ps1 [-Namespace <name>]
+
+Deploy run-capture.sh as the network-capture-scripts ConfigMap.
+"@
+}
+
+function Stop-Usage {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    [Console]::Error.WriteLine((Write-Usage))
+    exit 2
+}
+
+function Stop-Failure {
+    param([string]$Message)
+    [Console]::Error.WriteLine("Error: $Message")
+    exit 1
+}
+
+if ($Help) {
+    Write-Usage
+    exit 0
+}
+if ($Namespace.Length -gt 63 -or
+    $Namespace -cnotmatch "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$") {
+    Stop-Usage "-Namespace must be an RFC 1123 label"
+}
+if (-not (Get-Command kubectl -ErrorAction SilentlyContinue)) {
+    Stop-Failure "kubectl is not installed or not on PATH"
+}
+
+$runnerPath = Join-Path $PSScriptRoot "run-capture.sh"
+if (-not (Test-Path -LiteralPath $runnerPath -PathType Leaf)) {
+    Stop-Failure "run-capture.sh is not readable"
+}
+
+$manifest = (& kubectl create configmap network-capture-scripts `
+    "--from-file=run-capture.sh=$runnerPath" `
+    "--namespace=$Namespace" --dry-run=client -o yaml 2>&1) -join "`n"
+if ($LASTEXITCODE -ne 0) {
+    Stop-Failure "failed to render the ConfigMap: $manifest"
+}
+
+$applyOutput = ($manifest | & kubectl apply -f - 2>&1) -join "`n"
+if ($LASTEXITCODE -ne 0) {
+    Stop-Failure "failed to apply the ConfigMap: $applyOutput"
+}
+
+Write-Output $applyOutput
+Write-Output "ConfigMap network-capture-scripts created or updated in namespace: $Namespace"

--- a/plugins/aks-skills/skills/aks-network-capture/scripts/setup-capture-configmap.sh
+++ b/plugins/aks-skills/skills/aks-network-capture/scripts/setup-capture-configmap.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Deploy the fixed Linux capture runner as a ConfigMap.
+# Exit codes: 0 = success/help, 1 = kubectl/read failure, 2 = usage/argument error.
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $0 [namespace]
+
+Deploy run-capture.sh as the network-capture-scripts ConfigMap.
+The namespace defaults to "default".
+EOF
+}
+
+usage_error() {
+  echo "Error: $*" >&2
+  usage >&2
+  exit 2
+}
+
+die() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+esac
+[ "$#" -le 1 ] || usage_error "expected at most one namespace"
+
+NAMESPACE="${1:-default}"
+case "$NAMESPACE" in
+  ""|-*|*-|*[!a-z0-9-]*) usage_error "namespace must be an RFC 1123 label" ;;
+esac
+[ "${#NAMESPACE}" -le 63 ] || usage_error "namespace must not exceed 63 characters"
+
+command -v kubectl >/dev/null 2>&1 || die "kubectl is not installed or not on PATH"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -r "$SCRIPT_DIR/run-capture.sh" ] || die "run-capture.sh is not readable"
+
+kubectl create configmap network-capture-scripts \
+  --from-file=run-capture.sh="$SCRIPT_DIR/run-capture.sh" \
+  --namespace="$NAMESPACE" \
+  --dry-run=client -o yaml \
+  | kubectl apply -f -
+
+echo "ConfigMap network-capture-scripts created or updated in namespace: $NAMESPACE"

--- a/plugins/aks-skills/skills/aks-network-capture/version.json
+++ b/plugins/aks-skills/skills/aks-network-capture/version.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0",
+  "pathFilters": [
+    "."
+  ]
+}

--- a/plugins/aks-skills/skills/aks-troubleshooting/SKILL.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: aks-troubleshooting
+license: MIT
+metadata:
+  author: Microsoft
+  version: "0.0.0-placeholder"
+description: "Debug and root-cause live Azure Kubernetes Service (AKS) incidents with a read-only, evidence-first investigation and structured report. WHEN: pod crashes or Pending, CrashLoopBackOff, OOMKilled, ImagePullBackOff, node NotReady, DNS failure, ingress 502/503, connectivity timeout, network policy, SNAT exhaustion, upgrade stuck, cordon/drain failure, spot or zone disruption, expired certificate, or 'investigate my AKS cluster'. DO NOT USE FOR: packet capture (use aks-network-capture); GPU or model-serving issues (use aks-gpu-inference); cluster creation or provisioning (use aks-cluster-setup); cost or rightsizing (use aks-cost-optimization); an exact documented AKS error code, nested VM-extension/CSE signature, or message-qualified allocation failure (use aks-known-issues). Bare wrappers or codes without the nested cataloged signature, generic failures without a stable signature, and open-ended incidents stay here."
+---
+
+# AKS Troubleshooting
+
+Root-cause live AKS incidents with a read-only, evidence-first investigation. This skill covers the full Day-2 troubleshooting surface — workloads, nodes, networking, ingress, upgrades, and spot/zone disruptions — and produces a structured incident report.
+
+## Operating rules
+
+**Read-only by default.** Do not restart, delete, cordon, drain, scale, upgrade, or reconfigure any resource unless the user explicitly asks for remediation. Gather evidence, name the root cause, and propose the fix — but do not apply it uninvited.
+
+**Evidence before conclusion.** Do not state a root cause without quoting the evidence that supports it. "Pod is Pending" and "node is NotReady" are symptoms, not causes — trace them to the specific selector, taint, exhausted resource, or Azure-side condition.
+
+**Tool preference.** Inspect the host's available tools and advertised schemas. Azure MCP Server's AKS area can supply cluster and node-pool metadata. AppLens, Azure Monitor, and Resource Health are separate Azure MCP areas; use each only when its host-advertised schema fits the read. Never treat a specific prefix or spelling as an availability check, and do not invent a name-mapping layer. Use the portable `az` and `kubectl` flows for checks outside those surfaces or whenever the matching capability is unavailable. See [references/azure-mcp.md](references/azure-mcp.md).
+
+**Evidence order.** Gather Azure-side state first (cluster state, resource health, recent operations, node-pool state, detector/monitoring output), then Kubernetes-side state (reachability, nodes, `kube-system`, events, the affected namespace, pod detail, logs). This ordering catches platform-level causes — a failed upgrade operation, a stopped cluster, a quota block — before you spend time inside the cluster.
+
+## Route by symptom
+
+| Symptom | Reference |
+|---------|-----------|
+| Broad investigation, unknown root cause | [general-diagnostics.md](general-diagnostics.md) |
+| Pod crash, OOMKilled, ImagePullBackOff, Pending, readiness probe | [pod-failures.md](pod-failures.md) |
+| Node NotReady, node pressure, node scaling / autoscaler not triggering | [node-issues.md](node-issues.md) |
+| Service connectivity, DNS, pod-to-pod networking | [networking.md](networking.md) |
+| Ingress 502/503, load-balancer health probe, external access | [load-balancer-and-ingress.md](load-balancer-and-ingress.md) |
+| Network policy blocking traffic | [network-policy.md](network-policy.md) |
+| Upgrade stuck, cordon/drain failure | [upgrade-operations.md](upgrade-operations.md) |
+| Spot eviction, zone rebalance failure | [spot-and-zone-issues.md](spot-and-zone-issues.md) |
+| Any symptom → exact commands, in order | [references/symptom-map.md](references/symptom-map.md) |
+
+`references/symptom-map.md` is the fastest path: 16 symptom sections, each a self-contained block of the exact `kubectl`/`az` commands to run plus the common causes. Start there when the symptom is clear; use the topic files above for deeper investigation.
+
+## Scripts
+
+Both shipped scripts are POSIX `sh` and read-only. They require an explicit resource group, cluster, and kube context, then verify that the context endpoint matches the named AKS resource before any Kubernetes API read. Set `AKS_SUBSCRIPTION_ID` to pin Azure reads to a subscription.
+
+- `scripts/cluster-snapshot.sh <resource-group> <cluster> <kube-context>` — target-bound cluster overview (nodes, recent events, pressure, and node-pool state).
+- `scripts/pod-deep-dive.sh <namespace> <pod> <resource-group> <cluster> <kube-context> <artifacts-dir>` — target-bound pod evidence. Raw current/previous logs stay in the artifact directory; stdout contains redacted projections and no more than 50 lines from each stream.
+
+## AKS-specific gotchas
+
+The highest-signal failure patterns that are specific to AKS — a frontier model will not reliably know these. Review before investigating.
+
+- **Azure CNI vs kubenet is a fork in every networking fix.** Check `az aks show -o json --query networkProfile.networkPlugin` **first** — the plugin (kubenet, Azure CNI, CNI Overlay, Cilium) changes how pod IPs, routes, and network policy behave.
+- **Managed-identity RBAC is behind a large share of AKS failures.** ACR pull, disk attach, private DNS, and Key Vault access all depend on the cluster or kubelet identity having a role assignment. Check `az aks show --query identityProfile` and the relevant role assignments early.
+- **Node NotReady is not always a VM problem.** It can be kubelet, containerd, the CNI plugin, Azure host maintenance, or an expired kubelet/API-server certificate. Correlate `kubectl describe node` conditions with `az vm get-instance-view`, and check `kubectl get csr` for pending certificate requests.
+- **The Azure LB health probe can disagree with Kubernetes.** A Service can look healthy in-cluster but fail at the Azure load balancer because the LB rule's probe path/port does not match the app endpoint. Check `az network lb probe list`.
+- **Subnet exhaustion silently blocks scheduling.** Azure CNI allocates a VNet IP per pod; a full pod subnet stops new pods scheduling with no obvious error. Check `az network vnet subnet show --query '{addressPrefix: addressPrefix, used: ipConfigurations | length(@)}'`.
+- **System-pool PodDisruptionBudgets block drains during upgrades.** CoreDNS and metrics-server ship PDBs that can stall a node drain. Check `kubectl get pdb -A`.
+- **The API server IP can change after stop/start.** When a cluster is stopped and restarted, the API server IP may change; flush DNS and re-run `az aks get-credentials` if `kubectl` cannot connect afterward.
+- **Private clusters need in-VNet access.** `kubectl` must run from a VM inside — or peered to — the cluster VNet. Check `az aks show --query apiServerAccessProfile` for private-cluster and authorized-IP-range settings.
+- **NSG/firewall egress blocks surface as VM extension errors.** AKS nodes need outbound access to required FQDNs (AKS API, MCR, `management.azure.com`, and others). A restrictive NSG or firewall causes VM extension errors during create/upgrade — error codes 50 (`OutboundConnFailVMExtensionError`), 51 (`K8SAPIServerConnFailVMExtensionError`), 52 (`K8SAPIServerDNSLookupFailVMExtensionError`). Check `az network nsg rule list` and firewall logs.
+- **SNAT port exhaustion appears past a few hundred nodes.** Large clusters using the Azure Load Balancer for outbound can exhaust SNAT ports, causing intermittent egress failures. Check `az network lb show --query outboundRules`; fix by moving to a NAT gateway (`az aks update --outbound-type managedNATGateway`).
+- **Upgrade `max-surge` defaults to one node at a time.** Large-cluster upgrades take hours at the default. Check `az aks nodepool show --query upgradeSettings` and raise `--max-surge` if the workload tolerates it.
+- **`kubectl` must be within two minor versions of the cluster.** A stale client produces confusing errors. Compare `kubectl version --client` with `az aks show --query kubernetesVersion`.
+
+## Log discipline
+
+- Use `pod-deep-dive.sh` so current and previous streams are collected together, raw output stays outside model context, and visible log evidence is bounded and redacted.
+- The 50-line visible projection is an investigation starting point. If earlier evidence is necessary, keep the expanded raw collection in the artifact directory and expose only a separately reviewed bounded/redacted slice.
+- Preserve container prefixes and all-container collection so sidecar evidence remains attributable.
+- Get current UTC time with `date -u` before using `--since-time`.
+
+## Deep diagnostics
+
+When standard checks do not reveal a root cause, use **Inspektor Gadget** for real-time, low-level node and pod observability (DNS traces, TCP traces, process and file-access snapshots). The [Inspektor Gadget reference](references/inspektor-gadget.md) pins the approved MCR image by digest and requires both explicit privileged-debug approval and finite runtime bounds. Additional MCP-driven investigation modes are in [references/structured-input-modes.md](references/structured-input-modes.md) and [references/command-flows.md](references/command-flows.md).
+
+## Report
+
+Structure the final incident report using [references/report-template.md](references/report-template.md): symptom and impact, evidence gathered, failure domain, root cause with supporting evidence, confidence, remediation, and escalation. Quote relevant log snippets inline rather than pasting full dumps.
+
+## Reference
+
+Microsoft's AKS troubleshooting hub: https://learn.microsoft.com/troubleshoot/azure/azure-kubernetes/welcome-azure-kubernetes

--- a/plugins/aks-skills/skills/aks-troubleshooting/general-diagnostics.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/general-diagnostics.md
@@ -1,0 +1,60 @@
+# General AKS Investigation & Diagnostics
+
+## "What happened in my cluster?"
+
+When a user asks a broad question like "what happened in my AKS cluster?" or "check my AKS status", follow this systematic flow:
+
+1. Cluster health
+2. Recent events
+3. Node status
+4. Unhealthy pods
+5. All pods overview
+6. System pods health
+7. Activity log
+
+Gather Azure-side resource health, recent operations, and node-pool state first. Then run the target-bound snapshot rather than an ambient-context Kubernetes command chain:
+
+```bash
+AKS_SUBSCRIPTION_ID=<subscription-id> \
+  scripts/cluster-snapshot.sh <resource-group> <cluster-name> <kube-context>
+```
+
+The script stops before Kubernetes API reads unless the kube context endpoint matches the named AKS resource. Continue with affected-namespace pod detail and logs only after the cluster, node, `kube-system`, and event evidence is complete.
+
+---
+
+## AKS CLI Tools
+
+```bash
+# Get cluster credentials (required before kubectl commands)
+az aks get-credentials -g <rg> -n <cluster>
+
+# View node pools
+az aks nodepool list -g <rg> --cluster-name <cluster> -o table
+```
+
+### Azure MCP AppLens area for AKS
+
+AppLens is a separate Azure MCP Server area, not part of its AKS cluster/node-pool metadata area. For AI-powered diagnostics:
+
+```text
+<host-assigned Azure MCP AppLens tool>
+  resource: "<cluster-name>"
+  question: "Diagnose the reported AKS cluster issue and recommend remediation."
+  resource-group: "<resource-group>"  # optional disambiguation
+  resource-type: "Microsoft.ContainerService/managedClusters"  # optional disambiguation
+```
+
+The angle-bracketed token is a placeholder, not a literal tool name. Inspect the host's available tools for the Azure MCP capability that advertises AppLens diagnostics, use its assigned name, and follow its advertised schema. The representative inputs above match the current AppLens capability; omit or rename them if the host advertises a different schema.
+
+> 💡 **Tip:** AppLens uses the resource name and diagnostic question; provide the resource group and type only when needed to disambiguate the cluster.
+
+---
+
+## Best Practices
+
+1. **Start with kubectl get/describe** - Always check basic status first
+2. **Check events** - `kubectl get events -A` reveals recent issues
+3. **Use systematic isolation** - Pod -> Node -> Cluster -> Network
+4. **Document changes** - Note what you tried and what worked
+5. **Escalate when needed** - For control plane issues, contact Azure support

--- a/plugins/aks-skills/skills/aks-troubleshooting/load-balancer-and-ingress.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/load-balancer-and-ingress.md
@@ -1,0 +1,56 @@
+# Load Balancer And Ingress Troubleshooting
+
+Use this guide when AKS networking symptoms point at Azure load balancer provisioning, ingress controller behavior, or backend routing.
+
+## Load Balancer Stuck In Pending
+
+**Diagnostics:**
+
+```bash
+kubectl describe svc <svc> -n <ns>
+# Events section reveals the actual Azure error
+
+kubectl logs -n kube-system -l component=cloud-controller-manager --tail=100
+```
+
+**Error decision table:**
+
+| Error in Events / CCM Logs                             | Cause                                  | Fix                                                                          |
+| ------------------------------------------------------ | -------------------------------------- | ---------------------------------------------------------------------------- |
+| `InsufficientFreeAddresses`                            | Subnet has no free IPs                 | Expand subnet CIDR; use Azure CNI Overlay; use NAT gateway instead           |
+| `ensure(default/svc): failed... PublicIPAddress quota` | Public IP quota exhausted              | Request quota increase for Public IP Addresses in the region                 |
+| `cannot find NSG`                                      | NSG name changed or detached           | Re-associate NSG to the AKS subnet; check `az aks show` for NSG name         |
+| `reconciling NSG rules: failed`                        | NSG is locked or has conflicting rules | Remove resource lock; check for deny-all rules above AKS-managed rules       |
+| `subnet not found`                                     | Wrong subnet name in annotation        | Verify subnet name: `az network vnet subnet list -g <rg> --vnet-name <vnet>` |
+| No events, stuck Pending                               | CCM can't authenticate to Azure        | Check cluster managed identity access on the VNet resource group             |
+
+---
+
+## Ingress Not Routing Traffic
+
+**Diagnostics:**
+
+```bash
+# Confirm controller is running
+kubectl get pods -n <ingress-ns> -l 'app.kubernetes.io/name in (ingress-nginx,nginx-ingress)'
+kubectl logs -n <ingress-ns> -l app.kubernetes.io/name=ingress-nginx --tail=100
+
+# Check the ingress resource state
+kubectl describe ingress <name> -n <ns>
+kubectl get ingress <name> -n <ns>
+
+# Check backend
+kubectl get endpoints <backend-svc> -n <ns>
+```
+
+**Ingress failure patterns:**
+
+| Symptom                          | Cause                                          | Fix                                                          |
+| -------------------------------- | ---------------------------------------------- | ------------------------------------------------------------ |
+| ADDRESS empty                    | LB not provisioned or wrong `ingressClassName` | Check controller service; set correct `ingressClassName`     |
+| 404 for all paths                | No matching host rule                          | Check `host` field; `pathType: Prefix` vs `Exact`            |
+| 404 for some paths               | Trailing slash mismatch                        | `Prefix /api` matches `/api/foo` not `/api` - add both       |
+| 502 Bad Gateway                  | Backend pods unhealthy or wrong port           | Verify Endpoints has IPs; confirm `targetPort` and readiness |
+| 503 Service Unavailable          | All backend pods down                          | Check pod restarts and readiness probe                       |
+| TLS handshake fail               | cert-manager not issuing                       | Check certificate status and ACME challenge                  |
+| Works for host-a, 404 for host-b | DNS not pointing to ingress IP                 | Verify `nslookup <host>` resolves to the ingress address     |

--- a/plugins/aks-skills/skills/aks-troubleshooting/network-policy.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/network-policy.md
@@ -1,0 +1,17 @@
+# Network Policy Troubleshooting
+
+Use this guide when pod-to-pod or pod-to-service traffic is selectively blocked and the symptom points at ingress or egress filtering.
+
+```bash
+# List all policies in the namespace - check both ingress and egress
+kubectl get networkpolicy -n <ns> -o yaml
+
+# Check for a default-deny policy (blocks everything unless explicitly allowed)
+kubectl get networkpolicy -n <ns> -o jsonpath='{range .items[?(@.spec.podSelector=={})]}{.metadata.name}{"\n"}{end}'
+```
+
+**AKS network policy engine check:** Azure NPM (Azure CNI): `kubectl get pods -n kube-system -l k8s-app=azure-npm`. Calico: `kubectl get pods -n calico-system`.
+
+Policy audit: source labels, destination labels, destination ingress rules, and source egress rules must all line up. With default-deny, explicitly allow UDP/TCP 53 to kube-dns.
+
+Keep selector, ingress, egress, and engine evidence as the primary diagnostic path. If those rules and direct connectivity evidence remain ambiguous, hand off to `aks-network-capture` only when packet-level proof is requested or explicitly approved. The capture skill owns capture scope, runtime, least-privilege controls, and commands; packet capture is not a mandatory network-policy step.

--- a/plugins/aks-skills/skills/aks-troubleshooting/networking.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/networking.md
@@ -1,0 +1,711 @@
+# Networking Troubleshooting
+
+For CNI-specific issues, check CNI pod health and review [AKS networking concepts](https://learn.microsoft.com/azure/aks/concepts-network).
+
+## Service Unreachable / Connection Refused
+
+**Diagnostics - always start here:**
+
+```bash
+# 1. Verify service exists and has endpoints (read-only)
+kubectl get svc <service-name> -n <ns>
+kubectl get endpoints <service-name> -n <ns>
+kubectl get endpointslice -n <ns> \
+  -l kubernetes.io/service-name=<service-name> -o wide
+kubectl get pods -n <ns> -l <service-selector> -o wide
+```
+
+**Decision tree:**
+
+| Observation                             | Cause                              | Fix                                             |
+| --------------------------------------- | ---------------------------------- | ----------------------------------------------- |
+| Endpoints shows `<none>`                | Label selector mismatch            | Align selector with pod labels; check for typos |
+| Endpoints has IPs but unreachable       | Port mismatch or app not listening | Confirm `targetPort` = actual container port    |
+| Works from some pods, fails from others | Network policy blocking            | See Network Policy section                      |
+| Works inside cluster, fails externally  | Load balancer issue                | See Load Balancer section                       |
+| `ECONNREFUSED` immediately              | App not listening on that port     | Check listening ports in the pod                |
+
+Pods that are running but not Ready are removed from Endpoints. Check `kubectl get pod <pod> -n <ns>`.
+
+**Deep diagnostics with Inspektor Gadget** (when the above checks are inconclusive):
+
+Use the [IG base command pattern](references/inspektor-gadget.md) with `--k8s-namespace <ns> --k8s-podname <pod-name>` and these gadgets:
+
+- `snapshot_socket` (timeout 5) — check what ports the pod is listening on
+- `trace_tcp` (timeout 30) — trace connect/accept/close events
+- `trace_tcpretrans` (timeout 30) — packet retransmissions
+
+See [references/inspektor-gadget.md](references/inspektor-gadget.md).
+
+---
+
+## DNS Resolution Failures
+
+Use the affected pod; do not create a test pod or change DNS, NetworkPolicy, NSG, route, or firewall configuration without explicit approval.
+
+### Mandatory ordered read-only evidence
+
+A DNS diagnosis is incomplete until every step below is collected, or the inability to collect it is recorded. Do not skip resolver inputs, a query through kube-dns, direct upstream behavior, or the CoreDNS-to-upstream UDP/TCP 53 network path.
+
+```bash
+# 1. Preserve and explicitly inspect every nameserver, search suffix, and option
+kubectl exec <affected-pod> -n <ns> -- cat /etc/resolv.conf
+
+# 2. Check the kube-dns Service, backends, CoreDNS pods, logs, and config
+kubectl get service kube-dns -n kube-system -o wide
+kubectl get endpoints kube-dns -n kube-system -o wide
+kubectl get endpointslice -n kube-system \
+  -l kubernetes.io/service-name=kube-dns -o wide
+kubectl get pods -n kube-system -l k8s-app=kube-dns -o wide
+kubectl logs -n kube-system -l k8s-app=kube-dns \
+  --all-containers --prefix --tail=-1
+kubectl get configmap coredns -n kube-system -o yaml
+kubectl get configmap -n kube-system
+
+# 3. Prove CoreDNS query health through the kube-dns ClusterIP, then compare
+# direct UDP and TCP 53 behavior for every configured upstream forwarder.
+# Use clients already present in the affected pod; do not install packages.
+kubectl exec <affected-pod> -n <ns> -- \
+  nslookup <failing-fqdn> <kube-dns-cluster-ip>
+kubectl exec <affected-pod> -n <ns> -- \
+  dig +notcp +time=<timeout-seconds> +tries=<attempt-count> \
+  @<custom-forwarder-ip> <failing-fqdn>
+kubectl exec <affected-pod> -n <ns> -- \
+  dig +tcp +time=<timeout-seconds> +tries=<attempt-count> \
+  @<custom-forwarder-ip> <failing-fqdn>
+
+# 4. Preserve policy plus the node-NIC NSG/route path used by each CoreDNS pod
+kubectl get networkpolicy -n <ns> -o yaml
+kubectl get networkpolicy -n kube-system -o yaml
+kubectl get pods -n kube-system -l k8s-app=kube-dns \
+  -o custom-columns='POD:.metadata.name,POD_IP:.status.podIP,NODE:.spec.nodeName'
+NODE_RESOURCE_GROUP=$(az aks show \
+  --resource-group <cluster-resource-group> \
+  --name <cluster-name> \
+  --query nodeResourceGroup -o tsv)
+COREDNS_PROVIDER_ID=$(kubectl get node <coredns-node> \
+  -o jsonpath='{.spec.providerID}')
+COREDNS_POOL=$(kubectl get node <coredns-node> \
+  -o jsonpath='{.metadata.labels.agentpool}')
+COREDNS_VMSS_NAME=$(printf '%s\n' "$COREDNS_PROVIDER_ID" |
+  awk -F'/virtualMachineScaleSets/' '{print $2}' | cut -d/ -f1)
+COREDNS_INSTANCE_ID=${COREDNS_PROVIDER_ID##*/}
+COREDNS_NODE_NIC_ID=$(az vmss nic list-vm-nics \
+  --resource-group "$NODE_RESOURCE_GROUP" \
+  --vmss-name "$COREDNS_VMSS_NAME" \
+  --instance-id "$COREDNS_INSTANCE_ID" \
+  --query '[0].id' -o tsv)
+COREDNS_NODE_SUBNET_ID=$(az network nic show \
+  --ids "$COREDNS_NODE_NIC_ID" \
+  --query 'ipConfigurations[0].subnet.id' -o tsv)
+COREDNS_POD_SUBNET_ID=$(az aks nodepool show \
+  --resource-group <cluster-resource-group> \
+  --cluster-name <cluster-name> \
+  --name "$COREDNS_POOL" \
+  --query podSubnetId -o tsv)
+COREDNS_SOURCE_SUBNET_ID=${COREDNS_POD_SUBNET_ID:-$COREDNS_NODE_SUBNET_ID}
+
+# Effective node-NIC evidence, then explicit source-subnet NSG and UDR evidence
+az network nic list-effective-nsg \
+  --ids "$COREDNS_NODE_NIC_ID" -o json
+az network nic show-effective-route-table \
+  --ids "$COREDNS_NODE_NIC_ID" -o table
+if COREDNS_SUBNET_NSG_ID=$(az network vnet subnet show \
+  --ids "$COREDNS_SOURCE_SUBNET_ID" \
+  --query networkSecurityGroup.id -o tsv); then
+  if [ -n "$COREDNS_SUBNET_NSG_ID" ]; then
+    if COREDNS_SUBNET_NSG=$(az network nsg show \
+      --ids "$COREDNS_SUBNET_NSG_ID" \
+      --query '{customOutbound:securityRules[?direction==`Outbound`],defaultOutbound:defaultSecurityRules[?direction==`Outbound`]}' \
+      -o json); then
+      if [ -n "$COREDNS_SUBNET_NSG" ]; then
+        printf '%s\n' "$COREDNS_SUBNET_NSG"
+      else
+        printf 'subnetNsg=unknown: command=az network nsg show succeeded with empty output; id=%s\n' \
+          "$COREDNS_SUBNET_NSG_ID"
+      fi
+    else
+      printf 'subnetNsg=inaccessible: command=az network nsg show; id=%s\n' \
+        "$COREDNS_SUBNET_NSG_ID"
+    fi
+  else
+    printf 'subnetNsg=absent\n'
+  fi
+else
+  COREDNS_SUBNET_NSG_ID=""
+  printf 'subnetNsg=inaccessible: command=az network vnet subnet show; ids=%s; query=networkSecurityGroup.id\n' \
+    "$COREDNS_SOURCE_SUBNET_ID"
+fi
+if COREDNS_ROUTE_TABLE_ID=$(az network vnet subnet show \
+  --ids "$COREDNS_SOURCE_SUBNET_ID" \
+  --query routeTable.id -o tsv); then
+  if [ -n "$COREDNS_ROUTE_TABLE_ID" ]; then
+    if COREDNS_ROUTE_TABLE=$(az network route-table show \
+      --ids "$COREDNS_ROUTE_TABLE_ID" \
+      --query 'routes[].{name:name,addressPrefix:addressPrefix,nextHopType:nextHopType,nextHopIpAddress:nextHopIpAddress}' \
+      -o table); then
+      if [ -n "$COREDNS_ROUTE_TABLE" ]; then
+        printf '%s\n' "$COREDNS_ROUTE_TABLE"
+      else
+        printf 'routeTableRoutes=absent: command=az network route-table show succeeded with empty routes output; id=%s\n' \
+          "$COREDNS_ROUTE_TABLE_ID"
+      fi
+    else
+      printf 'routeTable=inaccessible: command=az network route-table show; id=%s\n' \
+        "$COREDNS_ROUTE_TABLE_ID"
+    fi
+  else
+    printf 'routeTable=absent\n'
+  fi
+else
+  COREDNS_ROUTE_TABLE_ID=""
+  printf 'routeTable=inaccessible: command=az network vnet subnet show; ids=%s; query=routeTable.id\n' \
+    "$COREDNS_SOURCE_SUBNET_ID"
+fi
+```
+
+Repeat these checks for each node hosting a CoreDNS pod. For Azure CNI Pod Subnet, `COREDNS_SOURCE_SUBNET_ID` is the pod subnet; otherwise it is the CoreDNS node NIC subnet. Record an NSG or route table as absent only when its association lookup succeeds with an empty ID; record a failed lookup as inaccessible instead of running its dependent `show` command. Evaluate outbound rules and routes from the CoreDNS pod/node source to every configured upstream on both UDP and TCP destination port 53.
+
+If the selected route has a `VirtualAppliance` next hop, run the exact policy or classic network-rule collection commands in [Mandatory Firewall or NVA branch when traversed](#3-mandatory-firewall-or-nva-branch-when-traversed), then query the matching DNS decisions:
+
+```bash
+az monitor log-analytics query \
+  --workspace <log-analytics-workspace-id> \
+  --timespan <incident-start-utc>/<incident-end-utc> \
+  --analytics-query "union isfuzzy=true AZFWNetworkRule, AzureDiagnostics | where _ResourceId =~ '<firewall-resource-id>' | where (SourceIp in ('<coredns-pod-ip>','<coredns-node-ip>') and DestinationIp == '<custom-forwarder-ip>' and DestinationPort == 53 and Protocol in ('UDP','TCP')) or (Category == 'AzureFirewallNetworkRule' and (msg_s has '<coredns-pod-ip>' or msg_s has '<coredns-node-ip>') and msg_s has '<custom-forwarder-ip>' and msg_s has '53' and (msg_s has 'UDP' or msg_s has 'TCP')) | project TimeGenerated,Category,Action,Protocol,SourceIp,DestinationIp,DestinationPort,RuleCollection,Rule,msg_s"
+```
+
+For a custom NVA, collect equivalent network-rule and log evidence filtered to the same CoreDNS source, upstream destination, incident window, and UDP/TCP 53.
+
+If CoreDNS imports a custom ConfigMap, retrieve the named ConfigMap shown by the inventory before evaluating its forwarding rules. A successful direct query to a custom forwarder with a failed query through kube-dns points to CoreDNS configuration or service-path evidence; failure to reach the forwarder points to routing, NSG, firewall, or NetworkPolicy evidence.
+
+**DNS failure patterns:**
+
+| Symptom | Evidence boundary |
+|---|---|
+| `NXDOMAIN` for `svc.cluster.local` | Confirm search domains, kube-dns endpoints, and the CoreDNS `kubernetes` plugin before changing CoreDNS |
+| Internal names resolve; external names return `NXDOMAIN` | Compare CoreDNS forwarding configuration and direct queries to each configured upstream |
+| `SERVFAIL` | Correlate CoreDNS logs with upstream reachability and forwarder responses |
+| Private endpoint FQDN resolves publicly | Inspect the `privatelink.*` private DNS zone, record set, virtual network links, and conditional forwarders |
+| `i/o timeout` | Inspect NetworkPolicy plus effective node-NIC NSG, route, and present firewall rules for both UDP and TCP 53 |
+
+Changing CoreDNS replicas/configuration, custom forwarders, NetworkPolicy, NSGs, routes, or firewall rules is remediation and requires explicit approval.
+
+**Deep diagnostics with Inspektor Gadget** (when the above checks are inconclusive):
+
+Use the [IG base command pattern](references/inspektor-gadget.md) with `--k8s-namespace <ns> --k8s-podname <pod-name>` and `trace_dns` (timeout 30). Key signals: `rcode=3` (NXDOMAIN), `rcode=2` (SERVFAIL), high `latency` values, queries going to unexpected destinations.
+
+See [references/inspektor-gadget.md](references/inspektor-gadget.md).
+
+---
+
+## AKS to an External Azure Service
+
+### Executable evidence first
+
+An external-connectivity diagnosis is incomplete until each evidence class below is collected, or the inability to collect it is recorded: the cluster's network model and outbound type; source NIC and subnet identity; effective NIC NSG rules plus the explicit subnet NSG rules; the effective route table and any UDR next hop; workload DNS and TCP behavior; the service's endpoint configuration — public access and firewall rules, service endpoint/VNet rules, private-endpoint connections, and the private-DNS zone, records, and links that determine which endpoint model is in effect; and — when the selected route's next hop is a firewall or NVA — the matching rule and incident-window logs. A skipped conditional step must be recorded with its reason (for example: selected next hop is Internet, so no firewall evidence applies). Do not conclude, and do not propose remediation, from a subset.
+
+Cluster-side identifiers are derivable — exhaust derivation before asking: the cluster name and resource group resolve from the current kubeconfig context confirmed against `az aks list` (same procedure as [node-issues.md](node-issues.md)), and the block computes the rest from the pod (pod → node → `providerID` → VMSS/NIC/subnet). Ask the user only for what cannot be derived: the target service's name and resource group and the incident window.
+
+```bash
+AKS_RG="<cluster-resource-group>"
+AKS_NAME="<cluster-name>"
+NS="<namespace>"
+POD="<affected-pod>"
+SQL_RG="<sql-resource-group>"
+SQL_SERVER="<sql-server-name>"
+SQL_FQDN="$SQL_SERVER.database.windows.net"
+SQL_DESTINATION_IP="<resolved-sql-destination-ip>"
+PRIVATE_DNS_RG="<private-dns-resource-group>"
+INCIDENT_START="<incident-start-utc>"
+INCIDENT_END="<incident-end-utc>"
+
+# AKS network model and source VMSS instance NIC/subnet
+az aks show \
+  --resource-group "$AKS_RG" \
+  --name "$AKS_NAME" \
+  --query '{nodeResourceGroup:nodeResourceGroup,networkPlugin:networkProfile.networkPlugin,networkPluginMode:networkProfile.networkPluginMode,networkPolicy:networkProfile.networkPolicy,networkDataplane:networkProfile.networkDataplane,outboundType:networkProfile.outboundType}' \
+  -o yaml
+NODE_RESOURCE_GROUP=$(az aks show \
+  --resource-group "$AKS_RG" \
+  --name "$AKS_NAME" \
+  --query nodeResourceGroup -o tsv)
+if SOURCE_NODE=$(kubectl get pod "$POD" -n "$NS" \
+  -o jsonpath='{.spec.nodeName}'); then
+  if [ -z "$SOURCE_NODE" ]; then
+    printf 'sourceNode=unknown: kubectl get pod succeeded with empty spec.nodeName; namespace=%s; pod=%s\n' \
+      "$NS" "$POD"
+  fi
+else
+  SOURCE_NODE=""
+  printf 'sourceNode=inaccessible: command=kubectl get pod; namespace=%s; pod=%s; jsonpath=.spec.nodeName\n' \
+    "$NS" "$POD"
+fi
+if SOURCE_POD_IP=$(kubectl get pod "$POD" -n "$NS" \
+  -o jsonpath='{.status.podIP}'); then
+  if [ -z "$SOURCE_POD_IP" ]; then
+    printf 'sourcePodIp=unknown: kubectl get pod succeeded with empty status.podIP; namespace=%s; pod=%s\n' \
+      "$NS" "$POD"
+  fi
+else
+  SOURCE_POD_IP=""
+  printf 'sourcePodIp=inaccessible: command=kubectl get pod; namespace=%s; pod=%s; jsonpath=.status.podIP\n' \
+    "$NS" "$POD"
+fi
+if [ -n "$SOURCE_NODE" ]; then
+  if SOURCE_NODE_IP=$(kubectl get node "$SOURCE_NODE" \
+    -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}'); then
+    if [ -z "$SOURCE_NODE_IP" ]; then
+      printf 'sourceNodeIp=unknown: kubectl get node succeeded with no InternalIP; node=%s\n' \
+        "$SOURCE_NODE"
+    fi
+  else
+    SOURCE_NODE_IP=""
+    printf 'sourceNodeIp=inaccessible: command=kubectl get node; node=%s; jsonpath=.status.addresses[InternalIP]\n' \
+      "$SOURCE_NODE"
+  fi
+else
+  SOURCE_NODE_IP=""
+  printf 'sourceNodeIp=unknown: source node is unavailable\n'
+fi
+SOURCE_POOL=$(kubectl get node "$SOURCE_NODE" \
+  -o jsonpath='{.metadata.labels.agentpool}')
+PROVIDER_ID=$(kubectl get node "$SOURCE_NODE" \
+  -o jsonpath='{.spec.providerID}')
+VMSS_NAME=$(printf '%s\n' "$PROVIDER_ID" |
+  awk -F'/virtualMachineScaleSets/' '{print $2}' | cut -d/ -f1)
+INSTANCE_ID=${PROVIDER_ID##*/}
+NODE_NIC_ID=$(az vmss nic list-vm-nics \
+  --resource-group "$NODE_RESOURCE_GROUP" \
+  --vmss-name "$VMSS_NAME" \
+  --instance-id "$INSTANCE_ID" \
+  --query '[0].id' -o tsv)
+NODE_SUBNET_ID=$(az network nic show --ids "$NODE_NIC_ID" \
+  --query 'ipConfigurations[0].subnet.id' -o tsv)
+POD_SUBNET_ID=$(az aks nodepool show \
+  --resource-group "$AKS_RG" \
+  --cluster-name "$AKS_NAME" \
+  --name "$SOURCE_POOL" \
+  --query podSubnetId -o tsv)
+SOURCE_SUBNET_ID=${POD_SUBNET_ID:-$NODE_SUBNET_ID}
+
+# Effective NIC rules/routes and explicit subnet NSG inbound/outbound rules
+az network nic list-effective-nsg \
+  --ids "$NODE_NIC_ID" -o json
+if SUBNET_NSG_ID=$(az network vnet subnet show \
+  --ids "$SOURCE_SUBNET_ID" \
+  --query networkSecurityGroup.id -o tsv); then
+  if [ -n "$SUBNET_NSG_ID" ]; then
+    if SUBNET_NSG=$(az network nsg show \
+      --ids "$SUBNET_NSG_ID" \
+      --query '{customInbound:securityRules[?direction==`Inbound`],customOutbound:securityRules[?direction==`Outbound`],defaultInbound:defaultSecurityRules[?direction==`Inbound`],defaultOutbound:defaultSecurityRules[?direction==`Outbound`]}' \
+      -o json); then
+      if [ -n "$SUBNET_NSG" ]; then
+        printf '%s\n' "$SUBNET_NSG"
+      else
+        printf 'subnetNsg=unknown: command=az network nsg show succeeded with empty output; id=%s\n' \
+          "$SUBNET_NSG_ID"
+      fi
+    else
+      printf 'subnetNsg=inaccessible: command=az network nsg show; id=%s\n' \
+        "$SUBNET_NSG_ID"
+    fi
+  else
+    printf 'subnetNsg=absent\n'
+  fi
+else
+  SUBNET_NSG_ID=""
+  printf 'subnetNsg=inaccessible: command=az network vnet subnet show; ids=%s; query=networkSecurityGroup.id\n' \
+    "$SOURCE_SUBNET_ID"
+fi
+az network nic show-effective-route-table \
+  --ids "$NODE_NIC_ID" -o table
+if ROUTE_TABLE_ID=$(az network vnet subnet show \
+  --ids "$SOURCE_SUBNET_ID" \
+  --query routeTable.id -o tsv); then
+  if [ -n "$ROUTE_TABLE_ID" ]; then
+    if ROUTE_TABLE=$(az network route-table show \
+      --ids "$ROUTE_TABLE_ID" \
+      --query '{disableBgpRoutePropagation:disableBgpRoutePropagation,routes:routes[].{name:name,addressPrefix:addressPrefix,nextHopType:nextHopType,nextHopIpAddress:nextHopIpAddress}}' \
+      -o json); then
+      if [ -n "$ROUTE_TABLE" ]; then
+        printf '%s\n' "$ROUTE_TABLE"
+      else
+        printf 'routeTable=unknown: command=az network route-table show succeeded with empty output; id=%s\n' \
+          "$ROUTE_TABLE_ID"
+      fi
+    else
+      printf 'routeTable=inaccessible: command=az network route-table show; id=%s\n' \
+        "$ROUTE_TABLE_ID"
+    fi
+  else
+    printf 'routeTable=absent\n'
+  fi
+else
+  ROUTE_TABLE_ID=""
+  printf 'routeTable=inaccessible: command=az network vnet subnet show; ids=%s; query=routeTable.id\n' \
+    "$SOURCE_SUBNET_ID"
+fi
+
+# Effective public egress identity for the reported AKS outbound type
+if OUTBOUND_TYPE=$(az aks show \
+  --resource-group "$AKS_RG" \
+  --name "$AKS_NAME" \
+  --query networkProfile.outboundType -o tsv); then
+  if [ -n "$OUTBOUND_TYPE" ]; then
+    printf 'outboundType=%s\n' "$OUTBOUND_TYPE"
+  else
+    printf 'outboundType=unknown: az aks show succeeded with empty networkProfile.outboundType\n'
+  fi
+else
+  OUTBOUND_TYPE=""
+  printf 'outboundType=inaccessible: command=az aks show; resourceGroup=%s; cluster=%s; query=networkProfile.outboundType\n' \
+    "$AKS_RG" "$AKS_NAME"
+fi
+
+case "$OUTBOUND_TYPE" in
+  loadBalancer)
+    if OUTBOUND_PUBLIC_IP_IDS=$(az aks show \
+      --resource-group "$AKS_RG" \
+      --name "$AKS_NAME" \
+      --query 'networkProfile.loadBalancerProfile.effectiveOutboundIPs[].id' \
+      -o tsv); then
+      if [ -n "$OUTBOUND_PUBLIC_IP_IDS" ]; then
+        printf '%s\n' "$OUTBOUND_PUBLIC_IP_IDS" |
+        while IFS= read -r PUBLIC_IP_ID; do
+          [ -n "$PUBLIC_IP_ID" ] || continue
+          if OUTBOUND_PUBLIC_IP=$(az network public-ip show \
+            --ids "$PUBLIC_IP_ID" \
+            --query '{id:id,ipAddress:ipAddress,publicIPPrefix:publicIPPrefix.id}' \
+            -o yaml); then
+            if [ -n "$OUTBOUND_PUBLIC_IP" ]; then
+              printf '%s\n' "$OUTBOUND_PUBLIC_IP"
+            else
+              printf 'outboundPublicIp=unknown: command=az network public-ip show succeeded with empty output; id=%s\n' \
+                "$PUBLIC_IP_ID"
+            fi
+          else
+            printf 'outboundPublicIp=inaccessible: command=az network public-ip show; id=%s\n' \
+              "$PUBLIC_IP_ID"
+          fi
+        done
+      else
+        printf 'outboundPublicIpIds=absent\n'
+        printf 'outboundIdentity=unknown: no effective load-balancer outbound public IP was returned\n'
+      fi
+    else
+      OUTBOUND_PUBLIC_IP_IDS=""
+      printf 'outboundPublicIpIds=inaccessible: command=az aks show; resourceGroup=%s; cluster=%s; query=networkProfile.loadBalancerProfile.effectiveOutboundIPs[].id\n' \
+        "$AKS_RG" "$AKS_NAME"
+      printf 'outboundIdentity=unknown: load-balancer outbound public IP lookup failed\n'
+    fi
+    ;;
+  managedNATGateway|managedNATGatewayV2|userAssignedNATGateway|none)
+    if NAT_GATEWAY_ID=$(az network vnet subnet show \
+      --ids "$SOURCE_SUBNET_ID" \
+      --query natGateway.id -o tsv); then
+      if [ -n "$NAT_GATEWAY_ID" ]; then
+        if NAT_GATEWAY=$(az network nat gateway show \
+          --ids "$NAT_GATEWAY_ID" \
+          --query '{id:id,publicIpAddresses:publicIpAddresses[].id,publicIpPrefixes:publicIpPrefixes[].id}' \
+          -o yaml); then
+          if [ -n "$NAT_GATEWAY" ]; then
+            printf '%s\n' "$NAT_GATEWAY"
+          else
+            printf 'natGateway=unknown: command=az network nat gateway show succeeded with empty output; id=%s\n' \
+              "$NAT_GATEWAY_ID"
+          fi
+        else
+          printf 'natGateway=inaccessible: command=az network nat gateway show; id=%s\n' \
+            "$NAT_GATEWAY_ID"
+        fi
+
+        NAT_PUBLIC_IP_LOOKUP=failed
+        if NAT_PUBLIC_IP_IDS=$(az network nat gateway show \
+          --ids "$NAT_GATEWAY_ID" \
+          --query 'publicIpAddresses[].id' -o tsv); then
+          NAT_PUBLIC_IP_LOOKUP=succeeded
+          if [ -n "$NAT_PUBLIC_IP_IDS" ]; then
+            printf '%s\n' "$NAT_PUBLIC_IP_IDS" |
+            while IFS= read -r PUBLIC_IP_ID; do
+              [ -n "$PUBLIC_IP_ID" ] || continue
+              if NAT_PUBLIC_IP=$(az network public-ip show \
+                --ids "$PUBLIC_IP_ID" \
+                --query '{id:id,ipAddress:ipAddress}' -o yaml); then
+                if [ -n "$NAT_PUBLIC_IP" ]; then
+                  printf '%s\n' "$NAT_PUBLIC_IP"
+                else
+                  printf 'natGatewayPublicIp=unknown: command=az network public-ip show succeeded with empty output; id=%s\n' \
+                    "$PUBLIC_IP_ID"
+                fi
+              else
+                printf 'natGatewayPublicIp=inaccessible: command=az network public-ip show; id=%s\n' \
+                  "$PUBLIC_IP_ID"
+              fi
+            done
+          else
+            printf 'natGatewayPublicIpAddresses=absent\n'
+          fi
+        else
+          NAT_PUBLIC_IP_IDS=""
+          printf 'natGatewayPublicIpAddresses=inaccessible: command=az network nat gateway show; id=%s; query=publicIpAddresses[].id\n' \
+            "$NAT_GATEWAY_ID"
+        fi
+
+        NAT_PUBLIC_IP_PREFIX_LOOKUP=failed
+        if NAT_PUBLIC_IP_PREFIX_IDS=$(az network nat gateway show \
+          --ids "$NAT_GATEWAY_ID" \
+          --query 'publicIpPrefixes[].id' -o tsv); then
+          NAT_PUBLIC_IP_PREFIX_LOOKUP=succeeded
+          if [ -n "$NAT_PUBLIC_IP_PREFIX_IDS" ]; then
+            printf '%s\n' "$NAT_PUBLIC_IP_PREFIX_IDS" |
+            while IFS= read -r PUBLIC_IP_PREFIX_ID; do
+              [ -n "$PUBLIC_IP_PREFIX_ID" ] || continue
+              if NAT_PUBLIC_IP_PREFIX=$(az network public-ip prefix show \
+                --ids "$PUBLIC_IP_PREFIX_ID" \
+                --query '{id:id,ipPrefix:ipPrefix}' -o yaml); then
+                if [ -n "$NAT_PUBLIC_IP_PREFIX" ]; then
+                  printf '%s\n' "$NAT_PUBLIC_IP_PREFIX"
+                else
+                  printf 'natGatewayPublicIpPrefix=unknown: command=az network public-ip prefix show succeeded with empty output; id=%s\n' \
+                    "$PUBLIC_IP_PREFIX_ID"
+                fi
+              else
+                printf 'natGatewayPublicIpPrefix=inaccessible: command=az network public-ip prefix show; id=%s\n' \
+                  "$PUBLIC_IP_PREFIX_ID"
+              fi
+            done
+          else
+            printf 'natGatewayPublicIpPrefixes=absent\n'
+          fi
+        else
+          NAT_PUBLIC_IP_PREFIX_IDS=""
+          printf 'natGatewayPublicIpPrefixes=inaccessible: command=az network nat gateway show; id=%s; query=publicIpPrefixes[].id\n' \
+            "$NAT_GATEWAY_ID"
+        fi
+
+        if [ "$NAT_PUBLIC_IP_LOOKUP" != succeeded ] ||
+          [ "$NAT_PUBLIC_IP_PREFIX_LOOKUP" != succeeded ]; then
+          printf 'outboundIdentity=unknown: NAT gateway public identity lookup is incomplete\n'
+        elif [ -z "$NAT_PUBLIC_IP_IDS" ] &&
+          [ -z "$NAT_PUBLIC_IP_PREFIX_IDS" ]; then
+          printf 'outboundIdentity=unknown: NAT gateway has no visible public IP or prefix identity\n'
+        fi
+      else
+        printf 'natGateway=absent\n'
+        if [ "$OUTBOUND_TYPE" = "none" ]; then
+          printf 'outboundIdentity=not AKS-managed: no source-subnet NAT gateway; use the effective route and resolve any next-hop SNAT identity\n'
+        else
+          printf 'outboundIdentity=unknown: no NAT gateway is associated with the selected source subnet\n'
+        fi
+      fi
+    else
+      NAT_GATEWAY_ID=""
+      printf 'natGateway=inaccessible: command=az network vnet subnet show; ids=%s; query=natGateway.id\n' \
+        "$SOURCE_SUBNET_ID"
+      printf 'outboundIdentity=unknown: source-subnet NAT gateway association lookup failed\n'
+    fi
+    ;;
+  userDefinedRouting)
+    printf 'outboundIdentity=not AKS-managed: use the effective default route and resolve the next-hop SNAT identity\n'
+    ;;
+  block)
+    printf 'outboundIdentity=blocked by AKS: record any observed exception path instead of assuming public egress\n'
+    ;;
+  "")
+    printf 'outboundIdentity=unknown: outboundType is unavailable\n'
+    ;;
+  *)
+    printf 'outboundIdentity=unknown: unrecognized outboundType=%s\n' "$OUTBOUND_TYPE"
+    ;;
+esac
+
+# Workload DNS/TCP evidence; use nc only when already present
+kubectl exec "$POD" -n "$NS" -- \
+  nslookup "$SQL_FQDN"
+kubectl exec "$POD" -n "$NS" -- \
+  nc -vz -w <timeout-seconds> "$SQL_FQDN" 1433
+
+# Azure SQL public endpoint, service endpoint/VNet rule, private endpoint/DNS
+az sql server show \
+  --resource-group "$SQL_RG" \
+  --name "$SQL_SERVER" \
+  --query '{publicNetworkAccess:publicNetworkAccess,minimalTlsVersion:minimalTlsVersion}' \
+  -o yaml
+az sql server firewall-rule list \
+  --resource-group "$SQL_RG" \
+  --server "$SQL_SERVER" \
+  --query '[].{name:name,startIpAddress:startIpAddress,endIpAddress:endIpAddress}' \
+  -o table
+az network vnet subnet show \
+  --ids "$SOURCE_SUBNET_ID" \
+  --query '{serviceEndpoints:serviceEndpoints,routeTable:routeTable.id,networkSecurityGroup:networkSecurityGroup.id}' \
+  -o yaml
+az sql server vnet-rule list \
+  --resource-group "$SQL_RG" \
+  --server "$SQL_SERVER" -o table
+SQL_SERVER_ID=$(az sql server show \
+  --resource-group "$SQL_RG" \
+  --name "$SQL_SERVER" --query id -o tsv)
+az network private-endpoint-connection list \
+  --id "$SQL_SERVER_ID" -o table
+az network private-dns zone show \
+  --resource-group "$PRIVATE_DNS_RG" \
+  --name privatelink.database.windows.net -o yaml
+az network private-dns record-set a list \
+  --resource-group "$PRIVATE_DNS_RG" \
+  --zone-name privatelink.database.windows.net -o table
+az network private-dns link vnet list \
+  --resource-group "$PRIVATE_DNS_RG" \
+  --zone-name privatelink.database.windows.net -o table
+
+# Only when the selected next hop is an Azure Firewall
+FIREWALL_RG="<firewall-resource-group>"
+FIREWALL_NAME="<firewall-name>"
+FIREWALL_POLICY_RG="<firewall-policy-resource-group>"
+FIREWALL_POLICY_NAME="<firewall-policy-name>"
+LOG_WORKSPACE="<log-analytics-workspace-id>"
+az network firewall show \
+  --resource-group "$FIREWALL_RG" \
+  --name "$FIREWALL_NAME" \
+  --query '{provisioningState:provisioningState,firewallPolicy:firewallPolicy.id,privateIPs:ipConfigurations[].privateIPAddress}' \
+  -o yaml
+FIREWALL_ID=$(az network firewall show \
+  --resource-group "$FIREWALL_RG" \
+  --name "$FIREWALL_NAME" --query id -o tsv)
+if FIREWALL_PUBLIC_IP_IDS=$(az network firewall show \
+  --resource-group "$FIREWALL_RG" \
+  --name "$FIREWALL_NAME" \
+  --query 'ipConfigurations[].publicIPAddress.id' -o tsv); then
+  if [ -n "$FIREWALL_PUBLIC_IP_IDS" ]; then
+    printf '%s\n' "$FIREWALL_PUBLIC_IP_IDS" |
+    while IFS= read -r PUBLIC_IP_ID; do
+      [ -n "$PUBLIC_IP_ID" ] || continue
+      if FIREWALL_PUBLIC_IP=$(az network public-ip show \
+        --ids "$PUBLIC_IP_ID" \
+        --query '{id:id,ipAddress:ipAddress}' -o yaml); then
+        if [ -n "$FIREWALL_PUBLIC_IP" ]; then
+          printf '%s\n' "$FIREWALL_PUBLIC_IP"
+        else
+          printf 'firewallPublicIp=unknown: command=az network public-ip show succeeded with empty output; id=%s\n' \
+            "$PUBLIC_IP_ID"
+        fi
+      else
+        printf 'firewallPublicIp=inaccessible: command=az network public-ip show; id=%s\n' \
+          "$PUBLIC_IP_ID"
+      fi
+    done
+  else
+    printf 'firewallPublicIpIds=absent\n'
+    printf 'firewallPublicEgressIdentity=unknown: no data-plane public IP was returned\n'
+  fi
+else
+  FIREWALL_PUBLIC_IP_IDS=""
+  printf 'firewallPublicIpIds=inaccessible: command=az network firewall show; resourceGroup=%s; firewall=%s; query=ipConfigurations[].publicIPAddress.id\n' \
+    "$FIREWALL_RG" "$FIREWALL_NAME"
+  printf 'firewallPublicEgressIdentity=unknown: data-plane public IP lookup failed\n'
+fi
+FIREWALL_POLICY_ID=$(az network firewall show \
+  --resource-group "$FIREWALL_RG" \
+  --name "$FIREWALL_NAME" --query firewallPolicy.id -o tsv)
+if [ -n "$FIREWALL_POLICY_ID" ]; then
+  az network firewall policy show \
+    --ids "$FIREWALL_POLICY_ID" -o yaml
+  az network firewall policy rule-collection-group list \
+    --resource-group "$FIREWALL_POLICY_RG" \
+    --policy-name "$FIREWALL_POLICY_NAME" -o table
+  az network firewall policy rule-collection-group list \
+    --resource-group "$FIREWALL_POLICY_RG" \
+    --policy-name "$FIREWALL_POLICY_NAME" \
+    --query '[].name' -o tsv |
+  while IFS= read -r RULE_COLLECTION_GROUP; do
+    az network firewall policy rule-collection-group show \
+      --resource-group "$FIREWALL_POLICY_RG" \
+      --policy-name "$FIREWALL_POLICY_NAME" \
+      --name "$RULE_COLLECTION_GROUP" -o json
+  done
+else
+  az network firewall network-rule collection list \
+    --resource-group "$FIREWALL_RG" \
+    --firewall-name "$FIREWALL_NAME" -o json
+  az network firewall application-rule collection list \
+    --resource-group "$FIREWALL_RG" \
+    --firewall-name "$FIREWALL_NAME" -o json
+fi
+az monitor diagnostic-settings list \
+  --resource "$FIREWALL_ID" -o json
+SOURCE_IP_KQL_LIST=""
+LEGACY_SOURCE_PREDICATE=""
+if [ -n "$SOURCE_POD_IP" ]; then
+  SOURCE_IP_KQL_LIST="'$SOURCE_POD_IP'"
+  LEGACY_SOURCE_PREDICATE="msg_s has '$SOURCE_POD_IP'"
+fi
+if [ -n "$SOURCE_NODE_IP" ]; then
+  if [ -n "$SOURCE_IP_KQL_LIST" ]; then
+    SOURCE_IP_KQL_LIST="$SOURCE_IP_KQL_LIST, '$SOURCE_NODE_IP'"
+    LEGACY_SOURCE_PREDICATE="$LEGACY_SOURCE_PREDICATE or msg_s has '$SOURCE_NODE_IP'"
+  else
+    SOURCE_IP_KQL_LIST="'$SOURCE_NODE_IP'"
+    LEGACY_SOURCE_PREDICATE="msg_s has '$SOURCE_NODE_IP'"
+  fi
+fi
+
+if [ -n "$SOURCE_IP_KQL_LIST" ]; then
+  az monitor log-analytics query \
+    --workspace "$LOG_WORKSPACE" \
+    --timespan "$INCIDENT_START/$INCIDENT_END" \
+    --analytics-query "
+union isfuzzy=true
+  (AZFWNetworkRule
+    | where _ResourceId =~ '$FIREWALL_ID'
+    | where SourceIp in ($SOURCE_IP_KQL_LIST)
+    | where DestinationIp == '$SQL_DESTINATION_IP'
+    | where DestinationPort == 1433 and Protocol =~ 'TCP'
+    | project TimeGenerated,LogTable='AZFWNetworkRule',Action,ActionReason,
+        Protocol,SourceIp,Destination=DestinationIp,DestinationPort,
+        RuleCollectionGroup,RuleCollection,Rule),
+  (AZFWApplicationRule
+    | where _ResourceId =~ '$FIREWALL_ID'
+    | where SourceIp in ($SOURCE_IP_KQL_LIST)
+    | where Fqdn =~ '$SQL_FQDN'
+    | where DestinationPort == 1433 and Protocol in~ ('MSSQL', 'TCP')
+    | project TimeGenerated,LogTable='AZFWApplicationRule',Action,ActionReason,
+        Protocol,SourceIp,Destination=Fqdn,DestinationPort,
+        RuleCollectionGroup,RuleCollection,Rule)
+| order by TimeGenerated asc"
+  az monitor log-analytics query \
+    --workspace "$LOG_WORKSPACE" \
+    --timespan "$INCIDENT_START/$INCIDENT_END" \
+    --analytics-query "
+AzureDiagnostics
+| where _ResourceId =~ '$FIREWALL_ID'
+| where Category in ('AzureFirewallNetworkRule','AzureFirewallApplicationRule')
+| where $LEGACY_SOURCE_PREDICATE
+| where msg_s has '$SQL_DESTINATION_IP' or msg_s has '$SQL_FQDN'
+| where msg_s has '1433'
+| where msg_s has 'TCP' or msg_s has 'MSSQL'
+| extend Protocol=extract('^([A-Za-z]+) request',1,msg_s),
+         Action=extract('Action: ([A-Za-z]+)',1,msg_s)
+| project TimeGenerated,Category,Action,Protocol,msg_s
+| order by TimeGenerated asc"
+else
+  printf 'firewallLogEvidence=incomplete: no proven nonempty pod or node source IP; source-scoped queries not run\n'
+fi
+```
+
+Fill the placeholders and run this read-only block before narrowing the failure. For Azure CNI Pod Subnet, `SOURCE_SUBNET_ID` is the pod subnet; otherwise it is the node subnet. A successful empty NSG, route-table, NAT gateway, public-IP, or prefix association means that resource is absent; a failed lookup means the evidence is inaccessible or unknown and must not be recorded as absence. Inspect Firewall commands only when `VirtualAppliance` resolves to Azure Firewall; for an NVA, collect the equivalent selected route, network/application rules, and incident-window logs.
+
+- Run `nc` only if it already exists in the affected pod; do not install packages or create a test pod.
+- Set `SQL_DESTINATION_IP` to each address returned for the SQL FQDN from the affected pod and repeat the Firewall queries for every address used during the incident.
+- **Public endpoint:** the server FQDN resolves to a public address; compare every collected load-balancer, NAT gateway, Azure Firewall, or other next-hop SNAT public IP/prefix with the SQL firewall ranges. For `userDefinedRouting` or `none`, do not conclude that a rule allows or denies the source until the selected effective route and next-hop SNAT identity are proven. Record an unknown identity or any command/permission failure as an evidence gap.
+- **Service endpoint:** the FQDN remains public, while the source subnet advertises `Microsoft.Sql` and the SQL server has a matching virtual network rule.
+- **Private endpoint:** the FQDN follows the `privatelink.database.windows.net` chain to the private endpoint IP; verify endpoint approval, the A record, the affected VNet link or conditional forwarder, and the effective route to that private IP.
+
+Do not change SQL networking, DNS links/records, NSGs, UDRs, NetworkPolicy, NVA rules, or Azure Firewall policy until the failing path and blocking rule are identified and remediation is explicitly approved.
+
+---
+
+## Detailed Networking Guides
+
+- [Load Balancer And Ingress Troubleshooting](load-balancer-and-ingress.md) for pending services, ingress controller state, backend routing, and TLS failures.
+- [Network Policy Troubleshooting](network-policy.md) for default-deny checks, Azure NPM or Calico validation, and ingress or egress rule audits.

--- a/plugins/aks-skills/skills/aks-troubleshooting/node-issues.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/node-issues.md
@@ -1,0 +1,172 @@
+# Node & Cluster Troubleshooting
+
+## Node NotReady — executable evidence first
+
+Every identifier in this block is derivable or enumerable — exhaust derivation before asking the user for one. If no node was named, enumerate candidates with `kubectl get nodes --no-headers | awk '$2 !~ /^Ready(,|$)/'` and run the block for each; an empty result means no node in the current cluster is NotReady, so reconfirm the cluster identity before concluding. The VMSS name and instance id are computed from the node's `providerID` inside the block — never request them.
+
+If the cluster name or resource group is unknown, capture the current kubeconfig server and enumerate AKS clusters in every enabled subscription available to the current Azure CLI identity:
+
+```bash
+KUBECONFIG_SERVER=$(kubectl config view --minify \
+  -o jsonpath='{.clusters[0].cluster.server}')
+printf 'kubeconfigServer=%s\n' "$KUBECONFIG_SERVER"
+
+az account list --query "[?state=='Enabled'].id" -o tsv |
+  while IFS= read -r SUBSCRIPTION_ID; do
+    printf 'subscriptionId=%s\n' "$SUBSCRIPTION_ID"
+    if ! az aks list \
+      --subscription "$SUBSCRIPTION_ID" \
+      --query "[].{id:id,name:name,resourceGroup:resourceGroup,fqdn:fqdn,privateFqdn:privateFqdn}" \
+      -o json; then
+      printf 'aksEnumeration=inaccessible; subscriptionId=%s\n' \
+        "$SUBSCRIPTION_ID"
+    fi
+  done
+```
+
+Match the kubeconfig server host against `fqdn` or `privateFqdn`, then take the cluster name and resource group from the matching resource ID. Only ask the user if this read-only cross-subscription enumeration cannot produce a unique match.
+
+```bash
+AKS_RG="<cluster-resource-group>"
+AKS_NAME="<cluster-name>"
+NODE="<node-name>"
+
+# Kubernetes description, conditions, and node-scoped events
+kubectl describe node "$NODE"
+kubectl get node "$NODE" \
+  -o jsonpath='{range .status.conditions[*]}{.lastTransitionTime}{"\t"}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+kubectl get events --all-namespaces \
+  --field-selector involvedObject.kind=Node,involvedObject.name="$NODE" \
+  --sort-by='.metadata.creationTimestamp'
+
+# AKS node resource group and Kubernetes node to VMSS instance mapping
+NODE_RG=$(az aks show \
+  --resource-group "$AKS_RG" \
+  --name "$AKS_NAME" \
+  --query nodeResourceGroup -o tsv)
+AGENT_POOL=$(kubectl get node "$NODE" \
+  -o jsonpath='{.metadata.labels.agentpool}')
+PROVIDER_ID=$(kubectl get node "$NODE" \
+  -o jsonpath='{.spec.providerID}')
+VMSS=$(printf '%s\n' "$PROVIDER_ID" |
+  awk -F'/virtualMachineScaleSets/' '{print $2}' | cut -d/ -f1)
+INSTANCE_ID=${PROVIDER_ID##*/}
+
+printf 'nodeResourceGroup=%s\nagentPool=%s\nvmss=%s\ninstanceId=%s\n' \
+  "$NODE_RG" "$AGENT_POOL" "$VMSS" "$INSTANCE_ID"
+
+# AKS pool state
+az aks nodepool show \
+  --resource-group "$AKS_RG" \
+  --cluster-name "$AKS_NAME" \
+  --name "$AGENT_POOL" \
+  --query '{provisioningState:provisioningState,powerState:powerState.code,nodeImageVersion:nodeImageVersion,orchestratorVersion:orchestratorVersion}' \
+  -o yaml
+
+# Exact VMSS instance view and extension statuses
+az vmss get-instance-view \
+  --resource-group "$NODE_RG" \
+  --name "$VMSS" \
+  --instance-id "$INSTANCE_ID" \
+  -o json
+az vmss get-instance-view \
+  --resource-group "$NODE_RG" \
+  --name "$VMSS" \
+  --instance-id "$INSTANCE_ID" \
+  --query 'extensions[].{name:name,statuses:statuses,substatuses:substatuses}' \
+  -o json
+```
+
+This block is the minimum Node NotReady evidence. It is incomplete until every command in it has produced output or the inability to collect it is recorded. Collect it before narrowing the failure to kubelet, host, provisioning, pressure, or network causes.
+
+### Privileged and service mutation boundary
+
+Kubelet/service inspection through privileged node access requires explicit approval after the mandatory block identifies a node-local evidence gap. Restarting kubelet, cordoning, draining, deleting, reimaging, or replacing a node are separate remediations and require explicit approval with workload, PodDisruptionBudget, and change-control impact understood. None is part of the default evidence path.
+
+**Condition decision tree:**
+
+| Condition | Value | Evidence boundary | Next investigation |
+|---|---|---|---|
+| `Ready` | `False` | Compare the transition time and reason with VMSS instance and extension statuses | Determine whether the failure is kubelet, host, provisioning, or network related before requesting node access |
+| `MemoryPressure` | `True` | Review allocated resources, pod requests/limits, eviction events, and metrics | Identify the workload or node-pool capacity constraint |
+| `DiskPressure` | `True` | Review eviction events, pod ephemeral-storage requests/limits, and node image/OS state | Determine whether workload storage use or node storage capacity is responsible |
+| `PIDPressure` | `True` | Correlate condition transitions with workload placement and process evidence | Use IG `snapshot_process` if process-level evidence is required |
+| `NetworkUnavailable` | `True` | Review CNI pod state and logs plus node NIC routes and NSG evidence | Continue with [Networking Troubleshooting](networking.md) |
+
+Do not infer that a `Ready=False` condition requires a kubelet restart or node replacement. The Kubernetes condition reason, node events, VMSS provisioning state, and extension substatus determine the next branch.
+
+---
+
+## Node Pool Not Scaling
+
+### Cluster Autoscaler Not Triggering
+
+**Diagnostics:**
+
+```bash
+# Autoscaler logs
+kubectl logs -n kube-system -l app=cluster-autoscaler --tail=100
+
+# Autoscaler status
+kubectl get configmap cluster-autoscaler-status -n kube-system -o yaml
+
+# Verify autoscaler is enabled on the node pool
+az aks nodepool show -g <rg> --cluster-name <cluster> -n <nodepool> \
+  --query "{autoscaleEnabled:enableAutoScaling, min:minCount, max:maxCount}"
+```
+
+**Autoscaler won't scale up - common reasons:**
+
+- Node pool already at `maxCount`
+- VM quota exhausted: `az vm list-usage -l <region> -o table | grep -i "DSv3\|quota"`
+- Pod `nodeAffinity` is unsatisfiable on any new node template
+- A recent autoscaler decision is still governed by the cluster's configured autoscaler profile; compare the status ConfigMap timestamps and profile settings before concluding scaling is stuck
+
+**Autoscaler won't scale down - common reasons:**
+
+- Pods with `emptyDir` local storage (configure `--skip-nodes-with-local-storage=false` if safe)
+- Standalone pods with no controller (not in a ReplicaSet)
+- `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` annotation on a pod
+
+### Manual Scaling
+
+```bash
+az aks nodepool scale -g <rg> --cluster-name <cluster> -n <nodepool> --node-count <n>
+```
+
+---
+
+## Resource Pressure & Capacity Planning
+
+**Check actual vs allocatable:**
+
+```bash
+kubectl describe node <node> | grep -A6 "Allocated resources:"
+```
+
+See [AKS resource reservations](https://learn.microsoft.com/azure/aks/concepts-clusters-workloads#resource-reservations) for allocatable math.
+
+**Ephemeral storage pressure:**
+
+```bash
+# Correlate node pressure with workload requests, limits, placement, and events
+kubectl describe node <node>
+kubectl get pods -A --field-selector spec.nodeName=<node> \
+  -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,EPHEMERAL_REQUESTS:.spec.containers[*].resources.requests.ephemeral-storage,EPHEMERAL_LIMITS:.spec.containers[*].resources.limits.ephemeral-storage'
+kubectl get events --all-namespaces \
+  --field-selector involvedObject.kind=Node,involvedObject.name=<node> \
+  --sort-by='.metadata.creationTimestamp'
+```
+
+If this evidence cannot identify the consumer, request approval before privileged node filesystem inspection.
+
+**Deep diagnostics with Inspektor Gadget** (PID pressure or unknown process load):
+
+Use `snapshot_process` (timeout 5) to list all processes on the node. For node-wide scope, omit pod filters. See [references/inspektor-gadget.md](references/inspektor-gadget.md).
+
+---
+
+## Detailed Node And Cluster Guides
+
+- [Upgrade Operations](upgrade-operations.md) for node images, Kubernetes version upgrades, surge settings, and PDB-related drain blockers.
+- [Spot And Zone Issues](spot-and-zone-issues.md) for spot evictions, tolerations, zone skew, and zonal storage or service behavior.

--- a/plugins/aks-skills/skills/aks-troubleshooting/pod-failures.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/pod-failures.md
@@ -1,0 +1,154 @@
+# Pod Failures & Application Issues
+
+## Target-Bound Pod Evidence
+
+Use the shipped collector instead of streaming raw logs into model context. It verifies the kube context against the named AKS resource before any Kubernetes API read, captures current and previous logs across all containers, and keeps the raw log files in a caller-selected artifact directory.
+
+```bash
+AKS_SUBSCRIPTION_ID=<subscription-id> \
+  scripts/pod-deep-dive.sh \
+  <namespace> <pod-name> <resource-group> <cluster-name> <kube-context> \
+  <artifacts-directory>
+```
+
+The model-visible projection redacts credential-shaped values and is capped at 50 lines per current/previous log stream. Inspect expanded raw evidence only outside model context.
+
+---
+
+## CrashLoopBackOff
+
+Pod starts, crashes, restarts with exponential backoff (10s, 20s, 40s... up to 5m).
+
+**Diagnostics:**
+
+```bash
+kubectl describe pod <pod-name> -n <namespace>
+# Check: Exit Code, Reason, Last State, Events
+```
+
+Use the `Previous Logs` section from `pod-deep-dive.sh`; it preserves the last crashed container output without exposing the raw stream.
+
+**Decision tree:**
+
+| Exit Code | Meaning                                               | Fix Path                                                      |
+| --------- | ----------------------------------------------------- | ------------------------------------------------------------- |
+| `0`       | App exited successfully (unexpected for long-running) | Check if entrypoint/command is correct; app may be a one-shot |
+| `1`       | Application error                                     | Read logs - unhandled exception, missing config, bad startup  |
+| `137`     | OOMKilled (SIGKILL)                                   | Increase `resources.limits.memory`; check for memory leaks    |
+| `139`     | Segfault (SIGSEGV)                                    | Binary compatibility issue or native code bug                 |
+| `143`     | SIGTERM - graceful shutdown                           | Pod was terminated; check if liveness probe killed it         |
+
+**OOMKilled specifically:**
+
+```bash
+kubectl describe pod <pod-name> -n <namespace> | grep -A2 "Last State"
+# Reason: OOMKilled -> container exceeded memory limit
+```
+
+Fix: increase `resources.limits.memory` or optimize application memory usage. Check `kubectl top pod <pod-name> -n <namespace>` for actual usage.
+
+**OOM kill tracing with Inspektor Gadget:** Use `trace_oomkill` (timeout 30) with `--k8s-namespace <namespace> --k8s-podname <pod-name>` to see which process was killed and memory at kill time. See [references/inspektor-gadget.md](references/inspektor-gadget.md).
+
+**Deep diagnostics with Inspektor Gadget** (when logs and describe are inconclusive):
+
+Use the [IG base command pattern](references/inspektor-gadget.md) with `--k8s-namespace <namespace> --k8s-podname <pod-name>` and these gadgets:
+
+- `trace_exec` (timeout 30) — see what the container executes at startup
+- `trace_open` (timeout 30) — find missing configs/secrets (retval -2 = ENOENT, -13 = EACCES)
+- `snapshot_process` (timeout 5) — list running processes in the pod
+
+See [references/inspektor-gadget.md](references/inspektor-gadget.md).
+
+---
+
+## ImagePullBackOff
+
+Pod can't pull the container image.
+
+**Diagnostics:**
+
+```bash
+kubectl describe pod <pod-name> -n <namespace>
+# Events section shows the exact pull error
+```
+
+| Error Message                           | Cause                        | Fix                                                            |
+| --------------------------------------- | ---------------------------- | -------------------------------------------------------------- |
+| `ErrImagePull` / `ImagePullBackOff`     | Image name or tag is wrong   | Verify image name and tag exist in the registry                |
+| `unauthorized: authentication required` | Missing or wrong pull secret | Create/update `imagePullSecrets` on the pod or service account |
+| `manifest unknown`                      | Tag doesn't exist            | Check available tags in the registry                           |
+| `context deadline exceeded`             | Registry unreachable         | Check network/firewall; for ACR, verify AKS -> ACR integration |
+
+**ACR integration check:**
+
+```bash
+# Verify AKS is attached to ACR
+az aks check-acr -g <rg> -n <cluster> --acr <acr-name>.azurecr.io
+```
+
+---
+
+## Pending Pods
+
+Pod stays in `Pending` - scheduler can't place it.
+
+**Diagnostics:**
+
+```bash
+kubectl describe pod <pod-name> -n <namespace>
+# Events section shows why scheduling failed
+```
+
+| Event Message                                                          | Cause                               | Fix                                                             |
+| ---------------------------------------------------------------------- | ----------------------------------- | --------------------------------------------------------------- |
+| `Insufficient cpu` / `Insufficient memory`                             | No node has enough resources        | Scale node pool; reduce resource requests; check for overcommit |
+| `node(s) had taint ... that the pod didn't tolerate`                   | Taint/toleration mismatch           | Add matching toleration or use a different node pool            |
+| `node(s) didn't match Pod's node affinity/selector`                    | Affinity rule unsatisfiable         | Check `nodeSelector` or `nodeAffinity` rules                    |
+| `persistentvolumeclaim ... not found` / `unbound`                      | PVC not ready                       | Check PVC status; verify storage class exists                   |
+| `0/N nodes are available: N node(s) had volume node affinity conflict` | Zonal disk vs pod in different zone | Use ZRS storage class or ensure same zone                       |
+
+---
+
+## Readiness & Liveness Probe Failures
+
+**Readiness probe failure** -> pod removed from Service endpoints (no traffic). **Liveness probe failure** -> pod killed and restarted.
+
+**Diagnostics:**
+
+```bash
+kubectl describe pod <pod-name> -n <namespace>
+# Look for: "Readiness probe failed" or "Liveness probe failed" in Events
+
+# Check the pod's READY column - must show n/n
+kubectl get pod <pod-name> -n <namespace>
+```
+
+| Symptom                              | Cause                   | Fix                                                        |
+| ------------------------------------ | ----------------------- | ---------------------------------------------------------- |
+| READY shows `0/1` but pod is Running | Readiness probe failing | Check probe path, port, and app health endpoint            |
+| Pod restarts repeatedly              | Liveness probe failing  | Increase `initialDelaySeconds`; check if app starts slowly |
+| Probe timeout errors                 | App responds too slowly | Increase `timeoutSeconds`; check app performance           |
+
+> 💡 **Tip:** Set `initialDelaySeconds` on liveness probes to be longer than your app's startup time. A common mistake is killing pods before they finish initializing.
+
+---
+
+## Resource Constraints (CPU/Memory)
+
+**Check actual usage vs limits:**
+
+```bash
+kubectl top pod <pod-name> -n <namespace>
+kubectl top pod -n <namespace> --sort-by=memory
+
+# Compare with requests/limits
+kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.containers[*].resources}'
+```
+
+| Symptom                          | Cause                                   | Fix                                                 |
+| -------------------------------- | --------------------------------------- | --------------------------------------------------- |
+| OOMKilled (exit code 137)        | Container exceeded memory limit         | Increase `limits.memory` or fix memory leak         |
+| CPU throttling (slow responses)  | Container hitting CPU limit             | Increase `limits.cpu` or remove CPU limits          |
+| Pending - insufficient resources | Requests exceed available node capacity | Lower requests, scale nodes, or use larger VM sizes |
+
+> ⚠️ **Warning:** Setting CPU limits can cause unnecessary throttling even when the node has spare capacity. Many teams set CPU requests but not limits. Memory limits should always be set.

--- a/plugins/aks-skills/skills/aks-troubleshooting/references/azure-mcp.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/references/azure-mcp.md
@@ -1,0 +1,41 @@
+# Azure MCP Server Reference
+
+Azure MCP Server is the `@azure/mcp` package configured by this repository. The **AKS MCP server** is the separate `Azure/aks-mcp` product; this repository does not configure it, and none of its deep Kubernetes tools or access-level flags are part of this reference.
+
+Use this reference to select Azure MCP Server operations and portable fallbacks in the current host.
+
+## Capability Discovery
+
+1. Inspect the host's available tool catalog or tool descriptions.
+2. Find the Azure MCP AKS area when cluster or node-pool metadata is needed.
+3. Identify AppLens, Azure Monitor, and Resource Health as separate Azure MCP areas when the investigation needs those capabilities.
+4. Use matching capabilities under the names assigned by the host. Names and prefixes are host-specific; a literal name is never an availability check.
+5. Inspect each selected tool's advertised schema, then choose the smallest read operation that fits.
+
+Do not guess names, translate one host's name to another, or build a mapping layer. Capability metadata supplied by the host is the source of truth.
+
+## Preference Order
+
+1. Host-discovered Azure MCP AKS cluster get/list or node-pool get/list operation
+2. Separate host-discovered AppLens, Azure Monitor, or Resource Health operation when relevant
+3. Portable `az` and `kubectl` flows for all other Azure-side and Kubernetes-side evidence
+
+## Happy Path
+
+After selecting the Azure MCP AKS area, inspect the exact operations and parameter schemas the host advertises. Its current scope is read-only metadata:
+
+- get or list AKS clusters
+- get or list AKS node pools
+
+Do not infer detector execution, monitoring queries, Resource Health checks, or Kubernetes command execution from the AKS area. Use the separate Azure MCP area that advertises the needed operation, or use the portable command flows.
+
+## Authentication And Access
+
+Authentication is host-specific. In Azure SRE Agent, built-in Azure operations use the agent's user-assigned managed identity; verify its target scope and RBAC. An external MCP connector uses the authentication configured on that connector. In CLI-backed hosts, the Azure MCP server can use the host's Azure CLI or service-principal context. Inspect the host and tool schema rather than assuming one credential source.
+
+## Fallback Rule
+
+Use these portable fallbacks whenever the host lacks the relevant Azure MCP Server area or its advertised schema does not provide the needed operation:
+
+- `az aks` for Azure-side AKS operations
+- raw `kubectl` for Kubernetes-side inspection

--- a/plugins/aks-skills/skills/aks-troubleshooting/references/command-flows.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/references/command-flows.md
@@ -1,0 +1,97 @@
+# AKS Command Flows
+
+## Cluster Baseline Flow
+
+```text
+Resolve subscription -> resolve resource group -> resolve cluster -> inspect cluster state -> inspect node pools -> inspect resource health -> inspect recent operations
+```
+
+Portable target-bound fallback for cluster metadata and Kubernetes state:
+
+```bash
+AKS_SUBSCRIPTION_ID=<subscription-id> \
+  scripts/cluster-snapshot.sh <resource-group> <cluster-name> <kube-context>
+```
+
+Gather resource health and recent Azure operations before this Kubernetes phase.
+
+## Kubernetes Baseline Flow
+
+```text
+Check API reachability -> inspect nodes -> inspect kube-system -> inspect events -> inspect affected namespace -> inspect pod details and logs
+```
+
+The snapshot verifies the kube endpoint before any Kubernetes API read. Use the pod collector for the final pod-detail/log phase:
+
+```bash
+AKS_SUBSCRIPTION_ID=<subscription-id> \
+  scripts/pod-deep-dive.sh \
+  <namespace> <pod-name> <resource-group> <cluster-name> <kube-context> \
+  <artifacts-directory>
+```
+
+## Connectivity Flow
+
+```text
+pod -> service -> endpoints -> ingress or load balancer -> DNS -> network controls
+```
+
+Portable Kubernetes CLI flow:
+
+```bash
+kubectl get pods -n <namespace> -o wide
+kubectl get svc -n <namespace>
+kubectl get endpoints -n <namespace>
+kubectl get ingress -n <namespace>
+kubectl describe ingress <ingress-name> -n <namespace>
+```
+
+## Detector Flow
+
+Use the separately advertised Azure MCP AppLens area when available; this is not part of the Azure MCP AKS metadata area.
+
+```text
+resolve cluster resource ID -> list detectors or choose category -> select a focused time window -> run the detector or category -> rank critical findings above warnings -> ignore emerging issues when choosing the primary root cause
+```
+
+## Monitoring Flow
+
+Use separately advertised Azure MCP Monitor and Resource Health areas when available, or their Azure CLI equivalents.
+
+```text
+check resource health -> inspect metrics -> verify diagnostics settings -> inspect control plane logs if available -> correlate with Application Insights or namespace symptoms
+```
+
+## Scheduling Flow
+
+```text
+pod events -> node capacity -> taints and tolerations -> affinity rules -> PVC state -> quotas
+```
+
+Portable Kubernetes CLI flow:
+
+```bash
+kubectl describe pod <pod-name> -n <namespace>
+kubectl get nodes -o wide
+kubectl describe node <node-name>
+kubectl get pvc -n <namespace>
+kubectl describe quota -n <namespace>
+```
+
+## Deep Diagnostics Flow (Inspektor Gadget)
+
+```text
+Standard diagnostics inconclusive -> prove the AKS/kube target -> select one symptom-specific gadget -> obtain privileged-debug approval -> run the digest-pinned command with finite bounds -> clean up the exact debug pod -> correlate output with prior evidence
+```
+
+Use when steps 1–3 of the evidence order (Azure-side, Kubernetes-side, and detector evidence) do not reveal root cause. See [inspektor-gadget.md](inspektor-gadget.md) for the pinned command pattern and gadget catalog.
+
+## Safety Boundary
+
+Treat the following as change operations and avoid them unless the user explicitly asks for remediation:
+
+- deleting or restarting pods
+- cordon and drain operations
+- scaling workloads or node pools
+- cluster upgrade operations
+- DNS, route, NSG, or firewall changes

--- a/plugins/aks-skills/skills/aks-troubleshooting/references/inspektor-gadget.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/references/inspektor-gadget.md
@@ -1,0 +1,151 @@
+# Inspektor Gadget (IG) Reference
+
+Use Inspektor Gadget for real-time, low-level node/pod diagnostics when `kubectl` is insufficient.
+
+## Approved Image
+
+Use the official `v0.51.0` multi-architecture image at this reviewed digest:
+
+```text
+mcr.microsoft.com/oss/v2/inspektor-gadget/ig:v0.51.0@sha256:6610863f6d8cae28800f9331756434639bca44be065719cbcfe76e34c91dffa4
+```
+
+Do not replace the digest with a tag-only reference. Re-review the upstream release and platform manifests before changing either the version or digest.
+
+## Base Command Pattern
+
+The incident owner must explicitly approve privileged debug-pod creation and choose a finite outer deadline before this command is run:
+
+```bash
+IG_IMAGE='mcr.microsoft.com/oss/v2/inspektor-gadget/ig:v0.51.0@sha256:6610863f6d8cae28800f9331756434639bca44be065719cbcfe76e34c91dffa4'
+timeout <approved-deadline> \
+  kubectl --context <kube-context> debug --profile=sysadmin \
+  node/<node-name> --attach --quiet --image="$IG_IMAGE" -- \
+  ig run <gadget>:v0.51.0 -o json --timeout <gadget-seconds> [filters...] \
+  > <raw-artifact>.json
+```
+
+Use both bounds: the outer deadline caps the whole `kubectl debug` operation, and the inner IG timeout caps the gadget. Use `--timeout 5` for snapshot/top and `--timeout 30` for trace/profile. Record the generated debug-pod name and delete that exact pod within the same approved operation.
+
+> **Note:** The gadget observes read-only state, but creating and deleting a `--profile=sysadmin` debug pod are privileged cluster mutations. Approval and appropriate RBAC are mandatory.
+
+**Required:** Resolve the node name first:
+
+```bash
+kubectl get pod <pod-name> -n <namespace> -o jsonpath='{.spec.nodeName}'
+```
+
+## Common Filters
+
+| Filter | Description |
+|---|---|
+| `--k8s-namespace <ns>` | Scope to a Kubernetes namespace |
+| `--k8s-podname <pod>` | Scope to a specific pod |
+| `--k8s-containername <ctr>` | Scope to a specific container |
+| `--timeout <seconds>` | Cap streaming duration for trace/profile gadgets |
+| `--max-entries <n>` | Max entries per batch for top/profile gadgets |
+| `--map-fetch-interval <dur>` | Map fetch interval for top (except `top_process`) and profile gadgets (default `1000ms`) |
+| `--interval <dur>` | Reporting interval for `top_process` only (e.g. `5s`) |
+| `--syscall-filters <list>` | Comma-separated syscalls for `traceloop` (e.g. `open,connect,accept`). **Always specify** to limit data volume |
+
+> **Tip:** For top/profile, set `--map-fetch-interval` ≤ half of `--timeout` to collect at least one batch. E.g. `--timeout 2 --map-fetch-interval 1000ms --max-entries 20`.
+>
+> **Note:** `top_process` uses `--interval` instead of `--map-fetch-interval`. E.g. `--timeout 10 --interval 5s --max-entries 20`.
+
+## Gadget Catalog
+
+### Networking
+
+| Gadget | Type | What It Does | When To Use |
+|---|---|---|---|
+| `trace_dns` | trace | Trace DNS queries and responses with latency | DNS failures, NXDOMAIN, SERVFAIL, slow resolution, intermittent DNS |
+| `trace_tcp` | trace | Trace TCP connect/accept/close events | Connection refused, timeouts, unexpected drops, mapping pod connectivity |
+| `trace_tcpretrans` | trace | Trace TCP retransmissions | Network congestion, lossy links, high latency between pods/services |
+| `trace_bind` | trace | Trace socket bind calls | Port conflicts, address-already-in-use errors |
+| `trace_sni` | trace | Trace TLS SNI (Server Name Indication) values | HTTPS routing issues, ingress TLS debugging, mTLS problems |
+| `snapshot_socket` | snapshot | List open sockets (TCP/UDP/Unix) | Port conflicts, listening ports, connection leaks, ECONNREFUSED |
+| `tcpdump` | special | Capture raw packets in pcap-ng format | Deep packet inspection, protocol-level debugging, reproducing network issues |
+
+#### tcpdump gadget
+
+Keep raw pcap-ng outside model context:
+
+```bash
+IG_IMAGE='mcr.microsoft.com/oss/v2/inspektor-gadget/ig:v0.51.0@sha256:6610863f6d8cae28800f9331756434639bca44be065719cbcfe76e34c91dffa4'
+timeout <approved-deadline> \
+  kubectl --context <kube-context> debug --profile=sysadmin \
+  node/<node-name> --attach --quiet --image="$IG_IMAGE" -- \
+  ig run tcpdump:v0.51.0 -o pcap-ng \
+  --k8s-namespace <ns> --k8s-podname <pod> \
+  --timeout 30 --pf "port 80" \
+  > <raw-artifact>.pcapng
+```
+
+Use `--pf "<expr>"` for a narrow tcpdump filter (for example, `port 80` or `host 10.0.0.1`). Output must be `-o pcap-ng` (not `-o json`). Inspect the artifact with an approved offline packet-analysis tool rather than pasting packet payloads into model context.
+
+### Process & Workload
+
+| Gadget | Type | What It Does | When To Use |
+|---|---|---|---|
+| `snapshot_process` | snapshot | List running processes in pod/node | PID pressure, unknown processes, verifying entrypoint, CrashLoopBackOff |
+| `trace_exec` | trace | Trace process execution (execve calls) | CrashLoopBackOff (what actually runs), unexpected child processes, security audit |
+| `trace_oomkill` | trace | Trace OOM kill events with victim details | OOMKilled pods — see which process was killed, memory usage at kill time |
+| `trace_signal` | trace | Trace signals delivered to processes | Unexpected SIGKILL/SIGTERM, liveness probe kills, graceful shutdown issues |
+| `top_process` | top | Rank processes by CPU/memory usage | Identifying resource-hungry processes inside a pod or across a node |
+| `profile_cpu` | profile | CPU profiling via stack sampling | High CPU usage investigation, finding hot code paths |
+| `traceloop` | trace | Record syscalls as a flight recorder | Catch-all for intermittent issues. **Always use `--syscall-filters`** (e.g., `open,connect,accept`) to limit data volume |
+
+### File & Storage
+
+| Gadget | Type | What It Does | When To Use |
+|---|---|---|---|
+| `trace_open` | trace | Trace openat syscall | Missing config/secret files (ENOENT), permission denied (EACCES), startup failures |
+| `trace_fsslower` | trace | Trace slow filesystem operations | Slow disk I/O, PVC performance issues, NFS/Azure Disk latency |
+| `top_file` | top | Rank files by read/write activity | Identifying I/O-heavy files, noisy log writers, disk pressure diagnosis |
+
+### Security & Audit
+
+| Gadget | Type | What It Does | When To Use |
+|---|---|---|---|
+| `trace_capabilities` | trace | Trace Linux capability checks | Permission denied from dropped capabilities, SecurityContext debugging |
+
+## Symptom-to-Gadget Map
+
+| Symptom | Gadget(s) |
+|---|---|
+| DNS resolution failures | `trace_dns` |
+| Connection refused / timeout | `trace_tcp` + `snapshot_socket` |
+| Silent connection drops | `trace_tcpretrans` |
+| High network latency | `trace_tcpretrans` |
+| TLS / HTTPS routing issues | `trace_sni` |
+| Port already in use | `trace_bind` + `snapshot_socket` |
+| CrashLoopBackOff (unknown cause) | `trace_exec` + `trace_open` |
+| OOMKilled pods | `trace_oomkill` + `top_process` |
+| Pod killed unexpectedly | `trace_signal` |
+| PID pressure on node | `snapshot_process` + `top_process` |
+| "Too many open files" | `top_file` |
+| Missing config / secret mount | `trace_open` |
+| Slow disk / PVC performance | `trace_fsslower` + `top_file` |
+| Permission denied (capabilities) | `trace_capabilities` |
+| High CPU (unknown cause) | `profile_cpu` + `top_process` |
+| Deep packet inspection | `tcpdump` |
+| Catch-all / intermittent issues | `traceloop` (use `--syscall-filters`) |
+
+## Gadget Type Reference
+
+| Type | Behavior | IG --timeout |
+|---|---|---|
+| `snapshot` | Point-in-time data, returns immediately | `--timeout 5` |
+| `top` | Aggregated view, returns quickly | `--timeout 5` |
+| `trace` | Streams events in real-time | `--timeout 30` |
+| `profile` | Samples over a duration | `--timeout 30` |
+| `tcpdump` | Streams pcap-ng data, pipe to `tcpdump -nvr -` | `--timeout 30` |
+
+## Guardrails
+
+- Prove the named AKS resource and kube context match before resolving the node or running IG.
+- Require explicit approval for privileged debug-pod creation and deletion.
+- Use only the digest-pinned image above, an outer deadline, and the gadget timeout.
+- Scope every run to the symptom, namespace, pod, and supported filter set; do not use an unbounded catch-all trace.
+- Keep raw JSON/pcap output outside model context and expose only a bounded, redacted finding summary.
+- Confirm deletion of the exact generated debug pod on success, failure, interruption, or timeout.

--- a/plugins/aks-skills/skills/aks-troubleshooting/references/report-template.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/references/report-template.md
@@ -1,0 +1,35 @@
+# Investigation Report
+
+**Date:** YYYY-MM-DDTHH:MM:SSZ
+**Cluster:** <cluster-name> / <resource-group> / <subscription>
+**Reported symptom:** <one-line symptom>
+
+## What Was Inspected
+
+| Resource | Command | Finding |
+|----------|---------|---------|
+| | | |
+
+## Root Cause
+
+<concise root cause — one or two sentences>
+
+## Evidence
+
+```
+<relevant log snippet or command output>
+```
+
+## Fix
+
+```bash
+# command(s) to resolve
+```
+
+## Additional Findings
+
+- (any secondary issues discovered during investigation)
+
+## Prevention
+
+- (optional: what would prevent recurrence — alert, config change, policy)

--- a/plugins/aks-skills/skills/aks-troubleshooting/references/structured-input-modes.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/references/structured-input-modes.md
@@ -1,0 +1,55 @@
+# AKS Structured Input Modes
+
+Use this reference when the troubleshooting request already contains structured inputs.
+
+## Detector-backed Mode
+
+Use when AKS-aware detectors or AppLens-style insights are available.
+
+Decision rules:
+
+- Ignore findings where the detector is `emergingIssues`.
+- Prefer critical findings over warnings.
+- Prefer findings with more concrete remediation detail when choosing the likely root problem.
+- Preserve per-insight output: problem summary, root-problem flag, affected resources, suggested commands.
+
+## Warning Events Mode
+
+Use when the request includes Kubernetes warning events.
+
+Expected output:
+
+- summary of the events and their impact
+- likely cause or causes
+- next kubectl checks
+- monitoring follow-up
+
+## Metrics Scan Mode
+
+Use when the request includes CPU or memory time-series data.
+
+Expected output:
+
+- healthy or unhealthy status
+- anomaly timestamps and explanations
+- suggestion tied to the observed metric pressure
+
+## Generic Symptoms Mode
+
+Use when the request includes resource symptoms but not detector results, warning events, or time-series metrics.
+
+Expected output:
+
+- symptom summary by resource
+- likely failure domain
+- next evidence-collection steps
+
+## Learn Grounding Fallback
+
+If the first troubleshooting pass is incomplete, search Microsoft Learn using:
+
+- the user prompt
+- the parsed problem names
+- the AKS troubleshooting context
+
+Use Learn grounding to refine or validate the root-cause hypothesis, not to replace observed evidence.

--- a/plugins/aks-skills/skills/aks-troubleshooting/references/symptom-map.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/references/symptom-map.md
@@ -1,0 +1,288 @@
+# Symptom → Investigation Map
+
+Look up the symptom, run the commands in order. Each section is self-contained.
+
+---
+
+## Pod Pending
+
+```bash
+kubectl describe pod <pod> -n <ns>         # Check Events for scheduling failure reason
+kubectl get events -n <ns> --sort-by='.lastTimestamp' --field-selector involvedObject.name=<pod>
+kubectl get nodes -o wide                  # Node count and status
+kubectl describe nodes | grep -A5 "Allocated resources"  # Resource pressure
+kubectl get pv,pvc -n <ns>                 # PVC binding stuck?
+```
+
+Common causes: insufficient CPU/memory, node taints without tolerations, PVC pending, node selector mismatch, subnet IP exhaustion (Azure CNI).
+
+---
+
+## Pod CrashLoopBackOff
+
+```bash
+# Preserve the terminated container output before another restart replaces it
+kubectl logs <pod> -n <ns> --previous --all-containers=true --prefix
+
+# Then collect current output from every app and init container
+kubectl logs <pod> -n <ns> --all-containers=true --prefix
+
+# Preserve pod state, termination reason/exit code, restart count, and events
+kubectl describe pod <pod> -n <ns>
+kubectl get pod <pod> -n <ns> \
+  -o jsonpath='{range .status.initContainerStatuses[*]}init/{.name}{"\t"}{.restartCount}{"\t"}{.lastState.terminated.reason}{"\t"}{.lastState.terminated.exitCode}{"\n"}{end}{range .status.containerStatuses[*]}container/{.name}{"\t"}{.restartCount}{"\t"}{.lastState.terminated.reason}{"\t"}{.lastState.terminated.exitCode}{"\n"}{end}'
+kubectl get events -n <ns> \
+  --field-selector involvedObject.kind=Pod,involvedObject.name=<pod> \
+  --sort-by='.metadata.creationTimestamp'
+```
+
+Distinguish the evidence before choosing a fix:
+
+- **Missing environment or Secret injection:** pod events report a missing Secret/key or `CreateContainerConfigError`, or the container log reports a required environment value is absent.
+- **Unmounted ConfigMap or configuration file:** pod events report `FailedMount`/`MountVolume.SetUp`, or the process starts and reports that the expected file path is absent. This is not the same as a missing environment value.
+- **OOM termination:** the terminated state reports `OOMKilled` or exit code `137`; compare limits and memory evidence.
+- **Unreachable dependency:** the application starts far enough to log DNS, timeout, refused-connection, TLS, or authentication errors for a named dependency.
+- **Probe-killed startup:** pod events show repeated startup/liveness probe failures and the termination/restart timeline follows those failures; distinguish a slow or invalid startup probe from an application crash.
+
+---
+
+## Node NotReady
+
+```bash
+AKS_RG="<cluster-resource-group>"
+AKS_NAME="<cluster-name>"
+NODE="<node-name>"
+
+kubectl describe node "$NODE"
+kubectl get node "$NODE" \
+  -o jsonpath='{range .status.conditions[*]}{.lastTransitionTime}{"\t"}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+kubectl get events --all-namespaces \
+  --field-selector involvedObject.kind=Node,involvedObject.name="$NODE" \
+  --sort-by='.metadata.creationTimestamp'
+
+# Derive the exact AKS node resource group, pool, VMSS, and instance
+NODE_RG=$(az aks show \
+  --resource-group "$AKS_RG" \
+  --name "$AKS_NAME" \
+  --query nodeResourceGroup -o tsv)
+AGENT_POOL=$(kubectl get node "$NODE" \
+  -o jsonpath='{.metadata.labels.agentpool}')
+PROVIDER_ID=$(kubectl get node "$NODE" \
+  -o jsonpath='{.spec.providerID}')
+VMSS=$(printf '%s\n' "$PROVIDER_ID" |
+  awk -F'/virtualMachineScaleSets/' '{print $2}' | cut -d/ -f1)
+INSTANCE_ID=${PROVIDER_ID##*/}
+
+printf 'nodeResourceGroup=%s\nagentPool=%s\nvmss=%s\ninstanceId=%s\n' \
+  "$NODE_RG" "$AGENT_POOL" "$VMSS" "$INSTANCE_ID"
+
+az aks nodepool show \
+  --resource-group "$AKS_RG" \
+  --cluster-name "$AKS_NAME" \
+  --name "$AGENT_POOL" \
+  --query '{provisioningState:provisioningState,powerState:powerState.code,nodeImageVersion:nodeImageVersion,orchestratorVersion:orchestratorVersion}' \
+  -o yaml
+az vmss get-instance-view \
+  --resource-group "$NODE_RG" \
+  --name "$VMSS" \
+  --instance-id "$INSTANCE_ID" \
+  -o json
+az vmss get-instance-view \
+  --resource-group "$NODE_RG" \
+  --name "$VMSS" \
+  --instance-id "$INSTANCE_ID" \
+  --query 'extensions[].{name:name,statuses:statuses,substatuses:substatuses}' \
+  -o json
+```
+
+Common causes: kubelet crash, containerd OOM, Azure host maintenance, disk full, NTP drift, CNI plugin crash.
+
+---
+
+## Image Pull Failure (ErrImagePull / ImagePullBackOff)
+
+```bash
+kubectl describe pod <pod> -n <ns>         # Image name and pull error in Events
+az aks show -g <rg> -n <cluster> --query "identityProfile.kubeletidentity.clientId" -o tsv
+az role assignment list --assignee <kubelet-id> --scope <acr-id> -o table
+az acr repository show -n <acr> --image <image>:<tag>
+```
+
+Common causes: wrong image tag, ACR not attached (`az aks update --attach-acr`), kubelet identity missing AcrPull role, private ACR without private endpoint.
+
+---
+
+## OOMKilled (Exit Code 137)
+
+```bash
+kubectl describe pod <pod> -n <ns>         # Last State: OOMKilled
+kubectl top pod -n <ns>                    # Current memory usage
+kubectl get pod <pod> -n <ns> -o jsonpath='{.spec.containers[*].resources}'
+kubectl logs <pod> -n <ns> --previous      # What was happening before OOM
+```
+
+Common causes: memory limit too low, memory leak, JVM heap exceeds container limit (set -Xmx), sidecar eating memory.
+
+---
+
+## Service Not Reachable / Connection Refused
+
+```bash
+kubectl get svc -n <ns>                    # ClusterIP, ports, selectors
+kubectl get endpoints -n <ns>              # Are endpoints populated?
+kubectl get pods -n <ns> -l <svc-selector> # Do pods match the selector?
+kubectl exec <client-pod> -n <ns> -- curl -v <svc>:<port>/healthz
+kubectl get networkpolicies -n <ns>        # Network policy blocking traffic?
+```
+
+Common causes: label selector mismatch (no endpoints), target port wrong, network policy denying ingress, pod not Ready.
+
+---
+
+## DNS Resolution Failure
+
+```bash
+kubectl exec <pod> -n <ns> -- nslookup kubernetes.default
+kubectl exec <pod> -n <ns> -- cat /etc/resolv.conf
+kubectl get pods -n kube-system -l k8s-app=kube-dns
+kubectl logs -n kube-system -l k8s-app=kube-dns --all-containers
+```
+
+Common causes: coredns pods crashed/pending, custom DNS config overriding cluster DNS, network policy blocking UDP 53, ndots:5 causing excessive lookups.
+
+---
+
+## Load Balancer Not Working
+
+```bash
+kubectl get svc -n <ns> -o wide            # EXTERNAL-IP stuck <pending>?
+kubectl describe svc <svc> -n <ns>         # Events for LoadBalancer provisioning errors
+az network lb list -g MC_<rg>_<cluster>_<region> -o table
+az network lb probe list -g MC_<rg>_<cluster>_<region> --lb-name <lb>
+az network lb rule list -g MC_<rg>_<cluster>_<region> --lb-name <lb>
+az network nsg rule list -g MC_<rg>_<cluster>_<region> --nsg-name <nsg>
+```
+
+Common causes: NSG blocking inbound, health probe path/port mismatch, subnet has no available IPs, service annotation misconfigured.
+
+---
+
+## Storage / PVC Stuck
+
+```bash
+kubectl get pvc -n <ns>                    # Status: Pending?
+kubectl describe pvc <pvc> -n <ns>         # Events for provisioning error
+kubectl get sc                             # StorageClass exists and is default?
+kubectl get pv                             # Volume available/bound?
+az disk list -g MC_<rg>_<cluster>_<region> --query "[?managedBy=='']" -o table  # Orphaned disks
+```
+
+Common causes: wrong StorageClass, disk in wrong zone/region, kubelet identity lacks disk attach permissions, Azure Disk max attach limit per VM size reached.
+
+---
+
+## Managed Identity / Permission Denied
+
+```bash
+az aks show -g <rg> -n <cluster> --query "identity"
+az aks show -g <rg> -n <cluster> --query "identityProfile"
+az role assignment list --assignee <identity-client-id> -o table
+az role assignment list --assignee <kubelet-client-id> -o table
+# Check if workload identity is configured
+kubectl get sa <sa> -n <ns> -o yaml | grep azure.workload.identity
+```
+
+Common causes: kubelet identity missing role, federated credential subject mismatch (namespace:sa typo), token audience wrong, identity not in same tenant.
+
+---
+
+## Node Pool Scaling Failure
+
+```bash
+az aks nodepool list -g <rg> --cluster-name <cluster> -o table
+az aks nodepool show -g <rg> --cluster-name <cluster> -n <pool> --query provisioningState
+az monitor activity-log list -g <rg> --offset 1h --query "[?status.value=='Failed']"
+az vm list-usage -l <region> -o table | grep -i "Total Regional vCPUs\|Standard.*Family"
+```
+
+Common causes: vCPU quota exhaustion, subnet IP exhaustion, VM SKU not available in region, system pool min-count prevents scale-down.
+
+---
+
+## API Server Unreachable / kubectl Can't Connect
+
+```bash
+az aks show -g <rg> -n <cluster> --query '{fqdn:fqdn, privateFqdn:privateFqdn, provisioningState:provisioningState, powerState:powerState.code}'
+FQDN=$(az aks show -g <rg> -n <cluster> --query fqdn -o tsv)
+nslookup "$FQDN"                           # DNS resolution of API server
+curl -k -Iv "https://$FQDN"               # TCP + TLS connectivity
+kubectl version --client                    # kubectl version (must be within ±2 minor versions of cluster)
+az aks show -g <rg> -n <cluster> --query kubernetesVersion -o tsv
+az aks show -g <rg> -n <cluster> --query "apiServerAccessProfile" # Authorized IP ranges / private cluster
+```
+
+Common causes: cluster stopped (power state not Running), private cluster accessed from outside VNet, client IP not in authorized IP ranges, API server FQDN DNS changed after stop/start, kubectl version skew > 2 minor versions, expired kubeconfig (`az aks get-credentials` to refresh).
+
+---
+
+## Cluster Create / Start Failure (VM Extension Errors)
+
+```bash
+az aks show -g <rg> -n <cluster> --query provisioningState -o tsv
+az monitor activity-log list -g <rg> --offset 1h --query "[?status.value=='Failed']" -o table
+# Check egress connectivity from node's perspective
+az aks show -g <rg> -n <cluster> --query "networkProfile.outboundType" -o tsv
+az network nsg list -g MC_<rg>_<cluster>_<region> -o table
+az network nsg rule list -g MC_<rg>_<cluster>_<region> --nsg-name <nsg> -o table
+```
+
+Common causes:
+- **Error 50 (OutboundConnFailVMExtensionError):** Node can't reach required endpoints. NSG or firewall blocks outbound to MCR, management.azure.com, or packages.microsoft.com.
+- **Error 51 (K8SAPIServerConnFailVMExtensionError):** Node can't connect to API server. Check NSG allows TCP 443 to API server IP.
+- **Error 52 (K8SAPIServerDNSLookupFailVMExtensionError):** DNS resolution for API server FQDN fails from node. Custom DNS without proper forwarding.
+
+---
+
+## Upgrade Stuck / Slow
+
+```bash
+az aks show -g <rg> -n <cluster> --query '{provisioningState:provisioningState, kubernetesVersion:kubernetesVersion}'
+az aks nodepool list -g <rg> --cluster-name <cluster> --query '[].{name:name, provisioningState:provisioningState, orchestratorVersion:orchestratorVersion, upgradeSettings:upgradeSettings}' -o table
+kubectl get pdb -A                         # PDBs blocking drain?
+kubectl get nodes -o wide                  # Nodes in mixed versions?
+az monitor activity-log list -g <rg> --offset 2h --query "[?contains(operationName.value,'Microsoft.ContainerService')]" -o table
+```
+
+Common causes: PDB blocking pod eviction (especially system pods), max-surge set to 1 (default — slow for large clusters), node with pods that have `terminationGracePeriodSeconds` > 30m, insufficient subnet IPs to surge new nodes.
+
+---
+
+## Egress / SNAT Exhaustion (Intermittent Outbound Failures)
+
+```bash
+az aks show -g <rg> -n <cluster> --query "networkProfile.outboundType" -o tsv
+az network lb show -g MC_<rg>_<cluster>_<region> --name kubernetes -o json --query '{outboundRules:outboundRules, frontendIPConfigurations:frontendIPConfigurations | length(@)}'
+az network nat gateway list -g MC_<rg>_<cluster>_<region> -o table
+kubectl get nodes | wc -l                  # Node count — SNAT issues start at ~500+ nodes
+# Test egress from inside a pod
+kubectl exec <pod> -n <ns> -- curl -sf -o /dev/null -w "%{http_code}" https://mcr.microsoft.com
+```
+
+Common causes: Azure LB SNAT port exhaustion (64K ports shared across nodes), too few frontend IPs for outbound rules, no NAT Gateway configured for large clusters. Fix: switch to `managedNATGateway` outbound type or add frontend IPs to LB.
+
+---
+
+## Certificate Expiration / Rotation
+
+```bash
+az aks show -g <rg> -n <cluster> --query "certificateProfile" 2>/dev/null || echo "(check cluster version)"
+# Check API server certificate expiry
+FQDN=$(az aks show -g <rg> -n <cluster> --query fqdn -o tsv)
+echo | openssl s_client -connect "$FQDN:443" -servername "$FQDN" 2>/dev/null | openssl x509 -noout -dates
+# Check for pending CSRs (kubelet cert rotation)
+kubectl get csr --sort-by='.metadata.creationTimestamp'
+# Check node kubelet certificate
+kubectl get nodes -o json | jq '.items[] | {name: .metadata.name, kubeletReady: (.status.conditions[] | select(.type=="Ready") | .status)}'
+```
+
+Common causes: AKS auto-rotates certs but rotation can fail if cluster is stopped for > 30 days, API server cert expired (nodes go NotReady), kubelet client cert expired (CSR stuck in Pending). Fix: `az aks rotate-certs` for full rotation.

--- a/plugins/aks-skills/skills/aks-troubleshooting/scripts/cluster-snapshot.sh
+++ b/plugins/aks-skills/skills/aks-troubleshooting/scripts/cluster-snapshot.sh
@@ -1,0 +1,84 @@
+#!/bin/sh
+# cluster-snapshot.sh — Quick cluster health overview
+# Run at the start of any investigation to capture baseline state.
+# Usage: sh cluster-snapshot.sh <resource-group> <cluster-name> <kube-context>
+set -e
+
+# Identify AKS Skills as the caller on Azure CLI requests so this traffic is
+# attributable server-side. Appends to any user agent the caller already set.
+export AZURE_HTTP_USER_AGENT="${AZURE_HTTP_USER_AGENT:+$AZURE_HTTP_USER_AGENT }AKS-Skills"
+
+RG="${1:-${AKS_RESOURCE_GROUP:-}}"
+CLUSTER="${2:-${AKS_CLUSTER_NAME:-}}"
+CONTEXT="${3:-${AKS_KUBE_CONTEXT:-}}"
+
+[ -n "$RG" ] && [ -n "$CLUSTER" ] && [ -n "$CONTEXT" ] || {
+  echo "usage: cluster-snapshot.sh <resource-group> <cluster-name> <kube-context>" >&2
+  exit 2
+}
+
+if [ -n "${AKS_SUBSCRIPTION_ID:-}" ]; then
+  aks_json=$(az aks show --subscription "$AKS_SUBSCRIPTION_ID" \
+    -g "$RG" -n "$CLUSTER" -o json 2>/dev/null)
+else
+  aks_json=$(az aks show -g "$RG" -n "$CLUSTER" -o json 2>/dev/null)
+fi || {
+  echo "AKS resource target is inaccessible" >&2
+  exit 2
+}
+kube_server=$(kubectl --context "$CONTEXT" config view --minify \
+  -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null) || {
+  echo "kube context is inaccessible" >&2
+  exit 2
+}
+normalize() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' |
+    sed -E 's#^[a-z]+://##; s#/.*$##; s#:[0-9]+$##; s/\.$//'
+}
+kube_host=$(normalize "$kube_server")
+public_host=$(normalize "$(printf '%s' "$aks_json" | jq -r '.fqdn // empty')")
+private_host=$(normalize "$(printf '%s' "$aks_json" | jq -r '.privateFqdn // empty')")
+[ -n "$kube_host" ] &&
+  { [ "$kube_host" = "$public_host" ] || [ "$kube_host" = "$private_host" ]; } || {
+  echo "kube context does not target the named AKS cluster" >&2
+  exit 2
+}
+kube() {
+  kubectl --context "$CONTEXT" "$@"
+}
+
+echo "=== Cluster Snapshot $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "targetProof=matched cluster=$RG/$CLUSTER context=$CONTEXT"
+
+echo ""
+echo "--- Nodes ---"
+kube get nodes -o wide 2>/dev/null || echo "(kubectl not configured)"
+
+echo ""
+echo "--- Node Conditions (non-Ready or pressure) ---"
+kube get nodes -o json 2>/dev/null | \
+  jq -r '.items[] | .metadata.name as $n | .status.conditions[] | select(.type != "Ready" and .status == "True") | [$n, .type, .reason] | @tsv' 2>/dev/null || true
+kube get nodes -o json 2>/dev/null | \
+  jq -r '.items[] | .metadata.name as $n | .status.conditions[] | select(.type == "Ready" and .status != "True") | [$n, .type, .status, .reason] | @tsv' 2>/dev/null || true
+
+echo ""
+echo "--- Pods Not Running/Succeeded (all namespaces) ---"
+kube get pods -A --field-selector 'status.phase!=Running,status.phase!=Succeeded' 2>/dev/null || echo "(none or error)"
+
+echo ""
+echo "--- Recent Warning Events (last 30m) ---"
+kube get events -A --field-selector type=Warning --sort-by='.lastTimestamp' 2>/dev/null | tail -20 || true
+
+echo ""
+echo "--- Resource Pressure ---"
+kube top nodes 2>/dev/null || echo "(metrics-server not available)"
+
+if [ -n "$RG" ] && [ -n "$CLUSTER" ]; then
+  echo ""
+  echo "--- AKS Cluster State ---"
+  printf '%s' "$aks_json" | \
+    jq '{provisioningState, powerState: .powerState.code, kubernetesVersion, networkPlugin: .networkProfile.networkPlugin, networkPolicy: .networkProfile.networkPolicy, nodePools: [.agentPoolProfiles[] | {name, count, vmSize, provisioningState, mode, osType}]}' 2>/dev/null || echo "(unable to project AKS state)"
+fi
+
+echo ""
+echo "=== End Snapshot ==="

--- a/plugins/aks-skills/skills/aks-troubleshooting/scripts/pod-deep-dive.sh
+++ b/plugins/aks-skills/skills/aks-troubleshooting/scripts/pod-deep-dive.sh
@@ -1,0 +1,105 @@
+#!/bin/sh
+# pod-deep-dive.sh — Full diagnostic dump for a single pod
+# Usage: pod-deep-dive.sh <namespace> <pod> <resource-group> <cluster> <context> <artifacts-dir>
+set -e
+
+NS="${1:-}"
+POD="${2:-}"
+RG="${3:-${AKS_RESOURCE_GROUP:-}}"
+CLUSTER="${4:-${AKS_CLUSTER_NAME:-}}"
+CONTEXT="${5:-${AKS_KUBE_CONTEXT:-}}"
+ARTIFACTS="${6:-${AKS_ARTIFACTS_DIR:-}}"
+LOG_LINES=50
+
+[ -n "$NS" ] && [ -n "$POD" ] && [ -n "$RG" ] && [ -n "$CLUSTER" ] &&
+  [ -n "$CONTEXT" ] && [ -n "$ARTIFACTS" ] || {
+  echo "usage: pod-deep-dive.sh <namespace> <pod> <resource-group> <cluster> <context> <artifacts-dir>" >&2
+  exit 2
+}
+[ "$ARTIFACTS" != "/" ] && [ ! -L "$ARTIFACTS" ] || {
+  echo "invalid artifacts directory" >&2
+  exit 2
+}
+mkdir -p "$ARTIFACTS"
+chmod 700 "$ARTIFACTS"
+
+if [ -n "${AKS_SUBSCRIPTION_ID:-}" ]; then
+  aks_json=$(az aks show --subscription "$AKS_SUBSCRIPTION_ID" \
+    -g "$RG" -n "$CLUSTER" -o json 2>/dev/null)
+else
+  aks_json=$(az aks show -g "$RG" -n "$CLUSTER" -o json 2>/dev/null)
+fi || {
+  echo "AKS resource target is inaccessible" >&2
+  exit 2
+}
+kube_server=$(kubectl --context "$CONTEXT" config view --minify \
+  -o jsonpath='{.clusters[0].cluster.server}' 2>/dev/null) || {
+  echo "kube context is inaccessible" >&2
+  exit 2
+}
+normalize() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' |
+    sed -E 's#^[a-z]+://##; s#/.*$##; s#:[0-9]+$##; s/\.$//'
+}
+kube_host=$(normalize "$kube_server")
+public_host=$(normalize "$(printf '%s' "$aks_json" | jq -r '.fqdn // empty')")
+private_host=$(normalize "$(printf '%s' "$aks_json" | jq -r '.privateFqdn // empty')")
+[ -n "$kube_host" ] &&
+  { [ "$kube_host" = "$public_host" ] || [ "$kube_host" = "$private_host" ]; } || {
+  echo "kube context does not target the named AKS cluster" >&2
+  exit 2
+}
+kube() {
+  kubectl --context "$CONTEXT" "$@"
+}
+redact() {
+  sed -E \
+    -e 's/(Authorization:).*/\1 [REDACTED]/I' \
+    -e 's/((client[_-]?secret|password|token|api[_-]?key)[[:space:]]*[:=][[:space:]]*)[^[:space:]]+/\1[REDACTED]/Ig' \
+    -e 's/([?&]sig=)[^&[:space:]]+/\1[REDACTED]/Ig'
+}
+logs() {
+  label="$1"
+  shift
+  raw="$ARTIFACTS/$label.raw.log"
+  kube logs "$POD" -n "$NS" --all-containers=true --prefix=true \
+    --tail="$LOG_LINES" "$@" >"$raw" 2>&1 || true
+  chmod 600 "$raw"
+  redact <"$raw" | sed -n "1,${LOG_LINES}p"
+}
+
+echo "=== Pod Deep Dive: $NS/$POD $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+echo "targetProof=matched cluster=$RG/$CLUSTER context=$CONTEXT"
+echo "rawArtifacts=$ARTIFACTS"
+
+echo ""
+echo "--- Pod Status ---"
+kube get pod "$POD" -n "$NS" -o wide 2>/dev/null || { echo "Pod not found"; exit 1; }
+
+echo ""
+echo "--- Describe ---"
+kube describe pod "$POD" -n "$NS" 2>/dev/null
+
+echo ""
+echo "--- Container Resources ---"
+kube get pod "$POD" -n "$NS" -o json | \
+  jq '.spec.containers[] | {name, resources}' 2>/dev/null || true
+
+echo ""
+echo "--- Current Logs (all containers) ---"
+logs current
+
+echo ""
+echo "--- Previous Logs (all containers) ---"
+logs previous --previous
+
+echo ""
+echo "--- Events ---"
+kube get events -n "$NS" --field-selector "involvedObject.name=$POD" --sort-by='.lastTimestamp' 2>/dev/null || true
+
+echo ""
+echo "--- Resource Usage ---"
+kube top pod "$POD" -n "$NS" --containers 2>/dev/null || echo "(metrics not available)"
+
+echo ""
+echo "=== End Deep Dive ==="

--- a/plugins/aks-skills/skills/aks-troubleshooting/spot-and-zone-issues.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/spot-and-zone-issues.md
@@ -1,0 +1,64 @@
+# Spot And Zone Issues
+
+Use this guide when workload placement, evictions, or zonal behavior is causing node-pool instability.
+
+## Spot Node Pool Evictions
+
+AKS spot nodes use Azure Spot VMs - they can be evicted with 30 seconds notice when Azure needs capacity.
+
+**Diagnose spot eviction:**
+
+```bash
+# Spot nodes carry this taint automatically
+kubectl describe node <node> | grep "Taint"
+# kubernetes.azure.com/scalesetpriority=spot:NoSchedule
+
+# Check eviction events
+kubectl get events -A --field-selector reason=SpotEviction
+kubectl get events -A | grep -i "evict\|spot\|preempt"
+```
+
+**Spot workload pattern:** pods must tolerate the spot taint. Prefer PDBs and avoid stateful PVC workloads on spot.
+
+```yaml
+tolerations:
+  - key: "kubernetes.azure.com/scalesetpriority"
+    operator: Equal
+    value: spot
+    effect: NoSchedule
+```
+
+Add this preferred node affinity when you want the workload to bias toward spot nodes:
+
+```yaml
+affinity:
+  nodeAffinity:
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 1
+        preference:
+          matchExpressions:
+            - key: kubernetes.azure.com/scalesetpriority
+              operator: In
+              values: ["spot"]
+```
+
+---
+
+## Multi-AZ Node Pool & Zone-Related Failures
+
+**Check zone distribution:**
+
+```bash
+kubectl get nodes -L topology.kubernetes.io/zone
+```
+
+**Zone-related failure patterns:**
+
+| Symptom                                          | Cause                                                | Fix                                                          |
+| ------------------------------------------------ | ---------------------------------------------------- | ------------------------------------------------------------ |
+| Pods stack on one zone after node failures       | Scheduling imbalance after zone failure              | `kubectl rollout restart deployment/<n>` to rebalance        |
+| PVC pending with `volume node affinity conflict` | Azure Disk is zonal; pod scheduled in different zone | Use ZRS storage class or ensure PVC and pod are in same zone |
+| Service endpoints unreachable from one zone      | Topology-aware routing misconfigured                 | Check `service.spec.trafficDistribution` or TopologyKeys     |
+| Upgrade causing zone imbalance                   | Surge nodes in one zone                              | Configure `maxSurge` in node pool upgrade settings           |
+
+Use `Premium_ZRS` or `StandardSSD_ZRS` in custom StorageClasses to reduce zonal PVC conflicts. See [AKS storage best practices](https://learn.microsoft.com/azure/aks/operator-best-practices-storage).

--- a/plugins/aks-skills/skills/aks-troubleshooting/upgrade-operations.md
+++ b/plugins/aks-skills/skills/aks-troubleshooting/upgrade-operations.md
@@ -1,0 +1,87 @@
+# Upgrade Operations
+
+Use this guide when node image rotation, Kubernetes version changes, or node-pool upgrade settings appear to be the failure domain.
+
+## Stuck or Failed Upgrade: Mandatory Read-only Evidence
+
+A stuck-upgrade diagnosis is incomplete until every step below is collected, or the inability to collect it is recorded. Do not skip deprecated API, admission webhook, upgrade-path, PDB/drain/event, or current `maxSurge` evidence.
+
+```bash
+# 1. Control-plane and node-pool state, versions, image, and current maxSurge
+az aks show \
+  --resource-group <cluster-resource-group> \
+  --name <cluster-name> \
+  --query '{provisioningState:provisioningState,powerState:powerState.code,kubernetesVersion:kubernetesVersion,currentKubernetesVersion:currentKubernetesVersion}' \
+  -o yaml
+az aks nodepool list \
+  --resource-group <cluster-resource-group> \
+  --cluster-name <cluster-name> \
+  --query '[].{name:name,provisioningState:provisioningState,powerState:powerState.code,orchestratorVersion:orchestratorVersion,currentOrchestratorVersion:currentOrchestratorVersion,nodeImageVersion:nodeImageVersion,maxSurge:upgradeSettings.maxSurge}' \
+  -o table
+kubectl get nodes -o wide
+
+# 2. Supported control-plane and affected node-pool upgrade paths
+az aks get-upgrades \
+  --resource-group <cluster-resource-group> \
+  --name <cluster-name> -o table
+az aks nodepool get-upgrades \
+  --resource-group <cluster-resource-group> \
+  --cluster-name <cluster-name> \
+  --nodepool-name <affected-nodepool> -o table
+
+# 3. Deprecated API requests that can stop an upgrade
+kubectl get --raw /metrics |
+  grep 'apiserver_requested_deprecated_apis'
+
+# 4. Admission webhooks that can reject or delay upgrade-time operations
+kubectl get validatingwebhookconfigurations,mutatingwebhookconfigurations \
+  -o yaml
+
+# 5. PDB and drain-blocker evidence
+kubectl get pdb -A \
+  -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,MIN_AVAILABLE:.spec.minAvailable,MAX_UNAVAILABLE:.spec.maxUnavailable,ALLOWED:.status.disruptionsAllowed,CURRENT_HEALTHY:.status.currentHealthy,DESIRED_HEALTHY:.status.desiredHealthy'
+kubectl describe pdb <pdb-name> -n <ns>
+kubectl get pods -A \
+  -o custom-columns='NAMESPACE:.metadata.namespace,NAME:.metadata.name,NODE:.spec.nodeName,PHASE:.status.phase,GRACE_SECONDS:.spec.terminationGracePeriodSeconds'
+kubectl get events --all-namespaces \
+  --sort-by='.metadata.creationTimestamp'
+```
+
+Interpret this evidence before selecting remediation:
+
+- A non-`Succeeded` provisioning state can block a new upgrade or indicate an operation still in progress.
+- An unavailable target version is not a valid upgrade path.
+- Deprecated API metrics identify clients that must be migrated before the target version removes the API.
+- Webhook service failures, restrictive failure policies, or timeouts can block admission.
+- `disruptionsAllowed: 0`, unhealthy replicas, long termination grace periods, and pod events can explain drain failure.
+- The reported `upgradeSettings.maxSurge` is the current configuration; choose any change from workload capacity, quota, subnet address, PDB, and availability evidence rather than a hard-coded percentage.
+
+## Mutation boundary: approval required
+
+`az aks upgrade`, `az aks nodepool upgrade`, and `az aks nodepool update --max-surge` mutate cluster state. The signatures below classify the boundary; do not recommend or execute them unless the owner explicitly approves the target version or surge value and accepts the change window.
+
+```bash
+# Control-plane and cluster upgrade
+az aks upgrade \
+  --resource-group <cluster-resource-group> \
+  --name <cluster-name> \
+  --kubernetes-version <approved-version>
+
+# Node-pool version or image upgrade
+az aks nodepool upgrade \
+  --resource-group <cluster-resource-group> \
+  --cluster-name <cluster-name> \
+  --name <nodepool-name> \
+  --kubernetes-version <approved-version>
+
+# Node-image-only upgrade uses the same mutating command with --node-image-only
+
+# Change maxSurge
+az aks nodepool update \
+  --resource-group <cluster-resource-group> \
+  --cluster-name <cluster-name> \
+  --name <nodepool-name> \
+  --max-surge <approved-count-or-percentage>
+```
+
+Changing or deleting a PDB, scaling a workload, retrying an upgrade, or changing a webhook is also mutating remediation. Preserve the original object, confirm workload availability requirements, and obtain explicit approval before making any of those changes.

--- a/plugins/aks-skills/skills/aks-troubleshooting/version.json
+++ b/plugins/aks-skills/skills/aks-troubleshooting/version.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.2",
+  "pathFilters": [
+    "."
+  ]
+}

--- a/plugins/aks-skills/version.json
+++ b/plugins/aks-skills/version.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "version": "1.0",
+  "pathFilters": [
+    "."
+  ]
+}

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -40,6 +40,16 @@
             }
         },
         {
+            "name": "aks-skills",
+            "dirname": "aks-skills",
+            "skills": [
+                "aks-network-capture"
+            ],
+            "integrationTestSchedule": {
+                "0 12 * * 2-6": "aks-network-capture"
+            }
+        },
+        {
             "name": "azure-kusto-graph-skills",
             "dirname": "azure-kusto-graph-skills",
             "skills": [

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -43,10 +43,11 @@
             "name": "aks-skills",
             "dirname": "aks-skills",
             "skills": [
-                "aks-network-capture"
+                "aks-network-capture",
+                "aks-troubleshooting"
             ],
             "integrationTestSchedule": {
-                "0 12 * * 2-6": "aks-network-capture"
+                "0 12 * * 2-6": "aks-network-capture,aks-troubleshooting"
             }
         },
         {

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -43,12 +43,13 @@
             "name": "aks-skills",
             "dirname": "aks-skills",
             "skills": [
+                "aks-gpu-inference",
                 "aks-known-issues",
                 "aks-network-capture",
                 "aks-troubleshooting"
             ],
             "integrationTestSchedule": {
-                "0 12 * * 2-6": "aks-known-issues,aks-network-capture,aks-troubleshooting"
+                "0 12 * * 2-6": "aks-gpu-inference,aks-known-issues,aks-network-capture,aks-troubleshooting"
             }
         },
         {

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -43,11 +43,12 @@
             "name": "aks-skills",
             "dirname": "aks-skills",
             "skills": [
+                "aks-known-issues",
                 "aks-network-capture",
                 "aks-troubleshooting"
             ],
             "integrationTestSchedule": {
-                "0 12 * * 2-6": "aks-network-capture,aks-troubleshooting"
+                "0 12 * * 2-6": "aks-known-issues,aks-network-capture,aks-troubleshooting"
             }
         },
         {


### PR DESCRIPTION
## Summary

Adds `plugins/aks-skills` as a budget-isolated sibling plugin for focused AKS Day-2 operations. The stack migrates accepted capabilities side-by-side with the existing broad `azure-skills` plugin rather than rewriting or deleting it.

## Accepted layers

1. `8918b5e8` — AKS network capture sibling plugin foundation and bounded packet-capture workflow.
2. `c3c218ba` — evidence-first AKS troubleshooting skill and native Vally public-canary coverage.
3. `2d909f05` — exact-signature AKS known-issues routing and coexistence coverage.
4. `f9fb003b` — profile-aware GPU and KAITO Day-2 diagnosis, observability, scaling separation, and route-competition coverage.

The stack is based on accepted repository commit `83fc4982` and is proposed against the current upstream `main`.

## Architecture and coexistence

- Keeps AKS operational skills under `plugins/aks-skills` with independent manifests, versions, build output, registry entries, and test scheduling.
- Preserves `plugins/azure-skills` unchanged.
- Routes explicit packet-capture intent to `aks-network-capture` and generic AKS connectivity incidents to `aks-troubleshooting`.
- Routes cataloged, fully qualified AKS operation signatures to `aks-known-issues`; generic or incomplete wrappers remain with troubleshooting.
- Routes existing AKS GPU/KAITO Day-2 incidents to `aks-gpu-inference`; initial AI/KAITO setup remains with `airunway-aks-setup`.
- Keeps non-GPU Azure diagnostics, standalone VM quota, compute, and generic cost requests with their existing broad skills.
- Requires target-bound, read-only evidence first and explicit authorization before mutations.

## Validation

The accepted layers were validated with repository build/version stamping, frontmatter and reference validation, registry and schedule coverage, token and Copilot CLI character budgets, unit tests, lint, typecheck, Vally stimulus validation, and strict Vally lint.

The final GPU tree passed all eight native Vally stimuli, including every required/disallowed routing grader and binary decision rubric, at 100% against the repository threshold. The final one-commit GPU SHA preserves that exact reviewed tree.

## Deferred or retired scope

This PR does not migrate every source skill. Setup-oriented, generic, overlapping, unsupported, or insufficiently evidenced material remains deferred or retired from this stack. In particular, it does not add AI Runway/KAITO setup, provider or model selection, generic VM quota, generic cost/spot/OOM guidance, duplicate model/SKU sizing tables, unsupported KAITO internals, unsourced rankings/timings/prices/discounts, or legacy deletion.

## Risks

- The migrated behavior is validated through supplied-evidence Vally scenarios; no authorized live GPU/KAITO substrate was used.
- Managed GPU guidance follows current Microsoft Learn preview constraints, including no cluster autoscaler support for managed GPU preview pools.
- Packaging/materialization and any future source retirement remain separate owner decisions.

## Non-goals

- No rewrite or deletion of `azure-skills`.
- No package-manifest, workflow, CODEOWNERS, generic runner/grader/provider, or deployment changes beyond the accepted sibling-plugin layers.
- No reviewer requests, stakeholder outreach, ready-for-review transition, or merge as part of this draft.
