### PR TITLE
fix: pass MSBench encrypted env names separately

### DIFF
--- a/pipelines/scripts/Invoke-RunBenchmarks.ps1
+++ b/pipelines/scripts/Invoke-RunBenchmarks.ps1
@@ -172,7 +172,7 @@
             "--agent", "github-copilot-cli",
             "--benchmark", $Benchmark,
             "--model", $m,
-            "--encrypted-env", "CAPI_INTEGRATION_ID CAPI_HMAC_KEY",
+            "--encrypted-env", "CAPI_INTEGRATION_ID", "CAPI_HMAC_KEY",
             "--env", "USE_COPILOT_CLI_VERSION",
             "--dataset", (Join-Path $targetDir "metadata.csv"),
             "--tag", "org=CoreAI Cloud and Tools",


### PR DESCRIPTION
MSBench validation fails because PowerShell passes `CAPI_INTEGRATION_ID CAPI_HMAC_KEY` as one argv token and the CLI interprets it as a single missing environment-variable name.

This passes `CAPI_INTEGRATION_ID` and `CAPI_HMAC_KEY` as separate values after `--encrypted-env`, while preserving `USE_COPILOT_CLI_VERSION` under `--env`.

Validation: parsed the script with the PowerShell AST and confirmed the expected argv token boundaries without accessing secret values or running the benchmark pipeline.