### PR TITLE
fix: deduplicate events from track-telemetry script

### DIFF
--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -159,6 +159,18 @@ $scriptDir = $PSScriptRoot
 if (-not $scriptDir) { $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path }
 $skillsDir = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) 'skills'
 
+# Return true only when a target belongs to this hook's plugin. Since this hook
+# is copied into every plugin, comparing through the skills directory prevents
+# each installed copy from reporting the same skill or reference event.
+function Test-OwnedSkillPath {
+    # targetPath is either path to the SKILL.md or to a reference file
+    param([string]$TargetPath)
+    if ([string]::IsNullOrWhiteSpace($TargetPath)) { return $false }
+    $skillsRootNorm = (($skillsDir -replace '\\', '/') -replace '/+', '/').TrimEnd('/')
+    $targetPathNorm = ($TargetPath -replace '\\', '/') -replace '/+', '/'
+    return $targetPathNorm.StartsWith("$skillsRootNorm/", [System.StringComparison]::OrdinalIgnoreCase)
+}
+
 # Extract the skill version from a SKILL.md frontmatter (metadata.version).
 # Returns $null if the file or version cannot be read.
 function Get-SkillVersion {
@@ -345,10 +357,11 @@ if ($toolName -eq "skill" -or $toolName -eq "Skill") {
     if ($skillName -and $skillName.StartsWith("azure:")) {
         $skillName = $skillName.Substring(6)
     }
-    if ($skillName) {
+    $skillMdPath = Join-Path $skillsDir (Join-Path $skillName 'SKILL.md')
+    if ($skillName -and (Test-Path -LiteralPath $skillMdPath) -and (Test-OwnedSkillPath $skillMdPath)) {
         $eventType = "skill_invocation"
         $shouldTrack = $true
-        $skillVersion = Get-SkillVersion (Join-Path $skillsDir (Join-Path $skillName 'SKILL.md'))
+        $skillVersion = Get-SkillVersion $skillMdPath
     }
 }
 
@@ -369,7 +382,7 @@ if ($toolName -eq "view" -or $toolName -eq "Read" -or $toolName -eq "read_file")
             }
         }
 
-        if ($isAzureSkillMd) {
+        if ($isAzureSkillMd -and (Test-OwnedSkillPath $pathToCheck)) {
             $pathNormalized = $pathToCheck -replace '\\', '/' -replace '/+', '/'
             if ($pathNormalized -match '/skills/([^/]+)/SKILL\.md$') {
                 $skillName = $Matches[1]
@@ -408,7 +421,7 @@ if (-not $filePath -and -not $skillName) {
                 break
             }
         }
-        if ($matchesPattern) {
+        if ($matchesPattern -and (Test-OwnedSkillPath $pathToCheck)) {
             # Extract relative path after 'skills/'
             $pathNormalized = $pathToCheck -replace '\\', '/' -replace '/+', '/'
 

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -148,6 +148,19 @@ write_telemetry_debug_log() {
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
 SKILLS_DIR="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)/skills"
 
+# Return true only when a target belongs to this hook's plugin. Since this hook
+# is copied into every plugin, comparing through the skills directory prevents
+# each installed copy from reporting the same skill or reference event.
+is_owned_skill_path() {
+    # targetPath is either path to the SKILL.md or to a reference file
+    local targetPath="$1"
+    local skillsRootNorm
+    local targetPathNorm
+    skillsRootNorm=$(echo "$SKILLS_DIR" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g; s|/$||')
+    targetPathNorm=$(echo "$targetPath" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g')
+    [[ "$targetPathNorm" == "$skillsRootNorm/"* ]]
+}
+
 # Extract the skill version from a SKILL.md frontmatter (metadata.version).
 # Prints nothing if the file or version cannot be read.
 get_skill_version() {
@@ -349,10 +362,11 @@ if [ "$toolName" = "skill" ] || [ "$toolName" = "Skill" ]; then
     # Claude Code prefixes skill names with "azure:" (e.g., "azure:azure-prepare")
     # Strip it to get the actual skill name for the allowlist
     skillName="${skillName#azure:}"
-    if [ -n "$skillName" ]; then
+    skillMdPath="$SKILLS_DIR/$skillName/SKILL.md"
+    if [ -n "$skillName" ] && [ -f "$skillMdPath" ] && is_owned_skill_path "$skillMdPath"; then
         eventType="skill_invocation"
         shouldTrack=true
-        skillVersion=$(get_skill_version "$SKILLS_DIR/$skillName/SKILL.md")
+        skillVersion=$(get_skill_version "$skillMdPath")
     fi
 fi
 
@@ -365,7 +379,7 @@ if [ "$toolName" = "view" ] || [ "$toolName" = "Read" ] || [ "$toolName" = "read
         pathLower=$(echo "$pathToCheck" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g')
 
         # Check for SKILL.md pattern — only match azure-skills paths
-        if is_azure_skills_path "$pathLower" && [[ "$pathLower" == *"/skill.md" ]]; then
+        if is_azure_skills_path "$pathLower" && is_owned_skill_path "$pathToCheck" && [[ "$pathLower" == *"/skill.md" ]]; then
             pathNormalized=$(echo "$pathToCheck" | tr '\\' '/' | sed 's|//*|/|g')
             if [[ "$pathNormalized" =~ /skills/([^/]+)/SKILL\.md$ ]]; then
                 skillName="${BASH_REMATCH[1]}"
@@ -398,7 +412,7 @@ if [ -z "$filePath" ] && [ -z "$skillName" ]; then
         pathLower=$(echo "$pathToCheck" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g')
 
         # Check if path matches azure skills folder structure
-        if is_azure_skills_path "$pathLower"; then
+        if is_azure_skills_path "$pathLower" && is_owned_skill_path "$pathToCheck"; then
             # Extract relative path after 'skills/'
             pathNormalized=$(echo "$pathToCheck" | tr '\\' '/' | sed 's|//*|/|g')
 


### PR DESCRIPTION
## Description

We replicate track-telemetry script to all plugins in this repo and they use the same in-script filter. If a user has both azure and azure-kusto-graph-skills plugins installed, a skill invocation or reference file read that passes the filter will trigger both scripts and result in two events sent (one of them is a duplicate). Besides, for skill invocation, one of the duplicate event will have the incorrect plugin version since it will report the plugin version of the hook for a skill not in it.

The fix is to check in the script to see if the skill.md or reference file belongs to the plugin of the hook. This can be done by checking if the skill.md or reference path has the hook's plugin's skills directory path as a prefix.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
