### PR TITLE
doc: remove required section for skill body

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -114,15 +114,13 @@ Integration tests are authored as vally eval suites. Read `vally-eval` skill to 
    - `version` must be `"0.0.0-placeholder"` — NBGV stamps the real version at build time
    - `description` must be 1-1024 chars, explaining WHAT and WHEN with trigger phrases
 
-4. **Required sections** in SKILL.md: Quick Reference, When to Use This Skill, MCP Tools, Workflow/Steps, Error Handling
+4. **Move detailed content** to `references/` subdirectory — keep SKILL.md under 500 tokens (soft limit)
 
-5. **Move detailed content** to `references/` subdirectory — keep SKILL.md under 500 tokens (soft limit)
+5. **Add to `tests/skills.json`**: Add your skill name to the `skills` array and assign it to an integration test schedule slot
 
-6. **Add to `tests/skills.json`**: Add your skill name to the `skills` array and assign it to an integration test schedule slot
+6. **Scaffold tests**: Copy `tests/_template` to `tests/<your-skill-name>/` and update `SKILL_NAME` in each test file
 
-7. **Scaffold tests**: Copy `tests/_template` to `tests/<your-skill-name>/` and update `SKILL_NAME` in each test file
-
-8. **Validate**:
+7. **Validate**:
    ```bash
    npm run build                              # Verify version stamping works
    cd scripts && npm run frontmatter          # Validate frontmatter

--- a/.github/instructions/skill-files.instructions.md
+++ b/.github/instructions/skill-files.instructions.md
@@ -31,11 +31,6 @@ metadata:
 
 Keep the main SKILL.md concise. Move detailed documentation to files under the `references/` subfolder.
 
-## Required Sections
-
-1. **Quick Reference** - Summary table with key properties (MCP tools, CLI commands, best for)
-2. **Workflow/Steps** - Numbered or phased step-by-step processes
-
 ## Optional Sections
 
 1. **Prerequisite** - Expected environmental conditions for the skill to operate (e.g. files in the workspace, local CLI tools, type of projects, etc.)

--- a/.github/skills/skill-reviewer/SKILL.md
+++ b/.github/skills/skill-reviewer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-reviewer
-description: "Review skill PRs with structured severity-rated feedback covering token budgets, routing conflicts, required sections, and repo conventions. WHEN: \"review skill\", \"review skill PR\", \"review skill changes\", \"check skill quality\", \"skill PR feedback\"."
+description: "Review skill PRs with structured severity-rated feedback covering token budgets, routing conflicts, and repo conventions. WHEN: \"review skill\", \"review skill PR\", \"review skill changes\", \"check skill quality\", \"skill PR feedback\"."
 license: MIT
 metadata:
   author: Microsoft


### PR DESCRIPTION
## Description

Remove "required section" instructions for skill body. There is no best practices for skill body. Skill authors should use their testing results to determine how they need to organize their content.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
