### PR TITLE
fix: restore azure-deploy ci test

### DIFF
--- a/.github/workflows/test-all-integration.yml
+++ b/.github/workflows/test-all-integration.yml
@@ -138,7 +138,7 @@ jobs:
     with:
       model-override: ${{ inputs.model-override }}
       test-pattern: ${{ needs.resolve-inputs.outputs.deploy-test-pattern }}
-      no-skills: ${{ inputs.no-skills }}
+      no-skills: ${{ inputs.no-skills || false }}
 
   test:
     name: Integration – ${{ matrix.skill }}


### PR DESCRIPTION
## Description

Scheduled runs don't supply this parameter. It by default resolves to ''. Unlike string typed parameter model-override, the boolean typed no-skills parameter fails the workflow when it gets a '' value. This PR gives it a fallback value so the workflow can proceed.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
