### PR TITLE
misc: add instructions copilot code review

### DIFF
--- a/.github/instructions/skill-files.instructions.md
+++ b/.github/instructions/skill-files.instructions.md
@@ -64,6 +64,16 @@ If including executable scripts:
 - Provide both bash (`.sh`) and PowerShell (`.ps1`) versions for non-trivial scripts
 - Trivial one-liners may use bash only
 
+## Integration Tests
+
+Each skill should have its test cases written under `evals/<owning-plugin>/<skill-name>`. The test cases must be implemented as Vally eval suites. See [vally-eval](../skills/vally-eval/SKILL.md) on the requirements of the eval suites.
+
+## Owners
+
+The parent directory of every new `SKILL.md` (the skill directory) must have an entry in [CODEOWNERS](../CODEOWNERS). The entry must include at least two distinct GitHub aliases from the skill's authoring team, plus `RickWinter` as the fallback repository owner.
+
+The directory containing the skill's eval suites must also have a `CODEOWNERS` entry with the same owners as the skill directory.
+
 ## Related Resources
 
 - Reference the [skill-authoring skill](../skills/skill-authoring/SKILL.md) for detailed guidelines

--- a/.github/instructions/skill-files.instructions.md
+++ b/.github/instructions/skill-files.instructions.md
@@ -66,11 +66,11 @@ If including executable scripts:
 
 ## Integration Tests
 
-Each skill should have its test cases written under `evals/<owning-plugin>/<skill-name>`. The test cases must be implemented as Vally eval suites. See [vally-eval](../skills/vally-eval/SKILL.md) on the requirements of the eval suites.
+Every skill must have its test cases written under `evals/<owning-plugin>/<skill-name>`. The test cases must be implemented as Vally eval suites. See [vally-eval](../skills/vally-eval/SKILL.md) on the requirements of the eval suites.
 
 ## Owners
 
-The parent directory of every new `SKILL.md` (the skill directory) must have an entry in [CODEOWNERS](../CODEOWNERS). The entry must include at least two distinct GitHub aliases from the skill's authoring team, plus `RickWinter` as the fallback repository owner.
+The entry must include at least two distinct GitHub aliases from the skill's authoring team, plus `@RickWinter` as the fallback repository owner.
 
 The directory containing the skill's eval suites must also have a `CODEOWNERS` entry with the same owners as the skill directory.
 


### PR DESCRIPTION
## Description

Add code review instructions for these answers we have been giving to partner teams offline more than once:
- Skills must have integration tests.
- Skill and their eval files must define two distinct code owners and add RickWinter as the fallback owner. 

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
