### PR TITLE
chore: bring back additional filter for multiple plugins

### DIFF
--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -74,7 +74,8 @@
 #     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
 #     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
 #
-#   Recognized azure-skills install paths:
+#   Recognized install paths (one set per plugin, see $pathPatterns below):
+#     azure-skills:
 #     - .copilot/installed-plugins/<catalog-name>/azure/skills/...
 #       (<catalog-name> is the marketplace/catalog folder the plugin was
 #       installed under, e.g. "awesome-copilot" — it does not necessarily
@@ -82,6 +83,11 @@
 #     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
 #     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
 #     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
+#     azure-kusto-graph-skills:
+#     - .copilot/installed-plugins/<catalog-name>/azure-kusto-graph-skills/skills/...
+#     - .claude/plugins/cache/azure-skills/azure-kusto-graph-skills/<version>/skills/...
+#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/...
+#     shared:
 #     - .agents/skills/...
 #
 #   If the path matches AND is not a SKILL.md file, the relative path after
@@ -289,14 +295,32 @@ function Get-ToolInputPath {
 
 # === STEP 2: Determine what to track for azmcp ===
 
-# Azure-skills path patterns per client (used for SKILL.md and file-reference matching)
+# Path patterns per client, one block per plugin (used for SKILL.md and
+# file-reference matching). Add a new block (with the "azure-skills"
+# segments swapped for the new plugin's name) when onboarding another plugin.
+
+# --- azure-skills plugin ---
+# The Copilot CLI pattern wildcards the catalog/marketplace folder name
+# (e.g. "awesome-copilot") since it does not necessarily match the plugin's
+# own name ("azure").
 $pathPatternCopilot = '\.copilot/installed-plugins/[^/]+/azure/skills/'
 $pathPatternClaude = '\.claude/plugins/cache/(azure-skills|claude-plugins-official)/azure/[0-9.]+/skills/'
 $pathPatternVscodeAgentPlugins = 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-skills/skills/'
+
+# --- azure-kusto-graph-skills plugin ---
+$pathPatternCopilotKustoGraph = '\.copilot/installed-plugins/[^/]+/azure-kusto-graph-skills/skills/'
+$pathPatternClaudeKustoGraph = '\.claude/plugins/cache/azure-skills/azure-kusto-graph-skills/[0-9.]+/skills/'
+$pathPatternVscodeAgentPluginsKustoGraph = 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-kusto-graph-skills/skills/'
+
+# --- shared across all plugins ---
 $pathPatternAgentsSkills = '\.agents/skills/'
 
 # Put the path patterns into an array for easier iteration
-$pathPatterns = @($pathPatternCopilot, $pathPatternClaude, $pathPatternVscodeAgentPlugins, $pathPatternAgentsSkills)
+$pathPatterns = @(
+    $pathPatternCopilot, $pathPatternClaude, $pathPatternVscodeAgentPlugins,
+    $pathPatternCopilotKustoGraph, $pathPatternClaudeKustoGraph, $pathPatternVscodeAgentPluginsKustoGraph,
+    $pathPatternAgentsSkills
+)
 
 # If $env:AZURE_SKILLS_PLUGIN_ROOT is set, add it to the path patterns for local skill development
 if ($env:AZURE_SKILLS_PLUGIN_ROOT) {

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -296,8 +296,9 @@ function Get-ToolInputPath {
 # === STEP 2: Determine what to track for azmcp ===
 
 # Path patterns per client, one block per plugin (used for SKILL.md and
-# file-reference matching). Add a new block (with the "azure-skills"
-# segments swapped for the new plugin's name) when onboarding another plugin.
+# file-reference matching). When onboarding another plugin, add a new block by
+# swapping both the catalog/plugin segments (e.g. "azure" and "azure-skills")
+# for the new plugin's name.
 
 # --- azure-skills plugin ---
 # The Copilot CLI pattern wildcards the catalog/marketplace folder name

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -303,9 +303,9 @@ fi
 # === STEP 2: Determine what to track for azmcp ===
 
 # Check if a path matches any known plugin skills folder structure.
-# Each plugin has its own block below — add a new block (with the
-# "azure-skills" segments swapped for the new plugin's name) when onboarding
-# another plugin. Returns 0 (true) if matched, 1 (false) otherwise.
+ # Each plugin has its own block below — when onboarding another plugin, add a new
+ # block by swapping both the catalog/plugin segments (e.g. "azure" and
+ # "azure-skills") for the new plugin. Returns 0 (true) if matched, 1 (false) otherwise.
 is_azure_skills_path() {
     local p="$1"
 

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -76,7 +76,8 @@
 #     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
 #     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
 #
-#   Recognized azure-skills install paths:
+#   Recognized install paths (one set per plugin, see is_azure_skills_path):
+#     azure-skills:
 #     - .copilot/installed-plugins/<catalog-name>/azure/skills/...
 #       (<catalog-name> is the marketplace/catalog folder the plugin was
 #       installed under, e.g. "awesome-copilot" — it does not necessarily
@@ -84,6 +85,11 @@
 #     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
 #     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
 #     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
+#     azure-kusto-graph-skills:
+#     - .copilot/installed-plugins/<catalog-name>/azure-kusto-graph-skills/skills/...
+#     - .claude/plugins/cache/azure-skills/azure-kusto-graph-skills/<version>/skills/...
+#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/...
+#     shared:
 #     - .agents/skills/...
 #
 #   If the path matches AND is not a SKILL.md file, the relative path after
@@ -296,15 +302,30 @@ fi
 
 # === STEP 2: Determine what to track for azmcp ===
 
-# Check if a path matches any known azure-skills folder structure
-# Returns 0 (true) if matched, 1 (false) otherwise
+# Check if a path matches any known plugin skills folder structure.
+# Each plugin has its own block below — add a new block (with the
+# "azure-skills" segments swapped for the new plugin's name) when onboarding
+# another plugin. Returns 0 (true) if matched, 1 (false) otherwise.
 is_azure_skills_path() {
     local p="$1"
+
+    # --- azure-skills plugin ---
+    # The Copilot CLI pattern wildcards the catalog/marketplace folder name
+    # (e.g. "awesome-copilot") since it does not necessarily match the
+    # plugin's own name ("azure").
     [[ "$p" == *".copilot/installed-plugins/"*"/azure/skills/"* ]] && return 0
     [[ "$p" == *".claude/plugins/cache/azure-skills/azure/"*"/skills/"* ]] && return 0
     [[ "$p" == *".claude/plugins/cache/claude-plugins-official/azure/"*"/skills/"* ]] && return 0
     [[ "$p" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/"* ]] && return 0
+
+    # --- azure-kusto-graph-skills plugin ---
+    [[ "$p" == *".copilot/installed-plugins/"*"/azure-kusto-graph-skills/skills/"* ]] && return 0
+    [[ "$p" == *".claude/plugins/cache/azure-skills/azure-kusto-graph-skills/"*"/skills/"* ]] && return 0
+    [[ "$p" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/"* ]] && return 0
+
+    # --- shared across all plugins ---
     [[ "$p" == *".agents/skills/"* ]] && return 0
+
     # Local plugin development: match paths under AZURE_SKILLS_PLUGIN_ROOT/skills/
     # (e.g. when loading a local plugin via `--plugin-dir`)
     if [ -n "$AZURE_SKILLS_PLUGIN_ROOT" ]; then
@@ -431,3 +452,4 @@ fi
 
 # Output success to stdout (required by hooks)
 return_success
+


### PR DESCRIPTION
## Description

We have identified that the root cause of the telemetry regression was in Azure MCP. This PR brings the temporarily removed filters for multiple plugins back.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
