### PR TITLE
chore: automate updating marketplace manifest in plugin sync workflow

### DIFF
--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -77,7 +77,22 @@ jobs:
             rsync --archive --delete --verbose "$child_dir/" "$target_dir"
           done
 
-      # 5. Commit changes and create a PR
+      # 5. Update marketplace.json
+      - name: Update marketplace.json
+        id: update-marketplace
+        working-directory: source-repo/scripts
+        env:
+          # microsoft/skills had already set repository and homepage of azure plugins to github-copilot-for-azure.
+          TARGET_REPOSITORY: https://github.com/microsoft/github-copilot-for-azure
+          TARGET_HOMEPAGE: https://github.com/microsoft/github-copilot-for-azure
+        run: >-
+          npm run plugin:sync-marketplace --
+          "$GITHUB_WORKSPACE/source-repo/output"
+          "$GITHUB_WORKSPACE/target-repo"
+          "$TARGET_REPOSITORY"
+          "$TARGET_HOMEPAGE"
+
+      # 6. Commit changes and create a PR
       - name: Commit and push changes
         id: commit
         working-directory: target-repo
@@ -221,7 +236,22 @@ jobs:
             fi
           done
 
-      # 7. Commit changes and create a PR
+      # 7. Update marketplace.json
+      - name: Update marketplace.json
+        id: update-marketplace
+        working-directory: source-repo/scripts
+        env:
+          # microsoft/azure-skills had already set homepage to azure-skills.
+          TARGET_REPOSITORY: https://github.com/microsoft/github-copilot-for-azure
+          TARGET_HOMEPAGE: https://github.com/microsoft/azure-skills
+        run: >-
+          npm run plugin:sync-marketplace --
+          "$GITHUB_WORKSPACE/source-repo/output"
+          "$GITHUB_WORKSPACE/target-repo"
+          "$TARGET_REPOSITORY"
+          "$TARGET_HOMEPAGE"
+
+      # 8. Commit changes and create a PR
       - name: Commit and push changes
         id: commit
         working-directory: target-repo

--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -35,6 +35,11 @@ jobs:
           npm ci --ignore-scripts
           npm run build
 
+      - name: Install scripts dependencies
+        working-directory: source-repo/scripts
+        run: |
+          npm ci --ignore-scripts
+
       # Generate a short-lived token from the GitHub App for microsoft/skills
       - name: Generate token for microsoft/skills
         id: skills-token
@@ -151,6 +156,11 @@ jobs:
         run: |
           npm ci --ignore-scripts
           npm run build
+
+      - name: Install scripts dependencies
+        working-directory: source-repo/scripts
+        run: |
+          npm ci --ignore-scripts
 
       # Generate a short-lived token from the GitHub App for microsoft/azure-skills
       - name: Generate token for microsoft/azure-skills

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -20,7 +20,8 @@
     "dashboard:collect": "node --import tsx src/dashboard/compose.ts",
     "generateMcpAllowlists": "node --import tsx src/generate-mcp-allowlists.ts",
     "vally": "node --import tsx src/vally/cli.ts",
-    "plugin:new": "node --import tsx src/plugin/bootstrap.ts"
+    "plugin:new": "node --import tsx src/plugin/bootstrap.ts",
+    "plugin:sync-marketplace": "node --import tsx src/plugin/sync-marketplace.ts"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.0",

--- a/scripts/src/__tests__/sync-marketplace.test.ts
+++ b/scripts/src/__tests__/sync-marketplace.test.ts
@@ -1,0 +1,89 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { syncMarketplacePlugins } from "../plugin/marketplace-helper.js";
+
+describe("sync marketplace plugins", () => {
+  let testRoot: string | undefined;
+
+  afterEach(() => {
+    if (testRoot) {
+      fs.rmSync(testRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("updates and appends every source plugin in both marketplaces", () => {
+    testRoot = fs.mkdtempSync(path.join(os.tmpdir(), "sync-marketplace-"));
+    const sourceRoot = path.join(testRoot, "source-repo/output");
+    const targetRoot = path.join(testRoot, "target-repo");
+    const marketplacePaths = [
+      path.join(targetRoot, ".claude-plugin/marketplace.json"),
+      path.join(targetRoot, ".github/plugin/marketplace.json"),
+      path.join(targetRoot, ".cursor-plugin/marketplace.json")
+    ];
+
+    for (const marketplacePath of marketplacePaths) {
+      fs.mkdirSync(path.dirname(marketplacePath), { recursive: true });
+      fs.writeFileSync(marketplacePath, JSON.stringify({
+        name: "target-marketplace",
+        plugins: [
+          { name: "azure", description: "old", customField: true },
+          { name: "unrelated", source: "./plugins/unrelated" }
+        ]
+      }));
+    }
+
+    const manifests = [
+      ["azure-skills", "azure", "Azure plugin", "1.2.3"],
+      ["kusto-skills", "kusto", "Kusto plugin", "2.0.0"]
+    ];
+    for (const [directory, name, description, version] of manifests) {
+      const manifestDirectory = path.join(sourceRoot, directory, ".plugin");
+      fs.mkdirSync(manifestDirectory, { recursive: true });
+      fs.writeFileSync(path.join(manifestDirectory, "plugin.json"), JSON.stringify({
+        name,
+        description,
+        version,
+        author: { name: "Microsoft" },
+        homepage: "https://example.test/plugin"
+      }));
+    }
+
+    syncMarketplacePlugins({
+      sourceRoot,
+      targetRoot,
+      repository: "https://github.com/microsoft/target",
+      homepage: "https://example.test/marketplace"
+    });
+
+    for (const marketplacePath of marketplacePaths) {
+      const marketplace = JSON.parse(fs.readFileSync(marketplacePath, "utf8")) as {
+        name: string;
+        plugins: Record<string, unknown>[];
+      };
+      expect(marketplace.name).toBe("target-marketplace");
+      expect(marketplace.plugins).toEqual([
+        {
+          name: "azure",
+          description: "Azure plugin",
+          customField: true,
+          source: "./.github/plugins/azure-skills",
+          author: { name: "Microsoft" },
+          homepage: "https://example.test/marketplace",
+          repository: "https://github.com/microsoft/target"
+        },
+        { name: "unrelated", source: "./plugins/unrelated" },
+        {
+          name: "kusto",
+          source: "./.github/plugins/kusto-skills",
+          description: "Kusto plugin",
+          author: { name: "Microsoft" },
+          homepage: "https://example.test/marketplace",
+          repository: "https://github.com/microsoft/target"
+        }
+      ]);
+      expect(fs.readFileSync(marketplacePath, "utf8")).toMatch(/\n$/);
+    }
+  });
+});

--- a/scripts/src/plugin/marketplace-helper.ts
+++ b/scripts/src/plugin/marketplace-helper.ts
@@ -2,9 +2,9 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 const MARKETPLACE_PATHS = [
-    ".claude-plugin/marketplace.json",
-    ".github/plugin/marketplace.json",
-    ".cursor-plugin/marketplace.json"
+  ".claude-plugin/marketplace.json",
+  ".github/plugin/marketplace.json",
+  ".cursor-plugin/marketplace.json"
 ] as const;
 
 interface PluginManifest {
@@ -28,74 +28,74 @@ export interface SyncMarketplaceOptions {
 }
 
 function readJson(filePath: string): unknown {
-    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  return JSON.parse(fs.readFileSync(filePath, "utf8"));
 }
 
 function readPluginManifest(filePath: string): PluginManifest {
-    const value = readJson(filePath);
-    if (
-        typeof value !== "object" || value === null ||
+  const value = readJson(filePath);
+  if (
+    typeof value !== "object" || value === null ||
         !("name" in value) || typeof value.name !== "string" ||
         !("description" in value) || typeof value.description !== "string" ||
         !("version" in value) || typeof value.version !== "string" ||
         !("author" in value) ||
         !("homepage" in value) || typeof value.homepage !== "string"
-    ) {
-        throw new Error(`Invalid plugin manifest: ${filePath}`);
-    }
+  ) {
+    throw new Error(`Invalid plugin manifest: ${filePath}`);
+  }
 
-    return value as PluginManifest;
+  return value as PluginManifest;
 }
 
 function readMarketplace(filePath: string): Marketplace {
-    const value = readJson(filePath);
-    if (
-        typeof value !== "object" || value === null ||
+  const value = readJson(filePath);
+  if (
+    typeof value !== "object" || value === null ||
         !("plugins" in value) || !Array.isArray(value.plugins) ||
         value.plugins.some(plugin => typeof plugin !== "object" || plugin === null)
-    ) {
-        throw new Error(`Invalid marketplace manifest: ${filePath}`);
-    }
+  ) {
+    throw new Error(`Invalid marketplace manifest: ${filePath}`);
+  }
 
-    return value as Marketplace;
+  return value as Marketplace;
 }
 
 export function syncMarketplacePlugins(options: SyncMarketplaceOptions): void {
-    const marketplaceFiles = MARKETPLACE_PATHS
-        .map(relativePath => path.join(options.targetRoot, relativePath))
-        .filter(filePath => fs.existsSync(filePath));
-    const marketplaces = marketplaceFiles.map(readMarketplace);
-    const pluginDirectories = fs.readdirSync(options.sourceRoot, { withFileTypes: true })
-        .filter(entry => entry.isDirectory())
-        .map(entry => entry.name)
-        .sort();
+  const marketplaceFiles = MARKETPLACE_PATHS
+    .map(relativePath => path.join(options.targetRoot, relativePath))
+    .filter(filePath => fs.existsSync(filePath));
+  const marketplaces = marketplaceFiles.map(readMarketplace);
+  const pluginDirectories = fs.readdirSync(options.sourceRoot, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map(entry => entry.name)
+    .sort();
 
-    for (const pluginDirectory of pluginDirectories) {
-        const manifestPath = path.join(options.sourceRoot, pluginDirectory, ".plugin/plugin.json");
-        const manifest = readPluginManifest(manifestPath);
-        const pluginEntry = {
-            name: manifest.name,
-            source: `./.github/plugins/${pluginDirectory}`,
-            description: manifest.description,
-            author: manifest.author,
-            homepage: options.homepage,
-            repository: options.repository
+  for (const pluginDirectory of pluginDirectories) {
+    const manifestPath = path.join(options.sourceRoot, pluginDirectory, ".plugin/plugin.json");
+    const manifest = readPluginManifest(manifestPath);
+    const pluginEntry = {
+      name: manifest.name,
+      source: `./.github/plugins/${pluginDirectory}`,
+      description: manifest.description,
+      author: manifest.author,
+      homepage: options.homepage,
+      repository: options.repository
+    };
+
+    for (const marketplace of marketplaces) {
+      const existingIndex = marketplace.plugins.findIndex(plugin => plugin.name === manifest.name);
+      if (existingIndex === -1) {
+        marketplace.plugins.push(pluginEntry);
+      } else {
+        marketplace.plugins[existingIndex] = {
+          ...marketplace.plugins[existingIndex],
+          ...pluginEntry
         };
-
-        for (const marketplace of marketplaces) {
-            const existingIndex = marketplace.plugins.findIndex(plugin => plugin.name === manifest.name);
-            if (existingIndex === -1) {
-                marketplace.plugins.push(pluginEntry);
-            } else {
-                marketplace.plugins[existingIndex] = {
-                    ...marketplace.plugins[existingIndex],
-                    ...pluginEntry
-                };
-            }
-        }
+      }
     }
+  }
 
-    for (let index = 0; index < marketplaceFiles.length; index += 1) {
-        fs.writeFileSync(marketplaceFiles[index], `${JSON.stringify(marketplaces[index], null, 2)}\n`);
-    }
+  for (let index = 0; index < marketplaceFiles.length; index += 1) {
+    fs.writeFileSync(marketplaceFiles[index], `${JSON.stringify(marketplaces[index], null, 2)}\n`);
+  }
 }

--- a/scripts/src/plugin/marketplace-helper.ts
+++ b/scripts/src/plugin/marketplace-helper.ts
@@ -1,0 +1,101 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const MARKETPLACE_PATHS = [
+    ".claude-plugin/marketplace.json",
+    ".github/plugin/marketplace.json",
+    ".cursor-plugin/marketplace.json"
+] as const;
+
+interface PluginManifest {
+    name: string;
+    description: string;
+    version: string;
+    author: unknown;
+    homepage: string;
+}
+
+interface Marketplace {
+    plugins: Record<string, unknown>[];
+    [key: string]: unknown;
+}
+
+export interface SyncMarketplaceOptions {
+    sourceRoot: string;
+    targetRoot: string;
+    repository: string;
+    homepage: string;
+}
+
+function readJson(filePath: string): unknown {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+}
+
+function readPluginManifest(filePath: string): PluginManifest {
+    const value = readJson(filePath);
+    if (
+        typeof value !== "object" || value === null ||
+        !("name" in value) || typeof value.name !== "string" ||
+        !("description" in value) || typeof value.description !== "string" ||
+        !("version" in value) || typeof value.version !== "string" ||
+        !("author" in value) ||
+        !("homepage" in value) || typeof value.homepage !== "string"
+    ) {
+        throw new Error(`Invalid plugin manifest: ${filePath}`);
+    }
+
+    return value as PluginManifest;
+}
+
+function readMarketplace(filePath: string): Marketplace {
+    const value = readJson(filePath);
+    if (
+        typeof value !== "object" || value === null ||
+        !("plugins" in value) || !Array.isArray(value.plugins) ||
+        value.plugins.some(plugin => typeof plugin !== "object" || plugin === null)
+    ) {
+        throw new Error(`Invalid marketplace manifest: ${filePath}`);
+    }
+
+    return value as Marketplace;
+}
+
+export function syncMarketplacePlugins(options: SyncMarketplaceOptions): void {
+    const marketplaceFiles = MARKETPLACE_PATHS
+        .map(relativePath => path.join(options.targetRoot, relativePath))
+        .filter(filePath => fs.existsSync(filePath));
+    const marketplaces = marketplaceFiles.map(readMarketplace);
+    const pluginDirectories = fs.readdirSync(options.sourceRoot, { withFileTypes: true })
+        .filter(entry => entry.isDirectory())
+        .map(entry => entry.name)
+        .sort();
+
+    for (const pluginDirectory of pluginDirectories) {
+        const manifestPath = path.join(options.sourceRoot, pluginDirectory, ".plugin/plugin.json");
+        const manifest = readPluginManifest(manifestPath);
+        const pluginEntry = {
+            name: manifest.name,
+            source: `./.github/plugins/${pluginDirectory}`,
+            description: manifest.description,
+            author: manifest.author,
+            homepage: options.homepage,
+            repository: options.repository
+        };
+
+        for (const marketplace of marketplaces) {
+            const existingIndex = marketplace.plugins.findIndex(plugin => plugin.name === manifest.name);
+            if (existingIndex === -1) {
+                marketplace.plugins.push(pluginEntry);
+            } else {
+                marketplace.plugins[existingIndex] = {
+                    ...marketplace.plugins[existingIndex],
+                    ...pluginEntry
+                };
+            }
+        }
+    }
+
+    for (let index = 0; index < marketplaceFiles.length; index += 1) {
+        fs.writeFileSync(marketplaceFiles[index], `${JSON.stringify(marketplaces[index], null, 2)}\n`);
+    }
+}

--- a/scripts/src/plugin/marketplace-helper.ts
+++ b/scripts/src/plugin/marketplace-helper.ts
@@ -8,23 +8,23 @@ const MARKETPLACE_PATHS = [
 ] as const;
 
 interface PluginManifest {
-    name: string;
-    description: string;
-    version: string;
-    author: unknown;
-    homepage: string;
+  name: string;
+  description: string;
+  version: string;
+  author: unknown;
+  homepage: string;
 }
 
 interface Marketplace {
-    plugins: Record<string, unknown>[];
-    [key: string]: unknown;
+  plugins: Record<string, unknown>[];
+  [key: string]: unknown;
 }
 
 export interface SyncMarketplaceOptions {
-    sourceRoot: string;
-    targetRoot: string;
-    repository: string;
-    homepage: string;
+  sourceRoot: string;
+  targetRoot: string;
+  repository: string;
+  homepage: string;
 }
 
 function readJson(filePath: string): unknown {
@@ -35,11 +35,11 @@ function readPluginManifest(filePath: string): PluginManifest {
   const value = readJson(filePath);
   if (
     typeof value !== "object" || value === null ||
-        !("name" in value) || typeof value.name !== "string" ||
-        !("description" in value) || typeof value.description !== "string" ||
-        !("version" in value) || typeof value.version !== "string" ||
-        !("author" in value) ||
-        !("homepage" in value) || typeof value.homepage !== "string"
+    !("name" in value) || typeof value.name !== "string" ||
+    !("description" in value) || typeof value.description !== "string" ||
+    !("version" in value) || typeof value.version !== "string" ||
+    !("author" in value) ||
+    !("homepage" in value) || typeof value.homepage !== "string"
   ) {
     throw new Error(`Invalid plugin manifest: ${filePath}`);
   }
@@ -51,8 +51,8 @@ function readMarketplace(filePath: string): Marketplace {
   const value = readJson(filePath);
   if (
     typeof value !== "object" || value === null ||
-        !("plugins" in value) || !Array.isArray(value.plugins) ||
-        value.plugins.some(plugin => typeof plugin !== "object" || plugin === null)
+    !("plugins" in value) || !Array.isArray(value.plugins) ||
+    value.plugins.some((plugin) => typeof plugin !== "object" || plugin === null || Array.isArray(plugin) || typeof (plugin as { name?: unknown }).name !== "string")
   ) {
     throw new Error(`Invalid marketplace manifest: ${filePath}`);
   }

--- a/scripts/src/plugin/sync-marketplace.ts
+++ b/scripts/src/plugin/sync-marketplace.ts
@@ -1,0 +1,12 @@
+import { syncMarketplacePlugins } from "./marketplace-helper.js";
+
+function main(args: string[] = process.argv.slice(2)): void {
+  if (args.length !== 4 || args.some(argument => argument.trim() === "")) {
+    throw new Error("Usage: sync-marketplace <source-root> <target-root> <repository-url> <homepage-url>");
+  }
+
+  const [sourceRoot, targetRoot, repository, homepage] = args;
+  syncMarketplacePlugins({ sourceRoot, targetRoot, repository, homepage });
+}
+
+main();

--- a/scripts/src/plugin/sync-marketplace.ts
+++ b/scripts/src/plugin/sync-marketplace.ts
@@ -2,7 +2,8 @@ import { syncMarketplacePlugins } from "./marketplace-helper.js";
 
 function main(args: string[] = process.argv.slice(2)): void {
   if (args.length !== 4 || args.some(argument => argument.trim() === "")) {
-    throw new Error("Usage: sync-marketplace <source-root> <target-root> <repository-url> <homepage-url>");
+    console.error("Usage: sync-marketplace <source-root> <target-root> <repository-url> <homepage-url>");
+    process.exit(1);
   }
 
   const [sourceRoot, targetRoot, repository, homepage] = args;


### PR DESCRIPTION
## Description

Automate updating marketplace.json in microsoft/skills and microsoft/azure-skills for all the plugins synced from github-copilot-for-azure. This step currently needs to be done manually after the plugin has been synced to the target repo.

The sync script will update the existing plugin entry using information from the up-to-date plugin.json, or add a new entry for plugins that don't have an existing entry.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
