### PR TITLE
fix: split telemetry scripts by client

### DIFF
--- a/hooks/scripts/clients/claude-code.ps1
+++ b/hooks/scripts/clients/claude-code.ps1
@@ -1,0 +1,33 @@
+# Dot-sourced by track-telemetry.ps1 after Claude Code detection.
+
+function Get-TelemetryEvent {
+    param($InputData)
+    $event = New-TelemetryEvent -ClientName "claude-code" -SessionId $InputData.session_id
+    $toolName = $InputData.tool_name
+    if (-not $toolName) { return $event }
+
+    $toolInput = $InputData.tool_input
+    if ($toolName -eq "Skill") {
+        $candidate = $toolInput.skill
+        if ($candidate -and $candidate.StartsWith("azure:")) {
+            $candidate = $candidate.Substring(6)
+        }
+        Set-SkillByName -Event $event -Candidate $candidate
+    }
+
+    $pathToCheck = Get-ToolInputPath $toolInput
+    $pathLower = Normalize-PathLower $pathToCheck
+    if ($toolName -eq "Read" -and $pathToCheck -and
+        (Test-AzureSkillsPath $pathLower) -and $pathLower.EndsWith("/skill.md")) {
+        Set-SkillRead -Event $event -TargetPath $pathToCheck
+    }
+
+    if ($toolName.StartsWith("mcp__plugin_azure_azure__")) {
+        Set-ToolInvocation -Event $event -ToolName $toolName
+    }
+
+    if (-not $event.SkillName -and $pathToCheck -and (Test-AzureSkillsPath $pathLower)) {
+        Set-ReferencePath -Event $event -TargetPath $pathToCheck
+    }
+    return $event
+}

--- a/hooks/scripts/clients/claude-code.ps1
+++ b/hooks/scripts/clients/claude-code.ps1
@@ -17,7 +17,7 @@ function Get-TelemetryEvent {
 
     $pathToCheck = Get-ToolInputPath $toolInput
     $pathLower = Normalize-PathLower $pathToCheck
-    if ($toolName -eq "Read" -and $pathToCheck -and
+    if ((Test-FileReadTool $toolName) -and $pathToCheck -and
         (Test-AzureSkillsPath $pathLower) -and $pathLower.EndsWith("/skill.md")) {
         Set-SkillRead -Event $event -TargetPath $pathToCheck
     }

--- a/hooks/scripts/clients/claude-code.sh
+++ b/hooks/scripts/clients/claude-code.sh
@@ -1,0 +1,35 @@
+# Sourced by track-telemetry.sh after Claude Code detection.
+
+process_telemetry_event() {
+    local raw_input="$1"
+    local tool_name
+    local path_to_check
+    local path_lower
+    local candidate
+
+    clientName="claude-code"
+    sessionId=$(extract_json_field "$raw_input" "session_id")
+    tool_name=$(extract_json_field "$raw_input" "tool_name")
+    [ -n "$tool_name" ] || return 0
+
+    if [ "$tool_name" = "Skill" ]; then
+        candidate=$(extract_toolargs_field "$raw_input" "tool_input" "skill")
+        candidate="${candidate#azure:}"
+        track_skill_by_name "$candidate"
+    fi
+
+    path_to_check=$(extract_toolargs_path "$raw_input" "tool_input")
+    path_lower=$(normalize_path_lower "$path_to_check")
+    if [ "$tool_name" = "Read" ] && [ -n "$path_to_check" ] \
+        && is_azure_skills_path "$path_lower" && [[ "$path_lower" == *"/skill.md" ]]; then
+        track_skill_read "$path_to_check"
+    fi
+
+    if [[ "$tool_name" == mcp__plugin_azure_azure__* ]]; then
+        track_tool_invocation "$tool_name"
+    fi
+
+    if [ -z "$skillName" ] && [ -n "$path_to_check" ] && is_azure_skills_path "$path_lower"; then
+        capture_reference_path "$path_to_check"
+    fi
+}

--- a/hooks/scripts/clients/claude-code.sh
+++ b/hooks/scripts/clients/claude-code.sh
@@ -20,7 +20,7 @@ process_telemetry_event() {
 
     path_to_check=$(extract_toolargs_path "$raw_input" "tool_input")
     path_lower=$(normalize_path_lower "$path_to_check")
-    if [ "$tool_name" = "Read" ] && [ -n "$path_to_check" ] \
+    if is_file_read_tool "$tool_name" && [ -n "$path_to_check" ] \
         && is_azure_skills_path "$path_lower" && [[ "$path_lower" == *"/skill.md" ]]; then
         track_skill_read "$path_to_check"
     fi

--- a/hooks/scripts/clients/copilot-cli.ps1
+++ b/hooks/scripts/clients/copilot-cli.ps1
@@ -13,7 +13,7 @@ function Get-TelemetryEvent {
 
     $pathToCheck = Get-ToolInputPath $toolInput
     $pathLower = Normalize-PathLower $pathToCheck
-    if ($toolName -eq "view" -and $pathToCheck -and
+    if ((Test-FileReadTool $toolName) -and $pathToCheck -and
         (Test-AzureSkillsPath $pathLower) -and $pathLower.EndsWith("/skill.md")) {
         Set-SkillRead -Event $event -TargetPath $pathToCheck
     }

--- a/hooks/scripts/clients/copilot-cli.ps1
+++ b/hooks/scripts/clients/copilot-cli.ps1
@@ -1,0 +1,29 @@
+# Dot-sourced by track-telemetry.ps1 after Copilot CLI detection.
+
+function Get-TelemetryEvent {
+    param($InputData)
+    $event = New-TelemetryEvent -ClientName "copilot-cli" -SessionId $InputData.sessionId
+    $toolName = $InputData.toolName
+    if (-not $toolName) { return $event }
+
+    $toolInput = $InputData.toolArgs
+    if ($toolName -eq "skill") {
+        Set-SkillByName -Event $event -Candidate $toolInput.skill
+    }
+
+    $pathToCheck = Get-ToolInputPath $toolInput
+    $pathLower = Normalize-PathLower $pathToCheck
+    if ($toolName -eq "view" -and $pathToCheck -and
+        (Test-AzureSkillsPath $pathLower) -and $pathLower.EndsWith("/skill.md")) {
+        Set-SkillRead -Event $event -TargetPath $pathToCheck
+    }
+
+    if ($toolName.StartsWith("azure-")) {
+        Set-ToolInvocation -Event $event -ToolName $toolName
+    }
+
+    if (-not $event.SkillName -and $pathToCheck -and (Test-AzureSkillsPath $pathLower)) {
+        Set-ReferencePath -Event $event -TargetPath $pathToCheck
+    }
+    return $event
+}

--- a/hooks/scripts/clients/copilot-cli.sh
+++ b/hooks/scripts/clients/copilot-cli.sh
@@ -1,0 +1,34 @@
+# Sourced by track-telemetry.sh after Copilot CLI detection.
+
+process_telemetry_event() {
+    local raw_input="$1"
+    local tool_name
+    local path_to_check
+    local path_lower
+    local candidate
+
+    clientName="copilot-cli"
+    sessionId=$(extract_json_field "$raw_input" "sessionId")
+    tool_name=$(extract_json_field "$raw_input" "toolName")
+    [ -n "$tool_name" ] || return 0
+
+    if [ "$tool_name" = "skill" ]; then
+        candidate=$(extract_toolargs_field "$raw_input" "toolArgs" "skill")
+        track_skill_by_name "$candidate"
+    fi
+
+    path_to_check=$(extract_toolargs_path "$raw_input" "toolArgs")
+    path_lower=$(normalize_path_lower "$path_to_check")
+    if [ "$tool_name" = "view" ] && [ -n "$path_to_check" ] \
+        && is_azure_skills_path "$path_lower" && [[ "$path_lower" == *"/skill.md" ]]; then
+        track_skill_read "$path_to_check"
+    fi
+
+    if [[ "$tool_name" == azure-* ]]; then
+        track_tool_invocation "$tool_name"
+    fi
+
+    if [ -z "$skillName" ] && [ -n "$path_to_check" ] && is_azure_skills_path "$path_lower"; then
+        capture_reference_path "$path_to_check"
+    fi
+}

--- a/hooks/scripts/clients/copilot-cli.sh
+++ b/hooks/scripts/clients/copilot-cli.sh
@@ -19,7 +19,7 @@ process_telemetry_event() {
 
     path_to_check=$(extract_toolargs_path "$raw_input" "toolArgs")
     path_lower=$(normalize_path_lower "$path_to_check")
-    if [ "$tool_name" = "view" ] && [ -n "$path_to_check" ] \
+    if is_file_read_tool "$tool_name" && [ -n "$path_to_check" ] \
         && is_azure_skills_path "$path_lower" && [[ "$path_lower" == *"/skill.md" ]]; then
         track_skill_read "$path_to_check"
     fi

--- a/hooks/scripts/clients/cursor.ps1
+++ b/hooks/scripts/clients/cursor.ps1
@@ -17,7 +17,7 @@ function Get-TelemetryEvent {
 
     $pathToCheck = Get-ToolInputPath $toolInput
     $pathLower = Normalize-PathLower $pathToCheck
-    if ($toolName -eq "Read" -and $pathToCheck -and
+    if ((Test-FileReadTool $toolName) -and $pathToCheck -and
         (Test-AzureSkillsPath $pathLower) -and $pathLower.EndsWith("/skill.md")) {
         Set-SkillRead -Event $event -TargetPath $pathToCheck
     }

--- a/hooks/scripts/clients/cursor.ps1
+++ b/hooks/scripts/clients/cursor.ps1
@@ -1,0 +1,38 @@
+# Dot-sourced by track-telemetry.ps1 after Cursor detection.
+
+function Get-TelemetryEvent {
+    param($InputData)
+    $event = New-TelemetryEvent -ClientName "cursor" -SessionId $InputData.session_id
+    $toolName = $InputData.tool_name
+    if (-not $toolName) { return $event }
+
+    $toolInput = $InputData.tool_input
+    if ($toolName -eq "Skill") {
+        $candidate = $toolInput.skill
+        if ($candidate -and $candidate.StartsWith("azure:")) {
+            $candidate = $candidate.Substring(6)
+        }
+        Set-SkillByName -Event $event -Candidate $candidate
+    }
+
+    $pathToCheck = Get-ToolInputPath $toolInput
+    $pathLower = Normalize-PathLower $pathToCheck
+    if ($toolName -eq "Read" -and $pathToCheck -and
+        (Test-AzureSkillsPath $pathLower) -and $pathLower.EndsWith("/skill.md")) {
+        Set-SkillRead -Event $event -TargetPath $pathToCheck
+    }
+
+    if ($InputData.hook_event_name -eq "afterMCPExecution" -and
+        $InputData.mcp_server_name -eq "azure") {
+        $azureToolName = $toolName
+        if ($azureToolName.StartsWith("MCP:", [System.StringComparison]::Ordinal)) {
+            $azureToolName = $azureToolName.Substring(4)
+        }
+        Set-ToolInvocation -Event $event -ToolName $azureToolName
+    }
+
+    if (-not $event.SkillName -and $pathToCheck -and (Test-AzureSkillsPath $pathLower)) {
+        Set-ReferencePath -Event $event -TargetPath $pathToCheck
+    }
+    return $event
+}

--- a/hooks/scripts/clients/cursor.sh
+++ b/hooks/scripts/clients/cursor.sh
@@ -22,7 +22,7 @@ process_telemetry_event() {
 
     path_to_check=$(extract_toolargs_path "$raw_input" "tool_input")
     path_lower=$(normalize_path_lower "$path_to_check")
-    if [ "$tool_name" = "Read" ] && [ -n "$path_to_check" ] \
+    if is_file_read_tool "$tool_name" && [ -n "$path_to_check" ] \
         && is_azure_skills_path "$path_lower" && [[ "$path_lower" == *"/skill.md" ]]; then
         track_skill_read "$path_to_check"
     fi

--- a/hooks/scripts/clients/cursor.sh
+++ b/hooks/scripts/clients/cursor.sh
@@ -1,0 +1,39 @@
+# Sourced by track-telemetry.sh after Cursor detection.
+
+process_telemetry_event() {
+    local raw_input="$1"
+    local tool_name
+    local hook_event_name
+    local mcp_server_name
+    local path_to_check
+    local path_lower
+    local candidate
+
+    clientName="cursor"
+    sessionId=$(extract_json_field "$raw_input" "session_id")
+    tool_name=$(extract_json_field "$raw_input" "tool_name")
+    [ -n "$tool_name" ] || return 0
+
+    if [ "$tool_name" = "Skill" ]; then
+        candidate=$(extract_toolargs_field "$raw_input" "tool_input" "skill")
+        candidate="${candidate#azure:}"
+        track_skill_by_name "$candidate"
+    fi
+
+    path_to_check=$(extract_toolargs_path "$raw_input" "tool_input")
+    path_lower=$(normalize_path_lower "$path_to_check")
+    if [ "$tool_name" = "Read" ] && [ -n "$path_to_check" ] \
+        && is_azure_skills_path "$path_lower" && [[ "$path_lower" == *"/skill.md" ]]; then
+        track_skill_read "$path_to_check"
+    fi
+
+    hook_event_name=$(extract_json_field "$raw_input" "hook_event_name")
+    mcp_server_name=$(extract_json_field "$raw_input" "mcp_server_name")
+    if [ "$hook_event_name" = "afterMCPExecution" ] && [ "$mcp_server_name" = "azure" ]; then
+        track_tool_invocation "${tool_name#MCP:}"
+    fi
+
+    if [ -z "$skillName" ] && [ -n "$path_to_check" ] && is_azure_skills_path "$path_lower"; then
+        capture_reference_path "$path_to_check"
+    fi
+}

--- a/hooks/scripts/clients/vscode.ps1
+++ b/hooks/scripts/clients/vscode.ps1
@@ -1,0 +1,37 @@
+# Dot-sourced by track-telemetry.ps1 after Visual Studio Code detection.
+
+function Get-TelemetryEvent {
+    param($InputData)
+    $clientName = "Visual Studio Code"
+    if ($InputData.transcript_path -match '[/\\]Code - Insiders[/\\]') {
+        $clientName = "Visual Studio Code - Insiders"
+    }
+    $event = New-TelemetryEvent -ClientName $clientName -SessionId $InputData.session_id
+    $toolName = $InputData.tool_name
+    if (-not $toolName) { return $event }
+
+    $toolInput = $InputData.tool_input
+    if ($toolName -eq "Skill") {
+        $candidate = $toolInput.skill
+        if ($candidate -and $candidate.StartsWith("azure:")) {
+            $candidate = $candidate.Substring(6)
+        }
+        Set-SkillByName -Event $event -Candidate $candidate
+    }
+
+    $pathToCheck = Get-ToolInputPath $toolInput
+    $pathLower = Normalize-PathLower $pathToCheck
+    if ($toolName -eq "read_file" -and $pathToCheck -and
+        (Test-AzureSkillsPath $pathLower) -and $pathLower.EndsWith("/skill.md")) {
+        Set-SkillRead -Event $event -TargetPath $pathToCheck
+    }
+
+    if ($toolName.StartsWith("mcp_azure_mcp_")) {
+        Set-ToolInvocation -Event $event -ToolName $toolName
+    }
+
+    if (-not $event.SkillName -and $pathToCheck -and (Test-AzureSkillsPath $pathLower)) {
+        Set-ReferencePath -Event $event -TargetPath $pathToCheck
+    }
+    return $event
+}

--- a/hooks/scripts/clients/vscode.ps1
+++ b/hooks/scripts/clients/vscode.ps1
@@ -21,7 +21,7 @@ function Get-TelemetryEvent {
 
     $pathToCheck = Get-ToolInputPath $toolInput
     $pathLower = Normalize-PathLower $pathToCheck
-    if ($toolName -eq "read_file" -and $pathToCheck -and
+    if ((Test-FileReadTool $toolName) -and $pathToCheck -and
         (Test-AzureSkillsPath $pathLower) -and $pathLower.EndsWith("/skill.md")) {
         Set-SkillRead -Event $event -TargetPath $pathToCheck
     }

--- a/hooks/scripts/clients/vscode.sh
+++ b/hooks/scripts/clients/vscode.sh
@@ -1,0 +1,44 @@
+# Sourced by track-telemetry.sh after Visual Studio Code detection.
+
+process_telemetry_event() {
+    local raw_input="$1"
+    local tool_name
+    local transcript_path
+    local transcript_path_norm
+    local path_to_check
+    local path_lower
+    local candidate
+
+    transcript_path=$(extract_json_field "$raw_input" "transcript_path")
+    transcript_path_norm=$(echo "$transcript_path" | tr '\\' '/')
+    if [[ "$transcript_path_norm" == */Code\ -\ Insiders/* ]]; then
+        clientName="Visual Studio Code - Insiders"
+    else
+        clientName="Visual Studio Code"
+    fi
+
+    sessionId=$(extract_json_field "$raw_input" "session_id")
+    tool_name=$(extract_json_field "$raw_input" "tool_name")
+    [ -n "$tool_name" ] || return 0
+
+    if [ "$tool_name" = "Skill" ]; then
+        candidate=$(extract_toolargs_field "$raw_input" "tool_input" "skill")
+        candidate="${candidate#azure:}"
+        track_skill_by_name "$candidate"
+    fi
+
+    path_to_check=$(extract_toolargs_path "$raw_input" "tool_input")
+    path_lower=$(normalize_path_lower "$path_to_check")
+    if [ "$tool_name" = "read_file" ] && [ -n "$path_to_check" ] \
+        && is_azure_skills_path "$path_lower" && [[ "$path_lower" == *"/skill.md" ]]; then
+        track_skill_read "$path_to_check"
+    fi
+
+    if [[ "$tool_name" == mcp_azure_mcp_* ]]; then
+        track_tool_invocation "$tool_name"
+    fi
+
+    if [ -z "$skillName" ] && [ -n "$path_to_check" ] && is_azure_skills_path "$path_lower"; then
+        capture_reference_path "$path_to_check"
+    fi
+}

--- a/hooks/scripts/clients/vscode.sh
+++ b/hooks/scripts/clients/vscode.sh
@@ -29,7 +29,7 @@ process_telemetry_event() {
 
     path_to_check=$(extract_toolargs_path "$raw_input" "tool_input")
     path_lower=$(normalize_path_lower "$path_to_check")
-    if [ "$tool_name" = "read_file" ] && [ -n "$path_to_check" ] \
+    if is_file_read_tool "$tool_name" && [ -n "$path_to_check" ] \
         && is_azure_skills_path "$path_lower" && [[ "$path_lower" == *"/skill.md" ]]; then
         track_skill_read "$path_to_check"
     fi

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -261,6 +261,13 @@ function Get-ToolInputPath {
     return $null
 }
 
+# Clients have used more than one file-read tool name over time. Accept the
+# complete compatibility list regardless of which client emitted the payload.
+function Test-FileReadTool {
+    param([string]$ToolName)
+    return $ToolName -eq "view" -or $ToolName -eq "Read" -or $ToolName -eq "read_file"
+}
+
 # Initialize the normalized event contract returned by every client handler.
 function New-TelemetryEvent {
     param([string]$ClientName, [string]$SessionId)

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -1,202 +1,235 @@
-# Telemetry tracking hook for Azure Copilot Skills
-# Reads JSON input from stdin, tracks relevant events, and publishes via MCP
+# Telemetry tracking hook for Azure Copilot Skills.
+# Reads JSON input from stdin, tracks relevant events, and publishes via MCP.
+# Exit codes: 0 = hook handled or safely skipped.
 #
 # === Client Format Reference ===
 #
 # Copilot CLI:
 #   - Field names:    camelCase (toolName, sessionId, toolArgs)
 #   - Tool names:     lowercase (skill, view)
-#   - MCP prefix:     azure-<command>  (e.g., azure-documentation)
+#   - MCP prefix:     azure-<command> (for example, azure-documentation)
 #   - Skill prefix:   none (skill name as-is)
-#   - Detection:      COPILOT_CLI env var is "1" (>=0.0.421); fallback: "toolArgs" without "hook_event_name" (<0.0.421)
+#   - Detection:      COPILOT_CLI is "1" (>=0.0.421); fallback is toolArgs
+#                     without hook_event_name (<0.0.421)
 #
 # Claude Code:
-#   - Field names:    snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Field names:    snake_case (tool_name, session_id, tool_input,
+#                     hook_event_name)
 #   - Tool names:     PascalCase (Skill, Read, Edit)
-#   - MCP prefix:     mcp__plugin_azure_azure__<command>  (double underscores)
-#   - Skill prefix:   azure:<skill-name>  (e.g., azure:azure-prepare)
-#   - Detection:      has "hook_event_name", tool_use_id does NOT contain "__vscode"
+#   - MCP prefix:     mcp__plugin_azure_azure__<command>
+#   - Skill prefix:   azure:<skill-name> (for example, azure:azure-prepare)
+#   - Detection:      has hook_event_name and tool_use_id does not contain
+#                     "__vscode"
 #
 # Cursor:
-#   - Field names:    snake_case (tool_name, session_id, tool_input, hook_event_name)
-#   - Tool names:     PascalCase for file reads (Read); raw MCP tool name from afterMCPExecution
-#   - Skill paths:    .cursor/plugins/cache/<catalog>/azure/<revision>/skills/<name>/SKILL.md
-#   - Detection:      has "hook_event_name" and "cursor_version"
-#   - MCP detection:  afterMCPExecution event with mcp_server_name "azure"
+#   - Field names:    snake_case (tool_name, session_id, tool_input,
+#                     hook_event_name)
+#   - Tool names:     PascalCase for file reads (Read); raw MCP tool name from
+#                     afterMCPExecution
+#   - Skill paths:    .cursor/plugins/cache/<catalog>/azure/<revision>/skills/
+#   - Detection:      has hook_event_name and cursor_version
+#   - MCP detection:  afterMCPExecution with mcp_server_name "azure"
 #
 # VS Code:
-#   - Field names:    snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Field names:    snake_case (tool_name, session_id, tool_input,
+#                     hook_event_name)
 #   - Tool names:     snake_case (read_file, replace_string_in_file)
-#   - MCP prefix:     mcp_azure_mcp_<command>  (e.g., mcp_azure_mcp_documentation)
-#   - Skill paths:    .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/<name>/SKILL.md          (VS Code)
-#                     .vscode-insiders/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/<name>/SKILL.md (VS Code Insiders)
+#   - MCP prefix:     mcp_azure_mcp_<command>
+#   - Skill paths:    .vscode/agent-plugins/github.com/microsoft/azure-skills/
+#                     .github/plugins/azure-skills/skills/<name>/SKILL.md
+#                     .vscode-insiders/agent-plugins/github.com/microsoft/
+#                     azure-skills/.github/plugins/azure-skills/skills/
+#                     <name>/SKILL.md
 #                     .agents/skills/<name>/SKILL.md
-#   - Detection:      has "hook_event_name", tool_use_id contains "__vscode"
+#   - Detection:      has hook_event_name and tool_use_id contains "__vscode",
 #                     or transcript_path contains "Code"
-#   - Client name:    "Visual Studio Code" (stable) or "Visual Studio Code - Insiders"
-#                     derived from transcript_path (e.g., .../Code - Insiders/User/...)
-#   - Note:           Skills under .agents/skills/ are tracked as "Visual Studio Code" but
-#                     transcript_path may be absent, so stable vs Insiders can only be
-#                     distinguished when skills are called from agent-plugins (which
-#                     includes transcript_path)
+#   - Client name:    "Visual Studio Code" or
+#                     "Visual Studio Code - Insiders", derived from
+#                     transcript_path
+#   - Note:           .agents/skills payloads can omit transcript_path, so
+#                     stable and Insiders can only be distinguished when that
+#                     path is available
 #
 # === Event Types ===
 #
 # 1. skill_invocation
-#    - Triggered when: the "skill"/"Skill" tool is called with a skill name,
-#      OR a SKILL.md file is read from a recognized azure-skills path
-#    - Tracked fields: --skill-name <name>, --skill-version <version>
+#    - Triggered when the skill tool is called with a skill name, or when a
+#      SKILL.md file is read from a recognized Azure skills path.
+#    - Fields: --skill-name <name>, --skill-version <version>
 #
 # 2. tool_invocation
-#    - Triggered when: a tool matching an Azure MCP prefix is called
-#      (azure-*, mcp__plugin_azure_azure__*, mcp_azure_mcp_*), or when Cursor
-#      sends afterMCPExecution with mcp_server_name "azure"
-#    - Tracked field: --tool-name <toolName>
+#    - Triggered by the client's Azure MCP prefix, or by Cursor's
+#      afterMCPExecution event when mcp_server_name is "azure".
+#    - Field: --tool-name <toolName>
 #
 # 3. reference_file_read
-#    - Triggered when: a file read tool (view/Read/read_file) targets a file
-#      inside a recognized azure-skills path that is NOT a SKILL.md
-#    - These are the reference/instruction files that skills bundle alongside
-#      SKILL.md (e.g., recipes, templates, requirement docs)
-#    - Tracked fields: --file-reference <relative-path-after-skills/>,
+#    - Triggered when a client file-read tool targets a bundled file inside a
+#      recognized Azure skills path that is not SKILL.md.
+#    - Fields: --file-reference <relative-path-after-skills/>,
 #      --skill-version <version>
 #
 # === Skill Version ===
 #
-# The skill version is read from the SKILL.md frontmatter (metadata.version),
-# which the build stamps at package time. It is resolved as follows:
-#   - skill/Skill tool call: locate SKILL.md relative to this script's plugin
-#     root ("<plugin-root>/skills/<name>/SKILL.md")
-#   - SKILL.md read:          read the version from the SKILL.md being read
-#   - reference_file_read:    read the version from the sibling SKILL.md at the
-#                             root of the skill folder the reference lives in
-#    - Example: azure-validate/references/recipes/azd/README.md
+# Skill versions come from metadata.version in the SKILL.md frontmatter, which
+# is stamped at package build time:
+#   - Direct skill call: <plugin-root>/skills/<name>/SKILL.md
+#   - SKILL.md read: the file being read
+#   - Reference read: the sibling SKILL.md at the root of the containing skill
 #
 # === Reference File Detection ===
 #
-# When a file read tool is invoked (Copilot CLI: "view", Claude Code/Cursor:
-# "Read", VS Code: "read_file"), the script extracts the file path from the tool input
-# and checks if it falls within a recognized azure-skills folder:
+# Client handlers extract a path from toolArgs or tool_input. The shared path
+# matcher accepts every supported installation layout because one client can
+# discover and invoke a plugin originally installed by another client:
+#   azure-skills:
+#   - .copilot/installed-plugins/<catalog>/azure/skills/...
+#   - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
+#   - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
+#   - .cursor/plugins/cache/<catalog>/azure/<revision>/skills/...
+#   - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/
+#     azure-skills/skills/...
+#   azure-kusto-graph-skills:
+#   - .copilot/installed-plugins/<catalog>/azure-kusto-graph-skills/skills/...
+#   - .claude/plugins/cache/azure-skills/azure-kusto-graph-skills/<version>/
+#     skills/...
+#   - .cursor/plugins/cache/<catalog>/azure-kusto-graph-skills/<revision>/
+#     skills/...
+#   - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/
+#     azure-kusto-graph-skills/skills/...
+#   shared:
+#   - .agents/skills/...
 #
-#   Path field lookup order:
-#     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
-#     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
-#
-#   Recognized install paths (one set per plugin, see $pathPatterns below):
-#     azure-skills:
-#     - .copilot/installed-plugins/<catalog-name>/azure/skills/...
-#       (<catalog-name> is the marketplace/catalog folder the plugin was
-#       installed under, e.g. "awesome-copilot" — it does not necessarily
-#       match the plugin's own name, "azure")
-#     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
-#     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
-#     - .cursor/plugins/cache/<catalog-name>/azure/<revision>/skills/...
-#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
-#     azure-kusto-graph-skills:
-#     - .copilot/installed-plugins/<catalog-name>/azure-kusto-graph-skills/skills/...
-#     - .claude/plugins/cache/azure-skills/azure-kusto-graph-skills/<version>/skills/...
-#     - .cursor/plugins/cache/<catalog-name>/azure-kusto-graph-skills/<revision>/skills/...
-#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/...
-#     shared:
-#     - .agents/skills/...
-#
-#   If the path matches AND is not a SKILL.md file, the relative path after
-#   "skills/" is extracted and emitted as a reference_file_read event.
-#   SKILL.md reads are tracked as skill_invocation instead (not double-counted).
+# If a path matches and is not SKILL.md, the path after skills/ is emitted as
+# reference_file_read. SKILL.md reads are emitted as skill_invocation instead.
 #
 # === Debugging ===
 #
-# If the AZURE_SKILLS_TELEMETRY_LOG_DIR env var is set, the script will create
-# a "raw-input" subdirectory and write each raw JSON input to a timestamped file
-# for debugging. It will also append a "telemetry.log" file with MCP args for
-# each tracked event.
+# AZURE_SKILLS_TELEMETRY_LOG_DIR enables raw input logs under raw-input/ and
+# appends published MCP arguments to telemetry.log.
 #
-# When using `--plugin-dir` to load a local plugin the AZURE_SKILLS_PLUGIN_ROOT
-# env var should be set so that the script can detect local skill paths for
-# reference_file_read events.
+# When using --plugin-dir, set AZURE_SKILLS_PLUGIN_ROOT so local skill paths
+# can be recognized for reference_file_read events.
+#
+# Client-specific payload parsing and event classification live in clients/.
+# This entry point owns client detection, shared skill/plugin helpers, telemetry
+# publication, diagnostic logging, and the hook response contract.
 
 $ErrorActionPreference = "SilentlyContinue"
 
-# Dumps raw input to a file in the AZURE_SKILLS_TELEMETRY_LOG_DIR/raw-input/
-# directory for debugging if the env var is set.
-function Write-RawInputToFile {
-    param([string]$RawInput)
-    if ($env:AZURE_SKILLS_TELEMETRY_LOG_DIR) {
-        $logDir = $env:AZURE_SKILLS_TELEMETRY_LOG_DIR
-        $rawInputDir = Join-Path $logDir 'raw-input'
-        if (-not (Test-Path -LiteralPath $rawInputDir)) {
-            New-Item -ItemType Directory -Path $rawInputDir -Force | Out-Null
-        }
-        $timestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
-        $rawInputFile = Join-Path $rawInputDir "$timestamp.json"
-        try {
-            $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
-            [System.IO.File]::WriteAllText($rawInputFile, $RawInput, $utf8WithoutBom)
-        } catch { }
-    }
-}
-
-# Writes a debug log entry to the AZURE_SKILLS_TELEMETRY_LOG_DIR/telemetry.log file
-# if the env var is set.
-function Write-TelemetryDebugLog {
-    param([string]$Content)
-
-    if ($env:AZURE_SKILLS_TELEMETRY_LOG_DIR) {
-        $logDir = $env:AZURE_SKILLS_TELEMETRY_LOG_DIR
-        $logFile = Join-Path $logDir 'telemetry.log'
-        $logEntry = "$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ss') | $Content"
-        try {
-            Add-Content -Path $logFile -Value $logEntry -ErrorAction SilentlyContinue
-        } catch { }
-    }
-}
-
-# Skip telemetry if opted out
-if ($env:AZURE_MCP_COLLECT_TELEMETRY -eq "false") {
-    Write-Output '{"continue":true}'
-    exit 0
-}
-
-# Return success and exit
+# Return the success response required by every supported hook host.
 function Write-Success {
     Write-Output '{"continue":true}'
     exit 0
 }
 
-# Resolve this script's directory so we can locate bundled skills. In the
-# installed plugin, hooks/ and skills/ are siblings under the plugin root, so
-# <plugin-root>/skills/<name>/SKILL.md is the skill definition.
+# Dump raw input to AZURE_SKILLS_TELEMETRY_LOG_DIR/raw-input/ for debugging.
+function Write-RawInputToFile {
+    param([string]$RawInput)
+    if (-not $env:AZURE_SKILLS_TELEMETRY_LOG_DIR) { return }
+    $rawInputDir = Join-Path $env:AZURE_SKILLS_TELEMETRY_LOG_DIR 'raw-input'
+    if (-not (Test-Path -LiteralPath $rawInputDir)) {
+        New-Item -ItemType Directory -Path $rawInputDir -Force | Out-Null
+    }
+    $timestamp = (Get-Date).ToUniversalTime().ToString("yyyyMMddTHHmmssZ")
+    $rawInputFile = Join-Path $rawInputDir "$timestamp.json"
+    try {
+        $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
+        [System.IO.File]::WriteAllText($rawInputFile, $RawInput, $utf8WithoutBom)
+    } catch { }
+}
+
+# Append the published MCP arguments to the optional telemetry debug log.
+function Write-TelemetryDebugLog {
+    param([string]$Content)
+    if (-not $env:AZURE_SKILLS_TELEMETRY_LOG_DIR) { return }
+    $logFile = Join-Path $env:AZURE_SKILLS_TELEMETRY_LOG_DIR 'telemetry.log'
+    $logEntry = "$(Get-Date -Format 'yyyy-MM-ddTHH:mm:ss') | $Content"
+    try {
+        Add-Content -Path $logFile -Value $logEntry -ErrorAction SilentlyContinue
+    } catch { }
+}
+
+# Resolve bundled skills relative to the installed hook. hooks/ and skills/ are
+# siblings under each plugin root.
 $scriptDir = $PSScriptRoot
 if (-not $scriptDir) { $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path }
 $skillsDir = Join-Path (Split-Path -Parent (Split-Path -Parent $scriptDir)) 'skills'
 
-# Return true only when a target belongs to this hook's plugin. Since this hook
-# is copied into every plugin, comparing through the skills directory prevents
-# each installed copy from reporting the same skill or reference event.
-function Test-OwnedSkillPath {
-    # targetPath is either path to the SKILL.md or to a reference file
-    param([string]$TargetPath)
-    if ([string]::IsNullOrWhiteSpace($TargetPath)) { return $false }
-    $skillsRootNorm = (($skillsDir -replace '\\', '/') -replace '/+', '/').TrimEnd('/')
-    $targetPathNorm = ($TargetPath -replace '\\', '/') -replace '/+', '/'
-    return $targetPathNorm.StartsWith("$skillsRootNorm/", [System.StringComparison]::OrdinalIgnoreCase)
+# Normalize paths for case-insensitive install-layout comparisons.
+function Normalize-PathLower {
+    param([string]$Path)
+    if ([string]::IsNullOrWhiteSpace($Path)) { return "" }
+    return (($Path.ToLowerInvariant() -replace '\\', '/') -replace '/+', '/')
 }
 
-# Extract the skill version from a SKILL.md frontmatter (metadata.version).
-# Returns $null if the file or version cannot be read.
+# Return true only when the target belongs to this installed plugin copy. The
+# hook is copied into every plugin, so this prevents duplicate reporting.
+function Test-OwnedSkillPath {
+    param([string]$TargetPath)
+    if ([string]::IsNullOrWhiteSpace($TargetPath)) { return $false }
+    $skillsRootNorm = (Normalize-PathLower $skillsDir).TrimEnd('/')
+    $targetPathNorm = Normalize-PathLower $TargetPath
+    return $targetPathNorm.StartsWith("$skillsRootNorm/", [System.StringComparison]::Ordinal)
+}
+
+# Match local plugin development paths configured through --plugin-dir.
+function Test-LocalSkillPath {
+    param([string]$NormalizedPath)
+    if (-not $NormalizedPath -or -not $env:AZURE_SKILLS_PLUGIN_ROOT) { return $false }
+    $localRoot = Normalize-PathLower $env:AZURE_SKILLS_PLUGIN_ROOT
+    return $NormalizedPath.Contains("$localRoot/skills/")
+}
+
+# Match every supported plugin installation layout, independent of the client
+# that emitted the hook payload.
+function Test-AzureSkillsPath {
+    param([string]$Path)
+    if (-not $Path) { return $false }
+
+    # azure-skills plugin
+    if ($Path -match '\.copilot/installed-plugins/[^/]+/azure/skills/') { return $true }
+    if ($Path -match '\.claude/plugins/cache/(azure-skills|claude-plugins-official)/azure/[^/]+/skills/') {
+        return $true
+    }
+    if ($Path -match '\.cursor/plugins/cache/[^/]+/azure/[^/]+/skills/') { return $true }
+    if ($Path -match 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-skills/skills/') {
+        return $true
+    }
+
+    # azure-kusto-graph-skills plugin
+    if ($Path -match '\.copilot/installed-plugins/[^/]+/azure-kusto-graph-skills/skills/') {
+        return $true
+    }
+    if ($Path -match '\.claude/plugins/cache/azure-skills/azure-kusto-graph-skills/[^/]+/skills/') {
+        return $true
+    }
+    if ($Path -match '\.cursor/plugins/cache/[^/]+/azure-kusto-graph-skills/[^/]+/skills/') {
+        return $true
+    }
+    if ($Path -match 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-kusto-graph-skills/skills/') {
+        return $true
+    }
+
+    # Shared and local-development skill paths
+    if ($Path -match '\.agents/skills/') { return $true }
+    return Test-LocalSkillPath $Path
+}
+
+# Extract metadata.version from SKILL.md frontmatter. Return null when the file
+# or version cannot be read.
 function Get-SkillVersion {
     param([string]$SkillMdPath)
     if (-not $SkillMdPath) { return $null }
     $SkillMdPath = $SkillMdPath -replace '\\', '/'
     if (-not (Test-Path -LiteralPath $SkillMdPath)) { return $null }
     try {
-        $lines = Get-Content -LiteralPath $SkillMdPath -ErrorAction SilentlyContinue
+        $lines = Get-Content -LiteralPath $SkillMdPath -ErrorAction Stop
     } catch { return $null }
     $inFrontmatter = $false
     foreach ($line in $lines) {
         if ($line -match '^---\s*$') {
             if (-not $inFrontmatter) { $inFrontmatter = $true; continue }
-            else { break }
+            break
         }
         if ($inFrontmatter -and $line -match '^\s*version:\s*(.+?)\s*$') {
             return $Matches[1].Trim().Trim('"').Trim("'")
@@ -205,13 +238,13 @@ function Get-SkillVersion {
     return $null
 }
 
-# Extract the plugin version from the top-level .plugin/plugin.json manifest.
-# Returns $null if the file or expected JSON value cannot be read.
+# Extract the built plugin version from the top-level .plugin/plugin.json.
 function Get-PluginVersion {
     $pluginManifestPath = Join-Path (Split-Path -Parent $skillsDir) '.plugin/plugin.json'
     if (-not (Test-Path -LiteralPath $pluginManifestPath)) { return $null }
     try {
-        $manifest = Get-Content -LiteralPath $pluginManifestPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        $manifest = Get-Content -LiteralPath $pluginManifestPath -Raw -ErrorAction Stop |
+            ConvertFrom-Json -ErrorAction Stop
         if ($manifest.version -is [string] -and -not [string]::IsNullOrWhiteSpace($manifest.version)) {
             return $manifest.version
         }
@@ -219,291 +252,185 @@ function Get-PluginVersion {
     return $null
 }
 
+# Return path, filePath, or file_path from the client's tool input object.
+function Get-ToolInputPath {
+    param($ToolInput)
+    if ($ToolInput.path) { return $ToolInput.path }
+    if ($ToolInput.filePath) { return $ToolInput.filePath }
+    if ($ToolInput.file_path) { return $ToolInput.file_path }
+    return $null
+}
+
+# Initialize the normalized event contract returned by every client handler.
+function New-TelemetryEvent {
+    param([string]$ClientName, [string]$SessionId)
+    return @{
+        ShouldTrack = $false
+        ClientName = $ClientName
+        SessionId = $SessionId
+        EventType = $null
+        SkillName = $null
+        SkillVersion = $null
+        AzureToolName = $null
+        FilePath = $null
+    }
+}
+
+# Track a direct skill-tool call after the handler normalizes the skill name.
+function Set-SkillByName {
+    param([hashtable]$Event, [string]$Candidate)
+    if (-not $Candidate) { return }
+    $skillMdPath = Join-Path $skillsDir (Join-Path $Candidate 'SKILL.md')
+    if ((Test-Path -LiteralPath $skillMdPath) -and (Test-OwnedSkillPath $skillMdPath)) {
+        $Event.SkillName = $Candidate
+        $Event.SkillVersion = Get-SkillVersion $skillMdPath
+        $Event.EventType = "skill_invocation"
+        $Event.ShouldTrack = $true
+    }
+}
+
+# Track a SKILL.md read after the handler validates the client install path.
+function Set-SkillRead {
+    param([hashtable]$Event, [string]$TargetPath)
+    if (-not (Test-OwnedSkillPath $TargetPath)) { return }
+    $normalizedPath = ($TargetPath -replace '\\', '/') -replace '/+', '/'
+    if ($normalizedPath -notmatch '/skills/([^/]+)/SKILL\.md$') { return }
+    $Event.SkillName = $Matches[1]
+    $Event.SkillVersion = Get-SkillVersion $TargetPath
+    $Event.EventType = "skill_invocation"
+    $Event.ShouldTrack = $true
+}
+
+# Capture a path relative to skills/. If no higher-priority event was already
+# selected, classify the path as a reference_file_read and resolve its version.
+function Set-ReferencePath {
+    param([hashtable]$Event, [string]$TargetPath)
+    if (-not (Test-OwnedSkillPath $TargetPath)) { return }
+    $normalizedPath = ($TargetPath -replace '\\', '/') -replace '/+', '/'
+    if ($normalizedPath -notmatch '.*/skills/(.+)$') { return }
+    $Event.FilePath = $Matches[1]
+    if (-not $Event.ShouldTrack) {
+        $Event.EventType = "reference_file_read"
+        $Event.ShouldTrack = $true
+        $skillNameSegment = ($Event.FilePath -split '/')[0]
+        $skillRootAbs = $normalizedPath.Substring(0, $normalizedPath.Length - $Event.FilePath.Length)
+        $Event.SkillVersion = Get-SkillVersion "$skillRootAbs$skillNameSegment/SKILL.md"
+    }
+}
+
+# Populate the normalized event fields for an Azure MCP tool invocation.
+function Set-ToolInvocation {
+    param([hashtable]$Event, [string]$ToolName)
+    $Event.AzureToolName = $ToolName
+    $Event.EventType = "tool_invocation"
+    $Event.ShouldTrack = $true
+}
+
+# Detect the client once, before handing the payload to client-specific logic.
+# Copilot's environment signal has highest precedence, followed by Cursor,
+# VS Code, Claude Code, and the legacy Copilot toolArgs fallback.
+function Get-ClientKey {
+    param($InputData)
+    if ($env:COPILOT_CLI -eq "1") { return "copilot-cli" }
+
+    $hasHookEventName = $InputData.PSObject.Properties.Name -contains "hook_event_name"
+    if ($hasHookEventName) {
+        if ($InputData.cursor_version) { return "cursor" }
+        $isVscodeToolUseId = $InputData.tool_use_id -and ($InputData.tool_use_id -match '__vscode')
+        $isVscodeTranscript = $InputData.transcript_path -and
+            ($InputData.transcript_path -match '[/\\]Code( - Insiders)?[/\\]')
+        if ($isVscodeToolUseId -or $isVscodeTranscript) { return "vscode" }
+        return "claude-code"
+    }
+
+    if ($InputData.PSObject.Properties.Name -contains "toolArgs") { return "copilot-cli" }
+    return "unknown"
+}
+
+# === Publish Event ===
+
+# Convert the normalized event to plugin-telemetry arguments and publish it.
+# Telemetry publication is best-effort and must never block the host client.
+function Publish-TelemetryEvent {
+    param([hashtable]$Event)
+    $timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $pluginVersion = Get-PluginVersion
+    $mcpArgs = @(
+        "server", "plugin-telemetry",
+        "--timestamp", $timestamp,
+        "--client-name", $Event.ClientName
+    )
+
+    if ($Event.EventType) { $mcpArgs += "--event-type"; $mcpArgs += $Event.EventType }
+    if ($Event.SessionId) { $mcpArgs += "--session-id"; $mcpArgs += $Event.SessionId }
+    if ($Event.SkillName) { $mcpArgs += "--skill-name"; $mcpArgs += $Event.SkillName }
+    if ($Event.SkillVersion) { $mcpArgs += "--skill-version"; $mcpArgs += $Event.SkillVersion }
+    if ($pluginVersion) { $mcpArgs += "--plugin-version"; $mcpArgs += $pluginVersion }
+    if ($Event.AzureToolName) { $mcpArgs += "--tool-name"; $mcpArgs += $Event.AzureToolName }
+    if ($Event.FilePath) {
+        $mcpArgs += "--file-reference"
+        $mcpArgs += ($Event.FilePath -replace '/', '\')
+    }
+
+    try {
+        & npx -y @azure/mcp@latest @mcpArgs 2>&1 | Out-Null
+    } catch { }
+    Write-TelemetryDebugLog -Content "MCP Args: $($mcpArgs -join ' ')"
+}
+
 # === Main Processing ===
 
-# Read entire stdin at once - hooks send one complete JSON per invocation
+# Skip collection when the user has opted out.
+if ($env:AZURE_MCP_COLLECT_TELEMETRY -eq "false") {
+    Write-Success
+}
+
+# Hooks send one complete JSON object per invocation. Windows PowerShell can
+# decode redirected UTF-8 input through its OEM code page, so reconstruct the
+# original UTF-8 text before parsing.
 try {
     $stdinEncoding = [Console]::InputEncoding
     $rawInput = [Console]::In.ReadToEnd()
     $utf8WithoutBom = New-Object System.Text.UTF8Encoding($false)
-    # Recover the original UTF-8 bytes when Windows PowerShell decoded stdin with its OEM code page.
     $rawInput = $utf8WithoutBom.GetString($stdinEncoding.GetBytes($rawInput))
 } catch {
     Write-Success
 }
 
-# Some clients prefix the JSON stream with a UTF-8 BOM; remove that marker before parsing.
+# Some clients prefix the JSON stream with a UTF-8 BOM.
 if ($rawInput.Length -gt 0 -and [int]$rawInput[0] -eq 0xFEFF) {
     $rawInput = $rawInput.Substring(1)
 }
-
-# Return success and exit if no input
 if ([string]::IsNullOrWhiteSpace($rawInput)) {
     Write-Success
 }
 
+# Log the exact normalized JSON used for parsing when debugging is enabled.
 Write-RawInputToFile -RawInput $rawInput
 
-# === STEP 1: Read and parse input ===
-
-# Parse JSON input
+# Parse once in the entry point so handlers receive their native payload shape.
 try {
-    $inputData = $rawInput | ConvertFrom-Json
+    $inputData = $rawInput | ConvertFrom-Json -ErrorAction Stop
 } catch {
     Write-Success
 }
 
-# Extract fields from hook data
-# Support Copilot CLI (camelCase), Claude Code (snake_case), and VS Code (snake_case) formats
-$toolName = $inputData.toolName
-if (-not $toolName) {
-    $toolName = $inputData.tool_name
-}
-
-$sessionId = $inputData.sessionId
-if (-not $sessionId) {
-    $sessionId = $inputData.session_id
-}
-$hookEventName = $inputData.hook_event_name
-$mcpServerName = $inputData.mcp_server_name
-
-# Get tool arguments (Copilot CLI: toolArgs, Claude Code / VS Code: tool_input)
-$toolInput = $inputData.toolArgs
-if (-not $toolInput) {
-    $toolInput = $inputData.tool_input
-}
-
-$timestamp = (Get-Date).ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ")
-
-# Detect client name based on input format
-# Copilot CLI (>=0.0.421): COPILOT_CLI env var is "1" — primary signal, checked first
-# Copilot CLI (<0.0.421):  has "toolArgs" field without "hook_event_name" — backward compat fallback
-# Cursor: has hook_event_name AND a "cursor_version" field
-# VS Code: has hook_event_name AND tool_use_id contains "__vscode" or transcript_path contains "Code"
-# Claude Code: has hook_event_name, tool_use_id does NOT contain "__vscode"
-$hasHookEventName = $inputData.PSObject.Properties.Name -contains "hook_event_name"
-$hasToolArgs = $inputData.PSObject.Properties.Name -contains "toolArgs"
-$toolUseId = $inputData.tool_use_id
-$transcriptPath = $inputData.transcript_path
-$cursorVersion = $inputData.cursor_version
-$isVscodeToolUseId = $toolUseId -and ($toolUseId -match '__vscode')
-# Match path separators around "Code" or "Code - Insiders" to avoid matching "Claude Code"
-$isVscodeTranscript = $transcriptPath -and ($transcriptPath -match '[/\\]Code( - Insiders)?[/\\]')
-
-# Copilot CLI check first — env var available since v0.0.421
-if ($env:COPILOT_CLI -eq "1") {
-    $clientName = "copilot-cli"
-} elseif ($hasHookEventName -and $cursorVersion) {
-    $clientName = "cursor"
-} elseif ($hasHookEventName -and ($isVscodeToolUseId -or $isVscodeTranscript)) {
-    # Detect VS Code variant from transcript_path
-    # Insiders: ...AppData\Roaming\Code - Insiders\User\...
-    # Stable:   ...AppData\Roaming\Code\User\...
-    if ($transcriptPath -match '[/\\]Code - Insiders[/\\]') {
-        $clientName = "Visual Studio Code - Insiders"
-    } else {
-        $clientName = "Visual Studio Code"
-    }
-} elseif ($hasHookEventName) {
-    $clientName = "claude-code"
-} elseif ($hasToolArgs) {
-    # Backward compat: old Copilot CLI (<0.0.421) sent toolArgs without hook_event_name
-    # Claude Code never sends toolArgs, so this is unambiguous
-    $clientName = "copilot-cli"
-} else {
-    $clientName = "unknown"
-}
-
-# Skip if no tool name found in any format
-if (-not $toolName) {
+# Load only the detected client's parser and event-classification rules.
+$clientKey = Get-ClientKey $inputData
+$handlerPath = Join-Path $scriptDir "clients/$clientKey.ps1"
+if ($clientKey -eq "unknown" -or -not (Test-Path -LiteralPath $handlerPath)) {
     Write-Success
 }
 
-# Helper to extract path from tool input (handles 'path', 'filePath', 'file_path')
-function Get-ToolInputPath {
-    if ($toolInput.path) { return $toolInput.path }
-    if ($toolInput.filePath) { return $toolInput.filePath }
-    if ($toolInput.file_path) { return $toolInput.file_path }
-    return $null
+try {
+    . $handlerPath
+    $telemetryEvent = Get-TelemetryEvent -InputData $inputData
+} catch {
+    Write-Success
 }
 
-# === STEP 2: Determine what to track for azmcp ===
-
-# Path patterns per client, one block per plugin (used for SKILL.md and
-# file-reference matching). When onboarding another plugin, add a new block by
-# swapping both the catalog/plugin segments (e.g. "azure" and "azure-skills")
-# for the new plugin's name.
-
-# --- azure-skills plugin ---
-# The Copilot CLI pattern wildcards the catalog/marketplace folder name
-# (e.g. "awesome-copilot") since it does not necessarily match the plugin's
-# own name ("azure").
-$pathPatternCopilot = '\.copilot/installed-plugins/[^/]+/azure/skills/'
-$pathPatternClaude = '\.claude/plugins/cache/(azure-skills|claude-plugins-official)/azure/[0-9.]+/skills/'
-$pathPatternCursor = '\.cursor/plugins/cache/[^/]+/azure/[^/]+/skills/'
-$pathPatternVscodeAgentPlugins = 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-skills/skills/'
-
-# --- azure-kusto-graph-skills plugin ---
-$pathPatternCopilotKustoGraph = '\.copilot/installed-plugins/[^/]+/azure-kusto-graph-skills/skills/'
-$pathPatternClaudeKustoGraph = '\.claude/plugins/cache/azure-skills/azure-kusto-graph-skills/[0-9.]+/skills/'
-$pathPatternCursorKustoGraph = '\.cursor/plugins/cache/[^/]+/azure-kusto-graph-skills/[^/]+/skills/'
-$pathPatternVscodeAgentPluginsKustoGraph = 'agent-plugins/github\.com/microsoft/azure-skills/\.github/plugins/azure-kusto-graph-skills/skills/'
-
-# --- shared across all plugins ---
-$pathPatternAgentsSkills = '\.agents/skills/'
-
-# Put the path patterns into an array for easier iteration
-$pathPatterns = @(
-    $pathPatternCopilot, $pathPatternClaude, $pathPatternCursor, $pathPatternVscodeAgentPlugins,
-    $pathPatternCopilotKustoGraph, $pathPatternClaudeKustoGraph, $pathPatternCursorKustoGraph, $pathPatternVscodeAgentPluginsKustoGraph,
-    $pathPatternAgentsSkills
-)
-
-# If $env:AZURE_SKILLS_PLUGIN_ROOT is set, add it to the path patterns for local skill development
-if ($env:AZURE_SKILLS_PLUGIN_ROOT) {
-    $localSkillsPath = [regex]::Escape($env:AZURE_SKILLS_PLUGIN_ROOT) + '/skills/'
-    $localSkillsPath = $localSkillsPath -replace '\\', '/' -replace '/+', '/'
-    $pathPatterns += $localSkillsPath
+# Publish a classified event, then always return the host success response.
+if ($telemetryEvent.ShouldTrack) {
+    Publish-TelemetryEvent $telemetryEvent
 }
-
-$shouldTrack = $false
-$eventType = $null
-$skillName = $null
-$skillVersion = $null
-$azureToolName = $null
-$filePath = $null
-
-# Check for skill invocation via 'skill'/'Skill' tool
-if ($toolName -eq "skill" -or $toolName -eq "Skill") {
-    $skillName = $toolInput.skill
-    # Claude Code prefixes skill names with "azure:" (e.g., "azure:azure-prepare")
-    # Strip it to get the actual skill name for the allowlist
-    if ($skillName -and $skillName.StartsWith("azure:")) {
-        $skillName = $skillName.Substring(6)
-    }
-    $skillMdPath = Join-Path $skillsDir (Join-Path $skillName 'SKILL.md')
-    if ($skillName -and (Test-Path -LiteralPath $skillMdPath) -and (Test-OwnedSkillPath $skillMdPath)) {
-        $eventType = "skill_invocation"
-        $shouldTrack = $true
-        $skillVersion = Get-SkillVersion $skillMdPath
-    }
-}
-
-# Check for skill invocation (reading SKILL.md files)
-# Copilot CLI: "view", Claude Code: "Read", VS Code: "read_file"
-if ($toolName -eq "view" -or $toolName -eq "Read" -or $toolName -eq "read_file") {
-    $pathToCheck = Get-ToolInputPath
-    if ($pathToCheck) {
-        # Normalize path: convert to lowercase, replace backslashes, and squeeze consecutive slashes
-        $pathLower = $pathToCheck.ToLower() -replace '\\', '/' -replace '/+', '/'
-
-        # Check for SKILL.md pattern — only match azure-skills paths (see pathPatterns above)
-        $isAzureSkillMd = $false
-        foreach ($pattern in $pathPatterns) {
-            if ($pathLower -match "${pattern}[^/]+/skill\.md") {
-                $isAzureSkillMd = $true
-                break
-            }
-        }
-
-        if ($isAzureSkillMd -and (Test-OwnedSkillPath $pathToCheck)) {
-            $pathNormalized = $pathToCheck -replace '\\', '/' -replace '/+', '/'
-            if ($pathNormalized -match '/skills/([^/]+)/SKILL\.md$') {
-                $skillName = $Matches[1]
-                $eventType = "skill_invocation"
-                $shouldTrack = $true
-                $skillVersion = Get-SkillVersion $pathToCheck
-            }
-        }
-    }
-}
-
-# Check for Azure MCP tool invocation
-# Copilot CLI:  "azure-*" prefix (e.g., azure-documentation)
-# Claude Code:  "mcp__plugin_azure_azure__*" prefix (e.g., mcp__plugin_azure_azure__documentation)
-# Cursor:       afterMCPExecution with mcp_server_name "azure"; remove Cursor's
-#               optional display prefix (e.g., MCP:get_azure_bestpractices)
-# VS Code:      "mcp_azure_mcp_*" prefix (e.g., mcp_azure_mcp_documentation)
-if ($toolName) {
-    if ($clientName -eq "cursor" -and $hookEventName -eq "afterMCPExecution" -and $mcpServerName -eq "azure") {
-        $azureToolName = $toolName
-        if ($azureToolName.StartsWith("MCP:", [System.StringComparison]::Ordinal)) {
-            $azureToolName = $azureToolName.Substring(4)
-        }
-        $eventType = "tool_invocation"
-        $shouldTrack = $true
-    } elseif ($toolName.StartsWith("azure-") -or $toolName.StartsWith("mcp__plugin_azure_azure__") -or $toolName.StartsWith("mcp_azure_mcp_")) {
-        $azureToolName = $toolName
-        $eventType = "tool_invocation"
-        $shouldTrack = $true
-    }
-}
-
-# Capture file path from any tool input (only track files in azure skills folder)
-# Skip if already matched as SKILL.md skill_invocation — SKILL.md is not a valid file-reference
-if (-not $filePath -and -not $skillName) {
-    $pathToCheck = Get-ToolInputPath
-    if ($pathToCheck) {
-        # Normalize path for matching: replace backslashes and squeeze consecutive slashes
-        $pathLower = $pathToCheck.ToLower() -replace '\\', '/' -replace '/+', '/'
-
-        $matchesPattern = $false
-        foreach ($pattern in $pathPatterns) {
-            if ($pathLower -match $pattern) {
-                $matchesPattern = $true
-                break
-            }
-        }
-        if ($matchesPattern -and (Test-OwnedSkillPath $pathToCheck)) {
-            # Extract relative path after 'skills/'
-            $pathNormalized = $pathToCheck -replace '\\', '/' -replace '/+', '/'
-
-            if ($pathNormalized -match '.*/skills/(.+)$') {
-                $filePath = $Matches[1]
-
-                if (-not $shouldTrack) {
-                    $shouldTrack = $true
-                    $eventType = "reference_file_read"
-                    # Resolve the version from the sibling SKILL.md at the root
-                    # of the skill folder this reference lives in.
-                    $skillNameSeg = ($filePath -split '/')[0]
-                    $skillRootAbs = $pathNormalized.Substring(0, $pathNormalized.Length - $filePath.Length)
-                    $skillVersion = Get-SkillVersion ("$skillRootAbs$skillNameSeg/SKILL.md")
-                }
-            }
-        }
-    }
-}
-
-# === STEP 3: Publish event ===
-
-if ($shouldTrack) {
-    $pluginVersion = Get-PluginVersion
-
-    # Build MCP command arguments
-    $mcpArgs = @(
-        "server", "plugin-telemetry",
-        "--timestamp", $timestamp,
-        "--client-name", $clientName
-    )
-
-    if ($eventType) { $mcpArgs += "--event-type"; $mcpArgs += $eventType }
-    if ($sessionId) { $mcpArgs += "--session-id"; $mcpArgs += $sessionId }
-    if ($skillName) { $mcpArgs += "--skill-name"; $mcpArgs += $skillName }
-    if ($skillVersion) { $mcpArgs += "--skill-version"; $mcpArgs += $skillVersion }
-    if ($pluginVersion) { $mcpArgs += "--plugin-version"; $mcpArgs += $pluginVersion }
-    if ($azureToolName) { $mcpArgs += "--tool-name"; $mcpArgs += $azureToolName }
-    # Convert forward slashes to backslashes for azmcp allowlist compatibility
-    if ($filePath) { $mcpArgs += "--file-reference"; $mcpArgs += ($filePath -replace '/', '\') }
-
-    # Publish telemetry via npx
-    try {
-        & npx -y @azure/mcp@latest @mcpArgs 2>&1 | Out-Null
-    } catch { }
-
-    # If AZURE_SKILLS_TELEMETRY_LOG_DIR env var is set, append the args to the telemetry.log file in that directory (for debugging)
-    Write-TelemetryDebugLog -Content "MCP Args: $($mcpArgs -join ' ')"
-}
-
-# Output success to stdout (required by hooks)
 Write-Success

--- a/hooks/scripts/track-telemetry.ps1
+++ b/hooks/scripts/track-telemetry.ps1
@@ -176,7 +176,7 @@ function Test-OwnedSkillPath {
 function Test-LocalSkillPath {
     param([string]$NormalizedPath)
     if (-not $NormalizedPath -or -not $env:AZURE_SKILLS_PLUGIN_ROOT) { return $false }
-    $localRoot = Normalize-PathLower $env:AZURE_SKILLS_PLUGIN_ROOT
+    $localRoot = (Normalize-PathLower $env:AZURE_SKILLS_PLUGIN_ROOT).TrimEnd('/')
     return $NormalizedPath.Contains("$localRoot/skills/")
 }
 

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -250,6 +250,13 @@ extract_toolargs_path() {
     echo "$path_value"
 }
 
+# Clients have used more than one file-read tool name over time. Accept the
+# complete compatibility list regardless of which client emitted the payload.
+is_file_read_tool() {
+    local tool_name="$1"
+    [ "$tool_name" = "view" ] || [ "$tool_name" = "Read" ] || [ "$tool_name" = "read_file" ]
+}
+
 # Initialize the normalized event contract populated by each client handler.
 reset_telemetry_event() {
     shouldTrack=false

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -1,488 +1,412 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Telemetry tracking hook for Azure Copilot Skills
-# Reads JSON input from stdin, tracks relevant events, and publishes via MCP
+# Telemetry tracking hook for Azure Copilot Skills.
+# Reads JSON input from stdin, tracks relevant events, and publishes via MCP.
+# Exit codes: 0 = hook handled or safely skipped.
 #
 # === Client Format Reference ===
 #
 # Copilot CLI:
 #   - Field names:    camelCase (toolName, sessionId, toolArgs)
 #   - Tool names:     lowercase (skill, view)
-#   - MCP prefix:     azure-<command>  (e.g., azure-documentation)
+#   - MCP prefix:     azure-<command> (for example, azure-documentation)
 #   - Skill prefix:   none (skill name as-is)
-#   - Detection:      COPILOT_CLI env var is "1" (>=0.0.421); fallback: "toolArgs" without "hook_event_name" (<0.0.421)
+#   - Detection:      COPILOT_CLI is "1" (>=0.0.421); fallback is toolArgs
+#                     without hook_event_name (<0.0.421)
 #
 # Claude Code:
-#   - Field names:    snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Field names:    snake_case (tool_name, session_id, tool_input,
+#                     hook_event_name)
 #   - Tool names:     PascalCase (Skill, Read, Edit)
-#   - MCP prefix:     mcp__plugin_azure_azure__<command>  (double underscores)
-#   - Skill prefix:   azure:<skill-name>  (e.g., azure:azure-prepare)
-#   - Detection:      has "hook_event_name", tool_use_id does NOT contain "__vscode"
+#   - MCP prefix:     mcp__plugin_azure_azure__<command>
+#   - Skill prefix:   azure:<skill-name> (for example, azure:azure-prepare)
+#   - Detection:      has hook_event_name and tool_use_id does not contain
+#                     "__vscode"
 #
 # Cursor:
-#   - Field names:    snake_case (tool_name, session_id, tool_input, hook_event_name)
-#   - Tool names:     PascalCase for file reads (Read); raw MCP tool name from afterMCPExecution
-#   - Skill paths:    .cursor/plugins/cache/<catalog>/azure/<revision>/skills/<name>/SKILL.md
-#   - Detection:      has "hook_event_name" and "cursor_version"
-#   - MCP detection:  afterMCPExecution event with mcp_server_name "azure"
+#   - Field names:    snake_case (tool_name, session_id, tool_input,
+#                     hook_event_name)
+#   - Tool names:     PascalCase for file reads (Read); raw MCP tool name from
+#                     afterMCPExecution
+#   - Skill paths:    .cursor/plugins/cache/<catalog>/azure/<revision>/skills/
+#   - Detection:      has hook_event_name and cursor_version
+#   - MCP detection:  afterMCPExecution with mcp_server_name "azure"
 #
 # VS Code:
-#   - Field names:    snake_case (tool_name, session_id, tool_input, hook_event_name)
+#   - Field names:    snake_case (tool_name, session_id, tool_input,
+#                     hook_event_name)
 #   - Tool names:     snake_case (read_file, replace_string_in_file)
-#   - MCP prefix:     mcp_azure_mcp_<command>  (e.g., mcp_azure_mcp_documentation)
-#   - Skill paths:    .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/<name>/SKILL.md          (VS Code)
-#                     .vscode-insiders/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/<name>/SKILL.md (VS Code Insiders)
+#   - MCP prefix:     mcp_azure_mcp_<command>
+#   - Skill paths:    .vscode/agent-plugins/github.com/microsoft/azure-skills/
+#                     .github/plugins/azure-skills/skills/<name>/SKILL.md
+#                     .vscode-insiders/agent-plugins/github.com/microsoft/
+#                     azure-skills/.github/plugins/azure-skills/skills/
+#                     <name>/SKILL.md
 #                     .agents/skills/<name>/SKILL.md
-#   - Detection:      has "hook_event_name", tool_use_id contains "__vscode"
+#   - Detection:      has hook_event_name and tool_use_id contains "__vscode",
 #                     or transcript_path contains "Code"
-#   - Client name:    "Visual Studio Code" (stable) or "Visual Studio Code - Insiders"
-#                     derived from transcript_path (e.g., .../Code - Insiders/User/...)
-#   - Note:           Skills under .agents/skills/ are tracked as "Visual Studio Code" but
-#                     transcript_path may be absent, so stable vs Insiders can only be
-#                     distinguished when skills are called from agent-plugins (which
-#                     includes transcript_path)
+#   - Client name:    "Visual Studio Code" or
+#                     "Visual Studio Code - Insiders", derived from
+#                     transcript_path
+#   - Note:           .agents/skills payloads can omit transcript_path, so
+#                     stable and Insiders can only be distinguished when that
+#                     path is available
 #
 # === Event Types ===
 #
 # 1. skill_invocation
-#    - Triggered when: the "skill"/"Skill" tool is called with a skill name,
-#      OR a SKILL.md file is read from a recognized azure-skills path
-#    - Tracked fields: --skill-name <name>, --skill-version <version>
+#    - Triggered when the skill tool is called with a skill name, or when a
+#      SKILL.md file is read from a recognized Azure skills path.
+#    - Fields: --skill-name <name>, --skill-version <version>
 #
 # 2. tool_invocation
-#    - Triggered when: a tool matching an Azure MCP prefix is called
-#      (azure-*, mcp__plugin_azure_azure__*, mcp_azure_mcp_*), or when Cursor
-#      sends afterMCPExecution with mcp_server_name "azure"
-#    - Tracked field: --tool-name <toolName>
+#    - Triggered by the client's Azure MCP prefix, or by Cursor's
+#      afterMCPExecution event when mcp_server_name is "azure".
+#    - Field: --tool-name <toolName>
 #
 # 3. reference_file_read
-#    - Triggered when: a file read tool (view/Read/read_file) targets a file
-#      inside a recognized azure-skills path that is NOT a SKILL.md
-#    - These are the reference/instruction files that skills bundle alongside
-#      SKILL.md (e.g., recipes, templates, requirement docs)
-#    - Tracked fields: --file-reference <relative-path-after-skills/>,
+#    - Triggered when a client file-read tool targets a bundled file inside a
+#      recognized Azure skills path that is not SKILL.md.
+#    - Fields: --file-reference <relative-path-after-skills/>,
 #      --skill-version <version>
 #
 # === Skill Version ===
 #
-# The skill version is read from the SKILL.md frontmatter (metadata.version),
-# which the build stamps at package time. It is resolved as follows:
-#   - skill/Skill tool call: locate SKILL.md relative to this script's plugin
-#     root ("<plugin-root>/skills/<name>/SKILL.md")
-#   - SKILL.md read:          read the version from the SKILL.md being read
-#   - reference_file_read:    read the version from the sibling SKILL.md at the
-#                             root of the skill folder the reference lives in
-#    - Example: azure-validate/references/recipes/azd/README.md
+# Skill versions come from metadata.version in the SKILL.md frontmatter, which
+# is stamped at package build time:
+#   - Direct skill call: <plugin-root>/skills/<name>/SKILL.md
+#   - SKILL.md read: the file being read
+#   - Reference read: the sibling SKILL.md at the root of the containing skill
 #
 # === Reference File Detection ===
 #
-# When a file read tool is invoked (Copilot CLI: "view", Claude Code/Cursor:
-# "Read", VS Code: "read_file"), the script extracts the file path from the tool input
-# and checks if it falls within a recognized azure-skills folder:
+# Client handlers extract a path from toolArgs or tool_input. The shared path
+# matcher accepts every supported installation layout because one client can
+# discover and invoke a plugin originally installed by another client:
+#   azure-skills:
+#   - .copilot/installed-plugins/<catalog>/azure/skills/...
+#   - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
+#   - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
+#   - .cursor/plugins/cache/<catalog>/azure/<revision>/skills/...
+#   - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/
+#     azure-skills/skills/...
+#   azure-kusto-graph-skills:
+#   - .copilot/installed-plugins/<catalog>/azure-kusto-graph-skills/skills/...
+#   - .claude/plugins/cache/azure-skills/azure-kusto-graph-skills/<version>/
+#     skills/...
+#   - .cursor/plugins/cache/<catalog>/azure-kusto-graph-skills/<revision>/
+#     skills/...
+#   - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/
+#     azure-kusto-graph-skills/skills/...
+#   shared:
+#   - .agents/skills/...
 #
-#   Path field lookup order:
-#     - toolArgs.path / toolArgs.filePath       (Copilot CLI)
-#     - tool_input.filePath / tool_input.file_path / tool_input.path  (Claude Code / VS Code)
-#
-#   Recognized install paths (one set per plugin, see is_azure_skills_path):
-#     azure-skills:
-#     - .copilot/installed-plugins/<catalog-name>/azure/skills/...
-#       (<catalog-name> is the marketplace/catalog folder the plugin was
-#       installed under, e.g. "awesome-copilot" — it does not necessarily
-#       match the plugin's own name, "azure")
-#     - .claude/plugins/cache/azure-skills/azure/<version>/skills/...
-#     - .claude/plugins/cache/claude-plugins-official/azure/<version>/skills/...
-#     - .cursor/plugins/cache/<catalog-name>/azure/<revision>/skills/...
-#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/...
-#     azure-kusto-graph-skills:
-#     - .copilot/installed-plugins/<catalog-name>/azure-kusto-graph-skills/skills/...
-#     - .claude/plugins/cache/azure-skills/azure-kusto-graph-skills/<version>/skills/...
-#     - .cursor/plugins/cache/<catalog-name>/azure-kusto-graph-skills/<revision>/skills/...
-#     - .vscode/agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/...
-#     shared:
-#     - .agents/skills/...
-#
-#   If the path matches AND is not a SKILL.md file, the relative path after
-#   "skills/" is extracted and emitted as a reference_file_read event.
-#   SKILL.md reads are tracked as skill_invocation instead (not double-counted).
+# If a path matches and is not SKILL.md, the path after skills/ is emitted as
+# reference_file_read. SKILL.md reads are emitted as skill_invocation instead.
 #
 # === Debugging ===
 #
-# If the AZURE_SKILLS_TELEMETRY_LOG_DIR env var is set, the script will create
-# a "raw-input" subdirectory and write each raw JSON input to a timestamped file
-# for debugging. It will also append a "telemetry.log" file with MCP args for
-# each tracked event.
+# AZURE_SKILLS_TELEMETRY_LOG_DIR enables raw input logs under raw-input/ and
+# appends published MCP arguments to telemetry.log.
 #
-# When using `--plugin-dir` to load a local plugin the AZURE_SKILLS_PLUGIN_ROOT
-# env var should be set so that the script can detect local skill paths for
-# reference_file_read events.
+# When using --plugin-dir, set AZURE_SKILLS_PLUGIN_ROOT so local skill paths
+# can be recognized for reference_file_read events.
+#
+# Client-specific payload parsing and event classification live in clients/.
+# This entry point owns client detection, shared skill/plugin helpers, telemetry
+# publication, diagnostic logging, and the hook response contract.
 
-set +e  # Don't exit on errors - fail silently for privacy
+set +e
 
-# Skip telemetry if opted out
-if [ "${AZURE_MCP_COLLECT_TELEMETRY}" = "false" ]; then
-    echo '{"continue":true}'
-    exit 0
-fi
-
-# Return success and exit
+# Return the success response required by every supported hook host.
 return_success() {
     echo '{"continue":true}'
     exit 0
 }
 
-# Dumps raw input to a file in the AZURE_SKILLS_TELEMETRY_LOG_DIR/raw-input/
-# directory for debugging if the env var is set.
+# Dump raw input to AZURE_SKILLS_TELEMETRY_LOG_DIR/raw-input/ for debugging.
 write_raw_input_to_file() {
-    local rawInputValue="$1"
+    local raw_input_value="$1"
     [ -n "$AZURE_SKILLS_TELEMETRY_LOG_DIR" ] || return 0
-    local rawInputDir="$AZURE_SKILLS_TELEMETRY_LOG_DIR/raw-input"
-    mkdir -p "$rawInputDir" 2>/dev/null || return 0
-    local ts
-    ts=$(date -u +"%Y%m%dT%H%M%SZ")
-    printf '%s\n' "$rawInputValue" > "$rawInputDir/$ts.json" 2>/dev/null || true
+    local raw_input_dir="$AZURE_SKILLS_TELEMETRY_LOG_DIR/raw-input"
+    mkdir -p "$raw_input_dir" 2>/dev/null || return 0
+    local timestamp
+    timestamp=$(date -u +"%Y%m%dT%H%M%SZ")
+    printf '%s\n' "$raw_input_value" > "$raw_input_dir/$timestamp.json" 2>/dev/null || true
 }
 
-# Appends a debug log entry to the AZURE_SKILLS_TELEMETRY_LOG_DIR/telemetry.log
-# file if the env var is set.
+# Append the published MCP arguments to the optional telemetry debug log.
 write_telemetry_debug_log() {
     local content="$1"
     [ -n "$AZURE_SKILLS_TELEMETRY_LOG_DIR" ] || return 0
-    local logFile="$AZURE_SKILLS_TELEMETRY_LOG_DIR/telemetry.log"
-    echo "$(date +"%Y-%m-%dT%H:%M:%S") | $content" >> "$logFile" 2>/dev/null || true
+    local log_file="$AZURE_SKILLS_TELEMETRY_LOG_DIR/telemetry.log"
+    echo "$(date +"%Y-%m-%dT%H:%M:%S") | $content" >> "$log_file" 2>/dev/null || true
 }
 
-# Resolve this script's directory so we can locate bundled skills. In the
-# installed plugin, hooks/ and skills/ are siblings under the plugin root, so
-# <script-dir>/../../skills/<name>/SKILL.md is the skill definition.
+# Resolve bundled skills relative to the installed hook. hooks/ and skills/ are
+# siblings under each plugin root.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" 2>/dev/null && pwd)"
 SKILLS_DIR="$(cd "$SCRIPT_DIR/../.." 2>/dev/null && pwd)/skills"
 
-# Return true only when a target belongs to this hook's plugin. Since this hook
-# is copied into every plugin, comparing through the skills directory prevents
-# each installed copy from reporting the same skill or reference event.
-is_owned_skill_path() {
-    # targetPath is either path to the SKILL.md or to a reference file
-    local targetPath="$1"
-    local skillsRootNorm
-    local targetPathNorm
-    skillsRootNorm=$(echo "$SKILLS_DIR" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g; s|/$||')
-    targetPathNorm=$(echo "$targetPath" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g')
-    [[ "$targetPathNorm" == "$skillsRootNorm/"* ]]
+# Normalize paths for case-insensitive install-layout comparisons.
+normalize_path_lower() {
+    echo "$1" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g'
 }
 
-# Extract the skill version from a SKILL.md frontmatter (metadata.version).
-# Prints nothing if the file or version cannot be read.
+# Return true only when the target belongs to this installed plugin copy. The
+# hook is copied into every plugin, so this prevents duplicate reporting.
+is_owned_skill_path() {
+    local target_path="$1"
+    local skills_root_norm
+    local target_path_norm
+    skills_root_norm=$(normalize_path_lower "$SKILLS_DIR" | sed 's|/$||')
+    target_path_norm=$(normalize_path_lower "$target_path")
+    [[ "$target_path_norm" == "$skills_root_norm/"* ]]
+}
+
+# Match local plugin development paths configured through --plugin-dir.
+is_local_skill_path() {
+    local normalized_path="$1"
+    [ -n "$AZURE_SKILLS_PLUGIN_ROOT" ] || return 1
+    local local_root
+    local_root=$(normalize_path_lower "$AZURE_SKILLS_PLUGIN_ROOT")
+    [[ "$normalized_path" == *"${local_root}/skills/"* ]]
+}
+
+# Match every supported plugin installation layout, independent of the client
+# that emitted the hook payload.
+is_azure_skills_path() {
+    local path="$1"
+
+    # azure-skills plugin
+    [[ "$path" == *".copilot/installed-plugins/"*"/azure/skills/"* ]] && return 0
+    [[ "$path" == *".claude/plugins/cache/azure-skills/azure/"*"/skills/"* ]] && return 0
+    [[ "$path" == *".claude/plugins/cache/claude-plugins-official/azure/"*"/skills/"* ]] && return 0
+    [[ "$path" == *".cursor/plugins/cache/"*"/azure/"*"/skills/"* ]] && return 0
+    [[ "$path" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/"* ]] && return 0
+
+    # azure-kusto-graph-skills plugin
+    [[ "$path" == *".copilot/installed-plugins/"*"/azure-kusto-graph-skills/skills/"* ]] && return 0
+    [[ "$path" == *".claude/plugins/cache/azure-skills/azure-kusto-graph-skills/"*"/skills/"* ]] && return 0
+    [[ "$path" == *".cursor/plugins/cache/"*"/azure-kusto-graph-skills/"*"/skills/"* ]] && return 0
+    [[ "$path" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/"* ]] && return 0
+
+    # Shared and local-development skill paths
+    [[ "$path" == *".agents/skills/"* ]] && return 0
+    is_local_skill_path "$path"
+}
+
+# Extract metadata.version from SKILL.md frontmatter. Print nothing when the
+# file or version cannot be read.
 get_skill_version() {
-    local skillMdPath="$1"
-    [ -n "$skillMdPath" ] || return 0
-    # Normalize backslashes so Windows-style paths are readable
-    skillMdPath="$(echo "$skillMdPath" | tr '\\' '/')"
-    [ -f "$skillMdPath" ] || return 0
-    # Read the frontmatter block (between the first two --- lines) and pull the
-    # version value, stripping surrounding quotes and whitespace.
-    sed -n '/^---[[:space:]]*$/,/^---[[:space:]]*$/p' "$skillMdPath" 2>/dev/null \
+    local skill_md_path="$1"
+    [ -n "$skill_md_path" ] || return 0
+    skill_md_path="$(echo "$skill_md_path" | tr '\\' '/')"
+    [ -f "$skill_md_path" ] || return 0
+    sed -n '/^---[[:space:]]*$/,/^---[[:space:]]*$/p' "$skill_md_path" 2>/dev/null \
         | grep -E '^[[:space:]]*version:[[:space:]]*' \
         | head -1 \
         | sed -E 's/^[[:space:]]*version:[[:space:]]*//; s/^["'"'"']//; s/["'"'"'][[:space:]]*$//; s/[[:space:]]*$//'
 }
 
-# Extract the plugin version from the top-level .plugin/plugin.json manifest.
-# Prints nothing if the file or expected JSON value cannot be read.
+# Extract the built plugin version from the top-level .plugin/plugin.json.
 get_plugin_version() {
-    local pluginManifestPath
-    pluginManifestPath="$(dirname "$SKILLS_DIR")/.plugin/plugin.json"
-    [ -f "$pluginManifestPath" ] || return 0
+    local plugin_manifest_path
+    plugin_manifest_path="$(dirname "$SKILLS_DIR")/.plugin/plugin.json"
+    [ -f "$plugin_manifest_path" ] || return 0
     node -e '
         try {
             const manifest = JSON.parse(require("fs").readFileSync(process.argv[1], "utf8"));
             if (typeof manifest.version === "string" && manifest.version) process.stdout.write(manifest.version);
         } catch { }
-    ' "$pluginManifestPath" 2>/dev/null
+    ' "$plugin_manifest_path" 2>/dev/null
 }
 
-# === JSON Parsing Functions (using sed - portable across platforms) ===
+# === Shared JSON Parsing Helpers ===
 
-# Extract simple string field from JSON
+# Extract a top-level string field from the hook JSON.
 extract_json_field() {
     local json="$1"
     local field="$2"
     echo "$json" | sed -n "s/.*\"$field\":[[:space:]]*\"\([^\"]*\)\".*/\1/p"
 }
 
-# Extract nested field from toolArgs/tool_input (e.g., toolArgs.skill or tool_input.skill)
+# Extract a string field from a specific toolArgs/tool_input container.
 extract_toolargs_field() {
     local json="$1"
-    local field="$2"
-    local value=""
-    # Try Copilot CLI format (toolArgs) first, then Claude Code / VS Code format (tool_input)
-    value=$(echo "$json" | sed -n "s/.*\"toolArgs\":[[:space:]]*{[^}]*\"$field\":[[:space:]]*\"\([^\"]*\)\".*/\1/p")
-    if [ -z "$value" ]; then
-        value=$(echo "$json" | sed -n "s/.*\"tool_input\":[[:space:]]*{[^}]*\"$field\":[[:space:]]*\"\([^\"]*\)\".*/\1/p")
-    fi
-    echo "$value"
+    local container="$2"
+    local field="$3"
+    echo "$json" | sed -n "s/.*\"$container\":[[:space:]]*{[^}]*\"$field\":[[:space:]]*\"\([^\"]*\)\".*/\1/p"
 }
 
-# Extract path from toolArgs/tool_input (handles 'path', 'filePath', 'file_path')
+# Extract a path, filePath, or file_path property from a tool input container.
 extract_toolargs_path() {
     local json="$1"
+    local container="$2"
     local path_value=""
-
-    # Try Copilot CLI format (toolArgs) first
-    path_value=$(echo "$json" | sed -n 's/.*"toolArgs":[[:space:]]*{[^}]*"path":[[:space:]]*"\([^"]*\)".*/\1/p')
-    if [ -z "$path_value" ]; then
-        path_value=$(echo "$json" | sed -n 's/.*"toolArgs":[[:space:]]*{[^}]*"filePath":[[:space:]]*"\([^"]*\)".*/\1/p')
-    fi
-    # Fall back to Claude Code / VS Code format (tool_input)
-    if [ -z "$path_value" ]; then
-        path_value=$(echo "$json" | sed -n 's/.*"tool_input":[[:space:]]*{[^}]*"filePath":[[:space:]]*"\([^"]*\)".*/\1/p')
-    fi
-    if [ -z "$path_value" ]; then
-        path_value=$(echo "$json" | sed -n 's/.*"tool_input":[[:space:]]*{[^}]*"file_path":[[:space:]]*"\([^"]*\)".*/\1/p')
-    fi
-    if [ -z "$path_value" ]; then
-        path_value=$(echo "$json" | sed -n 's/.*"tool_input":[[:space:]]*{[^}]*"path":[[:space:]]*"\([^"]*\)".*/\1/p')
-    fi
-
+    path_value=$(extract_toolargs_field "$json" "$container" "path")
+    [ -n "$path_value" ] || path_value=$(extract_toolargs_field "$json" "$container" "filePath")
+    [ -n "$path_value" ] || path_value=$(extract_toolargs_field "$json" "$container" "file_path")
     echo "$path_value"
 }
 
-# === Main Processing ===
-
-# Check if stdin has data
-if [ -t 0 ]; then
-    return_success
-fi
-
-# Read entire stdin at once - hooks send one complete JSON per invocation
-rawInput=$(cat)
-
-# Return success and exit if no input
-if [ -z "$rawInput" ]; then
-    return_success
-fi
-
-write_raw_input_to_file "$rawInput"
-
-# === STEP 1: Read and parse input ===
-
-# Extract fields from hook data
-# Support Copilot CLI (camelCase), Claude Code (snake_case), and VS Code (snake_case) formats
-toolName=$(extract_json_field "$rawInput" "toolName")
-sessionId=$(extract_json_field "$rawInput" "sessionId")
-hookEventName=$(extract_json_field "$rawInput" "hook_event_name")
-mcpServerName=$(extract_json_field "$rawInput" "mcp_server_name")
-
-# Fall back to Claude Code / VS Code snake_case field names
-if [ -z "$toolName" ]; then
-    toolName=$(extract_json_field "$rawInput" "tool_name")
-fi
-if [ -z "$sessionId" ]; then
-    sessionId=$(extract_json_field "$rawInput" "session_id")
-fi
-
-timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-# Detect client name based on input format
-# Copilot CLI (>=0.0.421): COPILOT_CLI env var is "1" — primary signal, checked first
-# Copilot CLI (<0.0.421):  has "toolArgs" field without "hook_event_name" — backward compat fallback
-# Cursor: has hook_event_name AND a "cursor_version" field
-# VS Code: has hook_event_name AND tool_use_id contains "__vscode" or transcript_path contains "Code"
-# Claude Code: has hook_event_name, tool_use_id does NOT contain "__vscode"
-if [ "$COPILOT_CLI" = "1" ]; then
-    clientName="copilot-cli"
-elif echo "$rawInput" | grep -q '"hook_event_name"'; then
-    toolUseId=$(extract_json_field "$rawInput" "tool_use_id")
-    transcriptPath=$(extract_json_field "$rawInput" "transcript_path")
-    cursorVersion=$(extract_json_field "$rawInput" "cursor_version")
-    # Normalize backslashes to forward slashes for consistent matching
-    transcriptPathNorm=$(echo "$transcriptPath" | tr '\\' '/')
-    if [ -n "$cursorVersion" ]; then
-        clientName="cursor"
-    # Match path separators around "Code" or "Code - Insiders" to avoid matching "Claude Code"
-    elif [[ "$toolUseId" == *"__vscode"* ]] || [[ "$transcriptPathNorm" == */Code/* ]] || [[ "$transcriptPathNorm" == */Code\ -\ Insiders/* ]]; then
-        # Detect VS Code variant from transcript_path
-        # Insiders: ...AppData/Roaming/Code - Insiders/User/...
-        # Stable:   ...AppData/Roaming/Code/User/...
-        if [[ "$transcriptPathNorm" == */Code\ -\ Insiders/* ]]; then
-            clientName="Visual Studio Code - Insiders"
-        else
-            clientName="Visual Studio Code"
-        fi
-    else
-        clientName="claude-code"
-    fi
-elif echo "$rawInput" | grep -q '"toolArgs"'; then
-    # Backward compat: old Copilot CLI (<0.0.421) sent toolArgs without hook_event_name
-    # Claude Code never sends toolArgs, so this is unambiguous
-    clientName="copilot-cli"
-else
-    clientName="unknown"
-fi
-
-# Skip if no tool name found in any format
-if [ -z "$toolName" ]; then
-    return_success
-fi
-
-# === STEP 2: Determine what to track for azmcp ===
-
-# Check if a path matches any known plugin skills folder structure.
- # Each plugin has its own block below — when onboarding another plugin, add a new
- # block by swapping both the catalog/plugin segments (e.g. "azure" and
- # "azure-skills") for the new plugin. Returns 0 (true) if matched, 1 (false) otherwise.
-is_azure_skills_path() {
-    local p="$1"
-
-    # --- azure-skills plugin ---
-    # The Copilot CLI pattern wildcards the catalog/marketplace folder name
-    # (e.g. "awesome-copilot") since it does not necessarily match the
-    # plugin's own name ("azure").
-    [[ "$p" == *".copilot/installed-plugins/"*"/azure/skills/"* ]] && return 0
-    [[ "$p" == *".claude/plugins/cache/azure-skills/azure/"*"/skills/"* ]] && return 0
-    [[ "$p" == *".claude/plugins/cache/claude-plugins-official/azure/"*"/skills/"* ]] && return 0
-    [[ "$p" == *".cursor/plugins/cache/"*"/azure/"*"/skills/"* ]] && return 0
-    [[ "$p" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-skills/skills/"* ]] && return 0
-
-    # --- azure-kusto-graph-skills plugin ---
-    [[ "$p" == *".copilot/installed-plugins/"*"/azure-kusto-graph-skills/skills/"* ]] && return 0
-    [[ "$p" == *".claude/plugins/cache/azure-skills/azure-kusto-graph-skills/"*"/skills/"* ]] && return 0
-    [[ "$p" == *".cursor/plugins/cache/"*"/azure-kusto-graph-skills/"*"/skills/"* ]] && return 0
-    [[ "$p" == *"agent-plugins/github.com/microsoft/azure-skills/.github/plugins/azure-kusto-graph-skills/skills/"* ]] && return 0
-
-    # --- shared across all plugins ---
-    [[ "$p" == *".agents/skills/"* ]] && return 0
-
-    # Local plugin development: match paths under AZURE_SKILLS_PLUGIN_ROOT/skills/
-    # (e.g. when loading a local plugin via `--plugin-dir`)
-    if [ -n "$AZURE_SKILLS_PLUGIN_ROOT" ]; then
-        local localRoot
-        localRoot=$(echo "$AZURE_SKILLS_PLUGIN_ROOT" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g')
-        [[ "$p" == *"${localRoot}/skills/"* ]] && return 0
-    fi
-    return 1
+# Initialize the normalized event contract populated by each client handler.
+reset_telemetry_event() {
+    shouldTrack=false
+    clientName=""
+    sessionId=""
+    eventType=""
+    skillName=""
+    skillVersion=""
+    azureToolName=""
+    filePath=""
 }
 
-shouldTrack=false
-eventType=""
-skillName=""
-skillVersion=""
-azureToolName=""
-filePath=""
-
-# Check for skill invocation via 'skill'/'Skill' tool
-if [ "$toolName" = "skill" ] || [ "$toolName" = "Skill" ]; then
-    skillName=$(extract_toolargs_field "$rawInput" "skill")
-    # Claude Code prefixes skill names with "azure:" (e.g., "azure:azure-prepare")
-    # Strip it to get the actual skill name for the allowlist
-    skillName="${skillName#azure:}"
-    skillMdPath="$SKILLS_DIR/$skillName/SKILL.md"
-    if [ -n "$skillName" ] && [ -f "$skillMdPath" ] && is_owned_skill_path "$skillMdPath"; then
+# Track a direct skill-tool call after the handler normalizes the skill name.
+track_skill_by_name() {
+    local candidate="$1"
+    local skill_md_path
+    [ -n "$candidate" ] || return 0
+    skill_md_path="$SKILLS_DIR/$candidate/SKILL.md"
+    if [ -f "$skill_md_path" ] && is_owned_skill_path "$skill_md_path"; then
+        skillName="$candidate"
+        skillVersion=$(get_skill_version "$skill_md_path")
         eventType="skill_invocation"
         shouldTrack=true
-        skillVersion=$(get_skill_version "$skillMdPath")
     fi
-fi
+}
 
-# Check for skill invocation (reading SKILL.md files)
-# Copilot CLI: "view", Claude Code: "Read", VS Code: "read_file"
-if [ "$toolName" = "view" ] || [ "$toolName" = "Read" ] || [ "$toolName" = "read_file" ]; then
-    pathToCheck=$(extract_toolargs_path "$rawInput")
-    if [ -n "$pathToCheck" ]; then
-        # Normalize path: convert to lowercase, replace backslashes, and squeeze consecutive slashes
-        pathLower=$(echo "$pathToCheck" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g')
+# Track a SKILL.md read after the handler validates the client install path.
+track_skill_read() {
+    local target_path="$1"
+    local normalized_path
+    local candidate
+    is_owned_skill_path "$target_path" || return 0
+    normalized_path=$(echo "$target_path" | tr '\\' '/' | sed 's|//*|/|g')
+    candidate=$(echo "$normalized_path" | sed -n 's|.*/skills/\([^/]*\)/[Ss][Kk][Ii][Ll][Ll]\.[Mm][Dd]$|\1|p')
+    [ -n "$candidate" ] || return 0
+    skillName="$candidate"
+    skillVersion=$(get_skill_version "$target_path")
+    eventType="skill_invocation"
+    shouldTrack=true
+}
 
-        # Check for SKILL.md pattern — only match azure-skills paths
-        if is_azure_skills_path "$pathLower" && is_owned_skill_path "$pathToCheck" && [[ "$pathLower" == *"/skill.md" ]]; then
-            pathNormalized=$(echo "$pathToCheck" | tr '\\' '/' | sed 's|//*|/|g')
-            if [[ "$pathNormalized" =~ /skills/([^/]+)/SKILL\.md$ ]]; then
-                skillName="${BASH_REMATCH[1]}"
-                eventType="skill_invocation"
-                shouldTrack=true
-                skillVersion=$(get_skill_version "$pathToCheck")
-            fi
-        fi
-    fi
-fi
-
-# Check for Azure MCP tool invocation
-# Copilot CLI:  "azure-*" prefix (e.g., azure-documentation)
-# Claude Code:  "mcp__plugin_azure_azure__*" prefix (e.g., mcp__plugin_azure_azure__documentation)
-# Cursor:       afterMCPExecution with mcp_server_name "azure"; remove Cursor's
-#               optional display prefix (e.g., MCP:get_azure_bestpractices)
-# VS Code:      "mcp_azure_mcp_*" prefix (e.g., mcp_azure_mcp_documentation)
-if [ -n "$toolName" ]; then
-    if [ "$clientName" = "cursor" ] && [ "$hookEventName" = "afterMCPExecution" ] && [ "$mcpServerName" = "azure" ]; then
-        azureToolName="${toolName#MCP:}"
-        eventType="tool_invocation"
+# Capture a path relative to skills/. If no higher-priority event was already
+# selected, classify the path as a reference_file_read and resolve its version.
+capture_reference_path() {
+    local target_path="$1"
+    local normalized_path
+    local skill_name_segment
+    local skill_root_abs
+    is_owned_skill_path "$target_path" || return 0
+    normalized_path=$(echo "$target_path" | tr '\\' '/' | sed 's|//*|/|g')
+    filePath=$(echo "$normalized_path" | sed -n 's|.*/skills/||p')
+    [ -n "$filePath" ] || return 0
+    if [ "$shouldTrack" = false ]; then
+        eventType="reference_file_read"
         shouldTrack=true
-    elif [[ "$toolName" == azure-* ]] || [[ "$toolName" == mcp__plugin_azure_azure__* ]] || [[ "$toolName" == mcp_azure_mcp_* ]]; then
-        azureToolName="$toolName"
-        eventType="tool_invocation"
-        shouldTrack=true
+        skill_name_segment="${filePath%%/*}"
+        skill_root_abs="${normalized_path:0:${#normalized_path}-${#filePath}}"
+        skillVersion=$(get_skill_version "${skill_root_abs}${skill_name_segment}/SKILL.md")
     fi
-fi
+}
 
-# Capture file path from any tool input (only track files in azure skills folder)
-# Skip if already matched as SKILL.md skill_invocation — SKILL.md is not a valid file-reference
-if [ -z "$filePath" ] && [ -z "$skillName" ]; then
-    pathToCheck=$(extract_toolargs_path "$rawInput")
-    if [ -n "$pathToCheck" ]; then
-        # Normalize path for matching: replace backslashes and squeeze consecutive slashes
-        pathLower=$(echo "$pathToCheck" | tr '[:upper:]' '[:lower:]' | tr '\\' '/' | sed 's|//*|/|g')
+# Populate the normalized event fields for an Azure MCP tool invocation.
+track_tool_invocation() {
+    azureToolName="$1"
+    eventType="tool_invocation"
+    shouldTrack=true
+}
 
-        # Check if path matches azure skills folder structure
-        if is_azure_skills_path "$pathLower" && is_owned_skill_path "$pathToCheck"; then
-            # Extract relative path after 'skills/'
-            pathNormalized=$(echo "$pathToCheck" | tr '\\' '/' | sed 's|//*|/|g')
+# Detect the client once, before handing the payload to client-specific logic.
+# Copilot's environment signal has highest precedence, followed by Cursor,
+# VS Code, Claude Code, and the legacy Copilot toolArgs fallback.
+detect_client() {
+    local raw_input="$1"
+    local tool_use_id
+    local transcript_path
+    local transcript_path_norm
+    local cursor_version
 
-            if [[ "$pathNormalized" =~ .*/skills/(.+)$ ]]; then
-                filePath="${BASH_REMATCH[1]}"
+    if [ "$COPILOT_CLI" = "1" ]; then
+        echo "copilot-cli"
+        return 0
+    fi
 
-                if [ "$shouldTrack" = false ]; then
-                    shouldTrack=true
-                    eventType="reference_file_read"
-                    # Resolve the version from the sibling SKILL.md at the root
-                    # of the skill folder this reference lives in. Strip the
-                    # relative suffix by length (literal removal) so glob
-                    # metacharacters in the path can't corrupt the result.
-                    skillNameSeg="${filePath%%/*}"
-                    skillRootAbs="${pathNormalized:0:${#pathNormalized}-${#filePath}}"
-                    skillVersion=$(get_skill_version "${skillRootAbs}${skillNameSeg}/SKILL.md")
-                fi
-            fi
+    if echo "$raw_input" | grep -Fq '"hook_event_name"'; then
+        tool_use_id=$(extract_json_field "$raw_input" "tool_use_id")
+        transcript_path=$(extract_json_field "$raw_input" "transcript_path")
+        cursor_version=$(extract_json_field "$raw_input" "cursor_version")
+        transcript_path_norm=$(echo "$transcript_path" | tr '\\' '/')
+        if [ -n "$cursor_version" ]; then
+            echo "cursor"
+        elif [[ "$tool_use_id" == *"__vscode"* ]] \
+            || [[ "$transcript_path_norm" == */Code/* ]] \
+            || [[ "$transcript_path_norm" == */Code\ -\ Insiders/* ]]; then
+            echo "vscode"
+        else
+            echo "claude-code"
         fi
+        return 0
     fi
-fi
 
-# === STEP 3: Publish event via azmcp ===
+    if echo "$raw_input" | grep -Fq '"toolArgs"'; then
+        echo "copilot-cli"
+        return 0
+    fi
 
-if [ "$shouldTrack" = true ]; then
-    pluginVersion=$(get_plugin_version)
+    echo "unknown"
+}
 
-    # Build MCP command arguments (using array for proper quoting)
-    mcpArgs=(
+# === Publish Event ===
+
+# Convert the normalized event to plugin-telemetry arguments and publish it.
+# Telemetry publication is best-effort and must never block the host client.
+publish_telemetry_event() {
+    local timestamp
+    local plugin_version
+    local mcp_args
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    plugin_version=$(get_plugin_version)
+    mcp_args=(
         "server" "plugin-telemetry"
         "--timestamp" "$timestamp"
         "--client-name" "$clientName"
     )
 
-    [ -n "$eventType" ] && mcpArgs+=("--event-type" "$eventType")
-    [ -n "$sessionId" ] && mcpArgs+=("--session-id" "$sessionId")
-    [ -n "$skillName" ] && mcpArgs+=("--skill-name" "$skillName")
-    [ -n "$skillVersion" ] && mcpArgs+=("--skill-version" "$skillVersion")
-    [ -n "$pluginVersion" ] && mcpArgs+=("--plugin-version" "$pluginVersion")
-    [ -n "$azureToolName" ] && mcpArgs+=("--tool-name" "$azureToolName")
-    # Convert forward slashes to backslashes for azmcp allowlist compatibility
-    [ -n "$filePath" ] && mcpArgs+=("--file-reference" "$(echo "$filePath" | tr '/' '\\')")
+    [ -n "$eventType" ] && mcp_args+=("--event-type" "$eventType")
+    [ -n "$sessionId" ] && mcp_args+=("--session-id" "$sessionId")
+    [ -n "$skillName" ] && mcp_args+=("--skill-name" "$skillName")
+    [ -n "$skillVersion" ] && mcp_args+=("--skill-version" "$skillVersion")
+    [ -n "$plugin_version" ] && mcp_args+=("--plugin-version" "$plugin_version")
+    [ -n "$azureToolName" ] && mcp_args+=("--tool-name" "$azureToolName")
+    [ -n "$filePath" ] && mcp_args+=("--file-reference" "$(echo "$filePath" | tr '/' '\\')")
 
-    # Publish telemetry via npx
-    npx -y @azure/mcp@latest "${mcpArgs[@]}" >/dev/null 2>&1 || true
+    npx -y @azure/mcp@latest "${mcp_args[@]}" >/dev/null 2>&1 || true
+    write_telemetry_debug_log "MCP Args: ${mcp_args[*]}"
+}
 
-    # If AZURE_SKILLS_TELEMETRY_LOG_DIR env var is set, append the args to the
-    # telemetry.log file in that directory (for debugging)
-    write_telemetry_debug_log "MCP Args: ${mcpArgs[*]}"
+# === Main Processing ===
+
+# Skip collection when opted out or when invoked without piped hook input.
+if [ "${AZURE_MCP_COLLECT_TELEMETRY}" = "false" ] || [ -t 0 ]; then
+    return_success
 fi
 
-# Output success to stdout (required by hooks)
+# Hooks send one complete JSON object per invocation.
+rawInput=$(cat)
+[ -n "$rawInput" ] || return_success
+write_raw_input_to_file "$rawInput"
+
+# Load only the detected client's parser and event-classification rules.
+client_key=$(detect_client "$rawInput")
+handler_path="$SCRIPT_DIR/clients/$client_key.sh"
+[ "$client_key" != "unknown" ] && [ -f "$handler_path" ] || return_success
+
+reset_telemetry_event
+. "$handler_path" 2>/dev/null || return_success
+process_telemetry_event "$rawInput"
+
+# Publish a classified event, then always return the host success response.
+[ "$shouldTrack" = true ] && publish_telemetry_event
 return_success

--- a/hooks/scripts/track-telemetry.sh
+++ b/hooks/scripts/track-telemetry.sh
@@ -169,7 +169,7 @@ is_local_skill_path() {
     local normalized_path="$1"
     [ -n "$AZURE_SKILLS_PLUGIN_ROOT" ] || return 1
     local local_root
-    local_root=$(normalize_path_lower "$AZURE_SKILLS_PLUGIN_ROOT")
+    local_root=$(normalize_path_lower "$AZURE_SKILLS_PLUGIN_ROOT" | sed 's|/*$||')
     [[ "$normalized_path" == *"${local_root}/skills/"* ]]
 }
 

--- a/scripts/src/__tests__/fixtures/claude-mcp-invocation.json
+++ b/scripts/src/__tests__/fixtures/claude-mcp-invocation.json
@@ -1,0 +1,7 @@
+{
+  "tool_name": "mcp__plugin_azure_azure__get_azure_bestpractices",
+  "tool_input": {},
+  "tool_use_id": "tool-mcp",
+  "session_id": "73e52424-a95d-4e21-b70c-2dffe48fdd86",
+  "hook_event_name": "PostToolUse"
+}

--- a/scripts/src/__tests__/fixtures/claude-reference-read.json
+++ b/scripts/src/__tests__/fixtures/claude-reference-read.json
@@ -1,0 +1,9 @@
+{
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "/home/test/.claude/plugins/cache/azure-skills/azure/1.2.3/skills/azure-cost/cost-query/guardrails.md"
+  },
+  "tool_use_id": "tool-read",
+  "session_id": "73e52424-a95d-4e21-b70c-2dffe48fdd86",
+  "hook_event_name": "PostToolUse"
+}

--- a/scripts/src/__tests__/fixtures/claude-skill-read.json
+++ b/scripts/src/__tests__/fixtures/claude-skill-read.json
@@ -1,0 +1,9 @@
+{
+  "tool_name": "Read",
+  "tool_input": {
+    "file_path": "/home/test/.claude/plugins/cache/azure-skills/azure/1.2.3/skills/azure-cost/SKILL.md"
+  },
+  "tool_use_id": "tool-read",
+  "session_id": "73e52424-a95d-4e21-b70c-2dffe48fdd86",
+  "hook_event_name": "PostToolUse"
+}

--- a/scripts/src/__tests__/fixtures/copilot-mcp-invocation.json
+++ b/scripts/src/__tests__/fixtures/copilot-mcp-invocation.json
@@ -1,0 +1,5 @@
+{
+  "toolName": "azure-get_azure_bestpractices",
+  "toolArgs": {},
+  "sessionId": "73e52424-a95d-4e21-b70c-2dffe48fdd86"
+}

--- a/scripts/src/__tests__/fixtures/copilot-reference-read.json
+++ b/scripts/src/__tests__/fixtures/copilot-reference-read.json
@@ -1,0 +1,7 @@
+{
+  "toolName": "view",
+  "toolArgs": {
+    "path": "/home/test/.copilot/installed-plugins/test-catalog/azure/skills/azure-cost/cost-query/guardrails.md"
+  },
+  "sessionId": "73e52424-a95d-4e21-b70c-2dffe48fdd86"
+}

--- a/scripts/src/__tests__/fixtures/copilot-skill-read.json
+++ b/scripts/src/__tests__/fixtures/copilot-skill-read.json
@@ -1,0 +1,7 @@
+{
+  "toolName": "view",
+  "toolArgs": {
+    "path": "/home/test/.copilot/installed-plugins/test-catalog/azure/skills/azure-cost/SKILL.md"
+  },
+  "sessionId": "73e52424-a95d-4e21-b70c-2dffe48fdd86"
+}

--- a/scripts/src/__tests__/fixtures/vscode-mcp-invocation.json
+++ b/scripts/src/__tests__/fixtures/vscode-mcp-invocation.json
@@ -1,0 +1,8 @@
+{
+  "tool_name": "mcp_azure_mcp_get_azure_bestpractices",
+  "tool_input": {},
+  "tool_use_id": "tool-mcp__vscode",
+  "session_id": "73e52424-a95d-4e21-b70c-2dffe48fdd86",
+  "transcript_path": "C:\\Users\\test\\AppData\\Roaming\\Code\\User\\workspaceStorage\\transcript.json",
+  "hook_event_name": "PostToolUse"
+}

--- a/scripts/src/__tests__/fixtures/vscode-reference-read.json
+++ b/scripts/src/__tests__/fixtures/vscode-reference-read.json
@@ -1,0 +1,10 @@
+{
+  "tool_name": "read_file",
+  "tool_input": {
+    "filePath": "C:\\Users\\test\\.vscode\\agent-plugins\\github.com\\microsoft\\azure-skills\\.github\\plugins\\azure-skills\\skills\\azure-cost\\cost-query\\guardrails.md"
+  },
+  "tool_use_id": "tool-read__vscode",
+  "session_id": "73e52424-a95d-4e21-b70c-2dffe48fdd86",
+  "transcript_path": "C:\\Users\\test\\AppData\\Roaming\\Code\\User\\workspaceStorage\\transcript.json",
+  "hook_event_name": "PostToolUse"
+}

--- a/scripts/src/__tests__/fixtures/vscode-skill-read.json
+++ b/scripts/src/__tests__/fixtures/vscode-skill-read.json
@@ -1,0 +1,10 @@
+{
+  "tool_name": "read_file",
+  "tool_input": {
+    "filePath": "C:\\Users\\test\\.vscode\\agent-plugins\\github.com\\microsoft\\azure-skills\\.github\\plugins\\azure-skills\\skills\\azure-cost\\SKILL.md"
+  },
+  "tool_use_id": "tool-read__vscode",
+  "session_id": "73e52424-a95d-4e21-b70c-2dffe48fdd86",
+  "transcript_path": "C:\\Users\\test\\AppData\\Roaming\\Code\\User\\workspaceStorage\\transcript.json",
+  "hook_event_name": "PostToolUse"
+}

--- a/scripts/src/__tests__/telemetry-hooks.test.ts
+++ b/scripts/src/__tests__/telemetry-hooks.test.ts
@@ -16,12 +16,6 @@ import { basename, delimiter, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 
-type CursorPayload = {
-  tool_input: {
-    file_path?: string;
-  };
-};
-
 type ShellCase = {
   name: string;
   command: string;
@@ -44,6 +38,15 @@ type Dispatcher = {
   ) => number;
 };
 
+type ClientCase = {
+  id: "copilot" | "claude" | "cursor" | "vscode";
+  expectedClientName: string;
+  pluginRoot: string;
+  inputContainer: "toolArgs" | "tool_input";
+  pathField: "path" | "file_path" | "filePath";
+  expectedToolName: string;
+};
+
 const TEST_DIR = mkdtempSync(join(tmpdir(), "azure-telemetry-hooks-"));
 const BIN_DIR = join(TEST_DIR, "bin");
 const CAPTURE_FILE = join(TEST_DIR, "npx-args.txt");
@@ -51,21 +54,88 @@ const LOG_DIR = join(TEST_DIR, "logs");
 const RAW_INPUT_DIR = join(LOG_DIR, "raw-input");
 const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
 const SOURCE_HOOKS_DIR = join(REPO_ROOT, "hooks", "scripts");
-const PLUGIN_ROOT = join(
+const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
+const SESSION_ID = "73e52424-a95d-4e21-b70c-2dffe48fdd86";
+const PLUGIN_VERSION = "4.5.6";
+const require = createRequire(import.meta.url);
+const dispatcher = require(join(SOURCE_HOOKS_DIR, "track-telemetry.js")) as Dispatcher;
+
+const clientCases: ClientCase[] = [
+  {
+    id: "copilot",
+    expectedClientName: "copilot-cli",
+    pluginRoot: join(TEST_DIR, ".copilot", "installed-plugins", "test-catalog", "azure"),
+    inputContainer: "toolArgs",
+    pathField: "path",
+    expectedToolName: "azure-get_azure_bestpractices",
+  },
+  {
+    id: "claude",
+    expectedClientName: "claude-code",
+    pluginRoot: join(
+      TEST_DIR,
+      ".claude",
+      "plugins",
+      "cache",
+      "azure-skills",
+      "azure",
+      "1.2.3",
+    ),
+    inputContainer: "tool_input",
+    pathField: "file_path",
+    expectedToolName: "mcp__plugin_azure_azure__get_azure_bestpractices",
+  },
+  {
+    id: "cursor",
+    expectedClientName: "cursor",
+    pluginRoot: join(
+      TEST_DIR,
+      ".cursor",
+      "plugins",
+      "cache",
+      "cursor-public",
+      "azure",
+      "revision",
+    ),
+    inputContainer: "tool_input",
+    pathField: "file_path",
+    expectedToolName: "get_azure_bestpractices",
+  },
+  {
+    id: "vscode",
+    expectedClientName: "Visual Studio Code",
+    pluginRoot: join(
+      TEST_DIR,
+      ".vscode",
+      "agent-plugins",
+      "github.com",
+      "microsoft",
+      "azure-skills",
+      ".github",
+      "plugins",
+      "azure-skills",
+    ),
+    inputContainer: "tool_input",
+    pathField: "filePath",
+    expectedToolName: "mcp_azure_mcp_get_azure_bestpractices",
+  },
+];
+
+const cursorCase = clientCases.find(client => client.id === "cursor")!;
+const crossClientInstallationCases = clientCases.map((client, index) => ({
+  client,
+  installation: clientCases[(index + 1) % clientCases.length],
+}));
+const DISPATCHER_PATH = join(cursorCase.pluginRoot, "hooks", "scripts", "track-telemetry.js");
+const FOREIGN_CURSOR_ROOT = join(
   TEST_DIR,
   ".cursor",
   "plugins",
   "cache",
   "cursor-public",
   "azure",
-  "revision",
+  "other-revision",
 );
-const HOOKS_DIR = join(PLUGIN_ROOT, "hooks", "scripts");
-const DISPATCHER_PATH = join(HOOKS_DIR, "track-telemetry.js");
-const FIXTURES_DIR = join(dirname(fileURLToPath(import.meta.url)), "fixtures");
-const SESSION_ID = "73e52424-a95d-4e21-b70c-2dffe48fdd86";
-const require = createRequire(import.meta.url);
-const dispatcher = require(join(SOURCE_HOOKS_DIR, "track-telemetry.js")) as Dispatcher;
 
 const shellCandidates: ShellCase[] = [
   {
@@ -80,31 +150,32 @@ const shellCandidates: ShellCase[] = [
   },
 ];
 
-// Returns whether the shell executable can be launched in the current environment.
 function isCommandAvailable(command: string): boolean {
   return spawnSync(command, ["--version"], { stdio: "ignore" }).error === undefined;
 }
 
 const shells = shellCandidates.filter(shell => isCommandAvailable(shell.command));
 
-// Loads a Cursor hook payload fixture by file name.
 function fixture(name: string): Record<string, unknown> {
   return JSON.parse(readFileSync(join(FIXTURES_DIR, name), "utf8")) as Record<string, unknown>;
 }
 
-// Creates a representative Cursor plugin cache with a versioned test skill.
-function createCursorSkillCache(): string {
-  const skillRoot = join(PLUGIN_ROOT, "skills", "azure-cost");
+function createPluginCache(pluginRoot: string): string {
+  const skillRoot = join(pluginRoot, "skills", "azure-cost");
   mkdirSync(join(skillRoot, "cost-query"), { recursive: true });
+  mkdirSync(join(pluginRoot, ".plugin"), { recursive: true });
   writeFileSync(
     join(skillRoot, "SKILL.md"),
     "---\nmetadata:\n  version: \"1.2.3\"\n---\n# Azure Cost\n",
   );
   writeFileSync(join(skillRoot, "cost-query", "guardrails.md"), "# Guardrails\n");
+  writeFileSync(
+    join(pluginRoot, ".plugin", "plugin.json"),
+    JSON.stringify({ version: PLUGIN_VERSION }),
+  );
   return skillRoot;
 }
 
-// Converts Windows fixture paths for Bash, which represents the Unix dispatcher branch.
 function pathForShell(shell: ShellCase, filePath: string): string {
   if (shell.name !== "Bash" || process.platform !== "win32") {
     return filePath;
@@ -117,16 +188,27 @@ function pathForShell(shell: ShellCase, filePath: string): string {
   return result.stdout.trim();
 }
 
-// Runs a telemetry hook with the payload and returns its captured npx arguments.
+function setPayloadPath(
+  shell: ShellCase,
+  client: ClientCase,
+  payload: Record<string, unknown>,
+  filePath: string,
+): void {
+  const toolInput = payload[client.inputContainer] as Record<string, unknown>;
+  toolInput[client.pathField] = pathForShell(shell, filePath);
+}
+
 function runHook(
   shell: ShellCase,
+  client: ClientCase,
   payload: Record<string, unknown>,
   inputPrefix = "",
 ): string[] {
   rmSync(CAPTURE_FILE, { force: true });
   rmSync(RAW_INPUT_DIR, { recursive: true, force: true });
   const extension = shell.name === "Bash" ? "sh" : "ps1";
-  const scriptPath = join(HOOKS_DIR, `track-telemetry.${extension}`);
+  const nativeScriptPath = join(client.pluginRoot, "hooks", "scripts", `track-telemetry.${extension}`);
+  const scriptPath = pathForShell(shell, nativeScriptPath);
   const result = spawnSync(shell.command, shell.args(scriptPath), {
     encoding: "utf8",
     input: `${inputPrefix}${JSON.stringify(payload)}`,
@@ -148,7 +230,6 @@ function runHook(
   return readFileSync(CAPTURE_FILE, "utf8").trim().split(/\r?\n/);
 }
 
-// Runs telemetry through the Node dispatcher using the current platform's shell.
 function runDispatcher(payload: Record<string, unknown>, inputPrefix = ""): string[] {
   rmSync(CAPTURE_FILE, { force: true });
   rmSync(RAW_INPUT_DIR, { recursive: true, force: true });
@@ -171,21 +252,48 @@ function runDispatcher(payload: Record<string, unknown>, inputPrefix = ""): stri
 }
 
 function readRawInput(): string {
-  const files = readdirSync(RAW_INPUT_DIR);
+  const files = readFileNames(RAW_INPUT_DIR);
   expect(files).toHaveLength(1);
   return readFileSync(join(RAW_INPUT_DIR, files[0]), "utf8");
 }
 
-// Verifies that a named command argument is followed by the expected value.
+function readFileNames(path: string): string[] {
+  return existsSync(path) ? readdirSync(path) : [];
+}
+
 function expectArg(args: string[], name: string, value: string): void {
   const index = args.indexOf(name);
   expect(index).toBeGreaterThan(-1);
   expect(args[index + 1]).toBe(value);
 }
 
+function makeNonAzurePayload(client: ClientCase): Record<string, unknown> {
+  const payload = fixture(`${client.id}-mcp-invocation.json`);
+  switch (client.id) {
+    case "copilot":
+      payload.toolName = "github-search";
+      break;
+    case "claude":
+      payload.tool_name = "mcp__plugin_github_github__search";
+      break;
+    case "cursor":
+      payload.mcp_server_name = "github";
+      break;
+    case "vscode":
+      payload.tool_name = "mcp_github_search";
+      break;
+  }
+  return payload;
+}
+
 beforeAll(() => {
   mkdirSync(BIN_DIR, { recursive: true });
-  cpSync(SOURCE_HOOKS_DIR, HOOKS_DIR, { recursive: true });
+  for (const client of clientCases) {
+    createPluginCache(client.pluginRoot);
+    cpSync(SOURCE_HOOKS_DIR, join(client.pluginRoot, "hooks", "scripts"), { recursive: true });
+  }
+  createPluginCache(FOREIGN_CURSOR_ROOT);
+
   writeFileSync(
     join(BIN_DIR, "npx"),
     "#!/usr/bin/env bash\nprintf '%s\\n' \"$@\" > \"$TELEMETRY_CAPTURE_FILE\"\n",
@@ -268,34 +376,35 @@ describe("Cursor telemetry dispatcher", () => {
   );
 });
 
-describe.each(shells)("Cursor telemetry hook ($name)", shell => {
-  const skillRoot = createCursorSkillCache();
+describe.each(shells)("Telemetry hook ($name)", shell => {
+  it.each(clientCases)("reports a $id SKILL.md read as a skill invocation", client => {
+    const payload = fixture(`${client.id}-skill-read.json`);
+    setPayloadPath(shell, client, payload, join(client.pluginRoot, "skills", "azure-cost", "SKILL.md"));
 
-  it("reports a SKILL.md read as a skill invocation", () => {
-    const payload = fixture("cursor-skill-read.json") as CursorPayload & Record<string, unknown>;
-    payload.tool_input.file_path = pathForShell(shell, join(skillRoot, "SKILL.md"));
-
-    const args = runHook(shell, payload);
+    const args = runHook(shell, client, payload);
 
     expect(args.slice(0, 4)).toEqual(["-y", "@azure/mcp@latest", "server", "plugin-telemetry"]);
-    expectArg(args, "--client-name", "cursor");
+    expectArg(args, "--client-name", client.expectedClientName);
     expectArg(args, "--event-type", "skill_invocation");
     expectArg(args, "--session-id", SESSION_ID);
     expectArg(args, "--skill-name", "azure-cost");
     expectArg(args, "--skill-version", "1.2.3");
+    expectArg(args, "--plugin-version", PLUGIN_VERSION);
     expect(args).not.toContain("--file-reference");
   });
 
-  it("reports a bundled file read as a reference read", () => {
-    const payload = fixture("cursor-reference-read.json") as CursorPayload & Record<string, unknown>;
-    payload.tool_input.file_path = pathForShell(
+  it.each(clientCases)("reports a $id bundled file read as a reference read", client => {
+    const payload = fixture(`${client.id}-reference-read.json`);
+    setPayloadPath(
       shell,
-      join(skillRoot, "cost-query", "guardrails.md"),
+      client,
+      payload,
+      join(client.pluginRoot, "skills", "azure-cost", "cost-query", "guardrails.md"),
     );
 
-    const args = runHook(shell, payload);
+    const args = runHook(shell, client, payload);
 
-    expectArg(args, "--client-name", "cursor");
+    expectArg(args, "--client-name", client.expectedClientName);
     expectArg(args, "--event-type", "reference_file_read");
     expectArg(args, "--session-id", SESSION_ID);
     expectArg(args, "--skill-version", "1.2.3");
@@ -303,34 +412,72 @@ describe.each(shells)("Cursor telemetry hook ($name)", shell => {
     expect(args).not.toContain("--skill-name");
   });
 
-  it.each(["get_azure_bestpractices", "MCP:get_azure_bestpractices"])(
-    "reports an Azure MCP invocation without Cursor's display prefix: %s",
-    toolName => {
-      const payload = fixture("cursor-mcp-invocation.json");
-      payload.tool_name = toolName;
-      const args = runHook(shell, payload);
+  it.each(crossClientInstallationCases)(
+    "reports a $client.id skill read from a $installation.id installation",
+    ({ client, installation }) => {
+      const payload = fixture(`${client.id}-skill-read.json`);
+      setPayloadPath(
+        shell,
+        client,
+        payload,
+        join(installation.pluginRoot, "skills", "azure-cost", "SKILL.md"),
+      );
 
-      expectArg(args, "--client-name", "cursor");
-      expectArg(args, "--event-type", "tool_invocation");
-      expectArg(args, "--session-id", SESSION_ID);
-      expectArg(args, "--tool-name", "get_azure_bestpractices");
+      const args = runHook(shell, installation, payload);
+
+      expectArg(args, "--client-name", client.expectedClientName);
+      expectArg(args, "--event-type", "skill_invocation");
+      expectArg(args, "--skill-name", "azure-cost");
+      expectArg(args, "--skill-version", "1.2.3");
     },
   );
 
-  it("does not report a non-Azure MCP invocation", () => {
-    const payload = fixture("cursor-mcp-invocation.json");
-    payload.mcp_server_name = "github";
+  it.each(clientCases)("reports a $id Azure MCP invocation", client => {
+    const args = runHook(shell, client, fixture(`${client.id}-mcp-invocation.json`));
 
-    expect(runHook(shell, payload)).toEqual([]);
+    expectArg(args, "--client-name", client.expectedClientName);
+    expectArg(args, "--event-type", "tool_invocation");
+    expectArg(args, "--session-id", SESSION_ID);
+    expectArg(args, "--tool-name", client.expectedToolName);
   });
 
-  it("does not report MCP calls from the generic postToolUse event", () => {
-    const payload = fixture("cursor-mcp-invocation.json");
-    payload.hook_event_name = "postToolUse";
-    payload.tool_name = "MCP:get_azure_bestpractices";
-    delete payload.mcp_server_name;
+  it.each(clientCases)("does not report a non-Azure $id tool invocation", client => {
+    expect(runHook(shell, client, makeNonAzurePayload(client))).toEqual([]);
+  });
 
-    expect(runHook(shell, payload)).toEqual([]);
+  it("strips Claude's skill namespace for direct skill calls", () => {
+    const claude = clientCases.find(client => client.id === "claude")!;
+    const payload = {
+      tool_name: "Skill",
+      tool_input: { skill: "azure:azure-cost" },
+      tool_use_id: "tool-skill",
+      session_id: SESSION_ID,
+      hook_event_name: "PostToolUse",
+    };
+
+    const args = runHook(shell, claude, payload);
+
+    expectArg(args, "--client-name", "claude-code");
+    expectArg(args, "--skill-name", "azure-cost");
+    expectArg(args, "--skill-version", "1.2.3");
+  });
+
+  it("distinguishes VS Code Insiders", () => {
+    const vscode = clientCases.find(client => client.id === "vscode")!;
+    const payload = fixture("vscode-mcp-invocation.json");
+    payload.transcript_path =
+      "C:\\Users\\test\\AppData\\Roaming\\Code - Insiders\\User\\workspaceStorage\\transcript.json";
+
+    const args = runHook(shell, vscode, payload);
+
+    expectArg(args, "--client-name", "Visual Studio Code - Insiders");
+  });
+
+  it("does not report paths owned by another installed copy", () => {
+    const payload = fixture("cursor-skill-read.json");
+    setPayloadPath(shell, cursorCase, payload, join(FOREIGN_CURSOR_ROOT, "skills", "azure-cost", "SKILL.md"));
+
+    expect(runHook(shell, cursorCase, payload)).toEqual([]);
   });
 });
 
@@ -346,7 +493,7 @@ describe.skipIf(!powerShell)("PowerShell telemetry input encoding", () => {
       unicode_probe: "café \u2603",
     };
 
-    const args = runHook(powerShell!, payload, prefix);
+    const args = runHook(powerShell!, cursorCase, payload, prefix);
 
     expectArg(args, "--client-name", "cursor");
     expectArg(args, "--tool-name", "get_azure_bestpractices");

--- a/scripts/src/__tests__/telemetry-hooks.test.ts
+++ b/scripts/src/__tests__/telemetry-hooks.test.ts
@@ -126,6 +126,11 @@ const crossClientInstallationCases = clientCases.map((client, index) => ({
   client,
   installation: clientCases[(index + 1) % clientCases.length],
 }));
+const LOCAL_PLUGIN_ROOT = join(TEST_DIR, "local-plugin");
+const localPluginCase: ClientCase = {
+  ...cursorCase,
+  pluginRoot: LOCAL_PLUGIN_ROOT,
+};
 const DISPATCHER_PATH = join(cursorCase.pluginRoot, "hooks", "scripts", "track-telemetry.js");
 const FOREIGN_CURSOR_ROOT = join(
   TEST_DIR,
@@ -203,6 +208,7 @@ function runHook(
   client: ClientCase,
   payload: Record<string, unknown>,
   inputPrefix = "",
+  extraEnv: NodeJS.ProcessEnv = {},
 ): string[] {
   rmSync(CAPTURE_FILE, { force: true });
   rmSync(RAW_INPUT_DIR, { recursive: true, force: true });
@@ -218,6 +224,7 @@ function runHook(
       AZURE_SKILLS_TELEMETRY_LOG_DIR: LOG_DIR,
       COPILOT_CLI: "",
       TELEMETRY_CAPTURE_FILE: CAPTURE_FILE,
+      ...extraEnv,
     },
   });
 
@@ -292,6 +299,8 @@ beforeAll(() => {
     createPluginCache(client.pluginRoot);
     cpSync(SOURCE_HOOKS_DIR, join(client.pluginRoot, "hooks", "scripts"), { recursive: true });
   }
+  createPluginCache(LOCAL_PLUGIN_ROOT);
+  cpSync(SOURCE_HOOKS_DIR, join(LOCAL_PLUGIN_ROOT, "hooks", "scripts"), { recursive: true });
   createPluginCache(FOREIGN_CURSOR_ROOT);
 
   writeFileSync(
@@ -478,6 +487,28 @@ describe.each(shells)("Telemetry hook ($name)", shell => {
     setPayloadPath(shell, cursorCase, payload, join(FOREIGN_CURSOR_ROOT, "skills", "azure-cost", "SKILL.md"));
 
     expect(runHook(shell, cursorCase, payload)).toEqual([]);
+  });
+
+  it.each([
+    { name: "forward slash", separator: "/" },
+    { name: "backslash", separator: "\\" },
+  ])("recognizes a local plugin root ending with a $name", ({ separator }) => {
+    const payload = fixture("cursor-skill-read.json");
+    setPayloadPath(
+      shell,
+      cursorCase,
+      payload,
+      join(LOCAL_PLUGIN_ROOT, "skills", "azure-cost", "SKILL.md"),
+    );
+    const configuredRoot = `${pathForShell(shell, LOCAL_PLUGIN_ROOT)}${separator}`;
+
+    const args = runHook(shell, localPluginCase, payload, "", {
+      AZURE_SKILLS_PLUGIN_ROOT: configuredRoot,
+    });
+
+    expectArg(args, "--client-name", "cursor");
+    expectArg(args, "--event-type", "skill_invocation");
+    expectArg(args, "--skill-name", "azure-cost");
   });
 });
 

--- a/scripts/src/__tests__/telemetry-hooks.test.ts
+++ b/scripts/src/__tests__/telemetry-hooks.test.ts
@@ -203,6 +203,18 @@ function setPayloadPath(
   toolInput[client.pathField] = pathForShell(shell, filePath);
 }
 
+function setPayloadToolName(
+  client: ClientCase,
+  payload: Record<string, unknown>,
+  toolName: string,
+): void {
+  if (client.id === "copilot") {
+    payload.toolName = toolName;
+  } else {
+    payload.tool_name = toolName;
+  }
+}
+
 function runHook(
   shell: ShellCase,
   client: ClientCase,
@@ -420,6 +432,30 @@ describe.each(shells)("Telemetry hook ($name)", shell => {
     expectArg(args, "--file-reference", "azure-cost\\cost-query\\guardrails.md");
     expect(args).not.toContain("--skill-name");
   });
+
+  it.each(
+    clientCases.flatMap(client =>
+      ["view", "Read", "read_file"].map(toolName => ({ client, toolName })),
+    ),
+  )(
+    "accepts $toolName as a file-read tool for $client.id payloads",
+    ({ client, toolName }) => {
+      const payload = fixture(`${client.id}-reference-read.json`);
+      setPayloadToolName(client, payload, toolName);
+      setPayloadPath(
+        shell,
+        client,
+        payload,
+        join(client.pluginRoot, "skills", "azure-cost", "cost-query", "guardrails.md"),
+      );
+
+      const args = runHook(shell, client, payload);
+
+      expectArg(args, "--client-name", client.expectedClientName);
+      expectArg(args, "--event-type", "reference_file_read");
+      expectArg(args, "--file-reference", "azure-cost\\cost-query\\guardrails.md");
+    },
+  );
 
   it.each(crossClientInstallationCases)(
     "reports a $client.id skill read from a $installation.id installation",


### PR DESCRIPTION
## Summary

- keep `track-telemetry.sh` and `track-telemetry.ps1` as shared entry points for client detection, logging, version lookup, path ownership, publication, and hook responses
- move Copilot CLI, Claude Code, Cursor, and VS Code payload parsing and event classification into paired client-specific Bash and PowerShell handlers
- use a shared installation-path allowlist so any client can report skills installed by another client
- expand fixture-driven regression coverage across all clients, shells, event types, cross-client installation layouts, ownership deduplication, and input encoding

## Validation

- `npm test -- --run src/__tests__/telemetry-hooks.test.ts` - 55 tests passed
- `cd scripts && npm run typecheck`
- `cd scripts && npm run lint`
- `npm run check:shell-scripts`
- `npm run build`

Closes #3144