### PR TITLE
misc: remove unused codeowner entries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,43 +7,6 @@
 # Workflow files — explicit protection (changes require team review)
 /.github/workflows/ @microsoft/github-copilot-for-azure-writers
 
-# Plugin skills owners (kept for reference)
-/plugin/skills/ @tmeschter @RickWinter
-/plugin/skills/airunway-aks-setup/ @tmeschter @RickWinter
-/plugin/skills/appinsights-instrumentation/ @JasonYeMSFT @RickWinter
-/plugin/skills/azure-ai/ @JasonYeMSFT @RickWinter
-/plugin/skills/azure-aigateway/ @azaslonov @RickWinter
-/plugin/skills/azure-cloud-migrate/ @saikoumudi @MadhuraBharadwaj-MSFT @RickWinter
-/plugin/skills/azure-compliance/ @saikoumudi @RickWinter
-/plugin/skills/azure-compute/ @alex-thompson @rakal-dyh @joybb @rmmue21 @RickWinter
-/plugin/skills/azure-cost/ @saikoumudi @RickWinter
-/plugin/skills/azure-deploy/ @microsoft/github-copilot-for-azure-writers @paulyuk
-/plugin/skills/azure-diagnostics/ @tmeschter @saikoumudi @RickWinter
-/plugin/skills/azure-enterprise-infra-planner/ @micha31r @arunrab @RickWinter
-/plugin/skills/azure-kubernetes/ @saikoumudi @chandraneel @gambtho @RickWinter
-/plugin/skills/azure-kusto/ @saikoumudi @RickWinter
-/plugin/skills/azure-messaging/ @kashifkhan @RickWinter
-/plugin/skills/azure-prepare/ @microsoft/github-copilot-for-azure-writers
-/plugin/skills/azure-quotas/ @rakal-dyh @RickWinter
-/plugin/skills/azure-reliability/ @MadhuraBharadwaj-MSFT @saikoumudi @RickWinter
-/plugin/skills/azure-resource-lookup/ @JasonYeMSFT @RickWinter
-/plugin/skills/azure-resource-visualizer/ @tmeschter @RickWinter
-/plugin/skills/azure-storage/ @JasonYeMSFT @RickWinter
-/plugin/skills/azure-upgrade/ @MadhuraBharadwaj-MSFT @saikoumudi @RickWinter
-/plugin/skills/azure-validate/ @microsoft/github-copilot-for-azure-writers
-/plugin/skills/entra-agent-id/ @ArLucaID @RickWinter
-/plugin/skills/entra-app-registration/ @JasonYeMSFT @RickWinter
-/plugin/skills/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter
-/plugin/skills/microsoft-foundry/foundry-agent/cicd/ @anchenyi @XiaofuHuang @swatDong @RickWinter
-/plugin/skills/microsoft-foundry/foundry-agent/create/ @anchenyi @XiaofuHuang @swatDong @RickWinter
-/plugin/skills/microsoft-foundry/foundry-agent/deploy/ @anchenyi @XiaofuHuang @swatDong @RickWinter
-/plugin/skills/microsoft-foundry/foundry-agent/invoke/ @anchenyi @XiaofuHuang @swatDong @RickWinter
-/plugin/skills/microsoft-foundry/foundry-agent/toolbox/ @anchenyi @XiaofuHuang @swatDong @RickWinter
-/plugin/skills/microsoft-foundry/foundry-agent/troubleshoot/ @anchenyi @XiaofuHuang @swatDong @RickWinter
-/plugin/skills/microsoft-foundry/foundry-agent/routine/ @anchenyi @XiaofuHuang @swatDong @RickWinter
-/plugin/skills/microsoft-foundry/foundry-agent/invocations-ws/ @anchenyi @XiaofuHuang @swatDong @RickWinter
-/plugin/skills/python-appservice-deploy/ @glaming1 @tmeschter @RickWinter
-
 # Plugin skills owners (multi-plugin)
 /plugins/azure-skills/skills/ @tmeschter @RickWinter
 /plugins/azure-skills/skills/airunway-aks-setup/ @tmeschter @RickWinter
@@ -82,9 +45,6 @@
 /plugins/azure-skills/skills/python-appservice-deploy/ @glaming1 @tmeschter @RickWinter
 /plugins/azure-skills/skills/azure-app-onboard/ @vaibbavisk20 @kunalsuri-microsoft @RickWinter
 /plugins/azure-skills/skills/azure-app-onboard-prereq/ @vaibbavisk20 @kunalsuri-microsoft @RickWinter
-
-# Plugin skills tests owners (multi-plugin)
-/tests/microsoft-foundry/ @ankitbko @tendau @XOEEst @anchenyi @XiaofuHuang @jugonzales @vebudumu @RickWinter
 
 # Plugin skills evals owners (multi-plugin)
 /evals/azure-skills/airunway-aks-setup/ @tmeschter @RickWinter


### PR DESCRIPTION
## Description

The directories/files pointed to by these entries no longer exist.

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
