### PR TITLE
add azure service retirement skill and related routing evaluation

### DIFF
--- a/evals/azure-skills/azure-service-retirement/routing.eval.yaml
+++ b/evals/azure-skills/azure-service-retirement/routing.eval.yaml
@@ -1,0 +1,85 @@
+name: azure-service-retirement-routing-eval
+description: |
+  Verifies routing for explicit Azure retirement lifecycle prompts, including
+  end of support and scheduled deprecation of resource versions.
+tags:
+  type: integration
+  skill: azure-service-retirement
+
+defaults:
+  runs: 5
+  timeout: "10m"
+  executor: integration-test-agent-runner
+  model: claude-sonnet-4.6
+
+scoring:
+  threshold: 0.8
+
+stimuli:
+  - name: "Routing: AKS Kubernetes version end of support"
+    prompt: "Are any of my AKS clusters on a Kubernetes version that's reaching end of support?"
+    tags:
+      type: integration
+      tier: smoke
+      cost: llm
+      area: routing
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-service-retirement"},{"type":"tool-call-count","count":3}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-service-retirement
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Routing: Azure service end of life"
+    prompt: "Which Azure services I use are reaching end of life?"
+    tags:
+      type: integration
+      tier: smoke
+      cost: llm
+      area: routing
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-service-retirement"},{"type":"tool-call-count","count":3}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-service-retirement
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Routing: deprecated Azure SKU"
+    prompt: "Which of my Azure VMs use a SKU that is being deprecated with a shutdown deadline?"
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: routing
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-service-retirement"},{"type":"tool-call-count","count":3}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-service-retirement
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"
+
+  - name: "Routing: unsupported App Service runtime"
+    prompt: "Are any of my App Services using a runtime version that is about to become unsupported?"
+    tags:
+      type: integration
+      tier: full
+      cost: llm
+      area: routing
+      earlyTerminate: '[{"type":"skill-call","skill":"azure-service-retirement"},{"type":"tool-call-count","count":3}]'
+    graders:
+      - type: skill-invocation
+        config:
+          required:
+            - azure-service-retirement
+      - type: output-not-matches
+        config:
+          pattern: "(?i)fatal error|unhandled exception|stack trace"

--- a/plugins/azure-skills/skills/azure-service-retirement/SKILL.md
+++ b/plugins/azure-skills/skills/azure-service-retirement/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: azure-service-retirement
+description: "Find Azure Advisor retirement deadlines and affected resources. WHEN: Azure service, SKU, runtime, API, feature, or version retirement, deprecation, shutdown, end of support, end of life; AKS or Kubernetes version support ending; Service Health retirement ID; retirement-required migration. DO NOT USE FOR: upgrades, patching, modernization, migrations, or Advisor requests without explicit retirement lifecycle context."
+license: MIT
+metadata:
+  author: Microsoft
+  version: "0.0.0-placeholder"
+---
+
+# Azure Service Retirement
+
+Use only for explicit Azure retirement lifecycle events. Upgrades and migrations are in scope only as retirement remediation.
+
+## Quick Reference
+
+| Property | Value |
+|---|---|
+| MCP tool | `advisor_recommendation_list` |
+| Required | `subscription` |
+| Optional filters | `subCategory`, `trackingIds`, `retirementDate` |
+
+## Workflow
+
+1. Infer `subscription` only from established context; otherwise ask for it.
+2. Read and follow [Retirement Query Rules](references/query-rules.md).
+3. Call `advisor_recommendation_list` with only justified, non-empty filters.
+4. Report only returned data; prioritize expired and nearest deadlines. Never invent findings.
+5. For no results, say no matching **active Advisor retirement recommendations** were found for the supplied scope and filters, not that no Azure retirement exists.
+6. If `areResultsTruncated` is true, identify results as partial.
+
+Do not handle routine updates, modernization, unrelated migrations, general Advisor requests, or upgrade-only prompts. Advisor results are authoritative; never infer unsupported status.

--- a/plugins/azure-skills/skills/azure-service-retirement/references/query-rules.md
+++ b/plugins/azure-skills/skills/azure-service-retirement/references/query-rules.md
@@ -1,0 +1,40 @@
+# Retirement Query Rules
+
+## Filters
+
+- General retirement request: pass `subCategory: "ServiceUpgradeAndRetirement"`.
+- Tracking IDs: pass user values through `trackingIds`. The tool infers the retirement subcategory, so `subCategory` may be omitted.
+- Date condition: pass one `retirementDate` as `<operator>:<yyyy-MM-dd>`. Supported operators are `eq` (on), `lt` (before), `le` (on or before), `gt` (after), and `ge` (on or after). The tool infers the retirement subcategory.
+- Tracking IDs and one date condition may be combined.
+- If `subCategory` accompanies `trackingIds` or `retirementDate`, it must be exactly `ServiceUpgradeAndRetirement`. Never combine retirement filters with another subcategory.
+- Preserve explicitly requested supported filters: `resourceGroup`, `resourceType`, `resource`, `impact`, `status`, `recommendationTypeId`, `search`, `top`, and `tenant`. Add no unrelated filters. Omit `status` to use the active-recommendations default.
+
+Never pass empty or invented filter values.
+
+## Examples
+
+```json
+{"subscription":"<subscription>","subCategory":"ServiceUpgradeAndRetirement"}
+```
+
+```json
+{"subscription":"<subscription>","trackingIds":["QNY1-HB8","9G0V-_G8"]}
+```
+
+```json
+{"subscription":"<subscription>","retirementDate":"le:2027-03-31"}
+```
+
+```json
+{"subscription":"<subscription>","trackingIds":["QNY1-HB8"],"retirementDate":"ge:2026-09-19"}
+```
+
+## Relative Dates
+
+Resolve dates at execution time. "Already retired" is `lt:<today>`; "before the end of this quarter" is `le:<quarter-end>`; "after today" is `gt:<today>`.
+
+Only one comparison is supported. For a bounded period, use the closest server-side boundary, disclose the limitation, and apply the remaining boundary to returned results without claiming the query enforced both bounds.
+
+## Response
+
+Sort expired and nearest deadlines first. Include when returned: recommendation name, retirement date, days remaining or passed, impact, resource name and ARM resource ID, subscription, resource group, Service Health tracking IDs, recommended action or replacement, and recommendation status.

--- a/plugins/azure-skills/skills/azure-service-retirement/version.json
+++ b/plugins/azure-skills/skills/azure-service-retirement/version.json
@@ -1,0 +1,6 @@
+{
+  "version": "1.1",
+  "pathFilters": [
+    "."
+  ]
+}

--- a/tests/skills.json
+++ b/tests/skills.json
@@ -25,6 +25,7 @@
                 "azure-reliability",
                 "azure-resource-lookup",
                 "azure-resource-visualizer",
+                "azure-service-retirement",
                 "azure-storage",
                 "azure-upgrade",
                 "azure-validate",
@@ -36,7 +37,7 @@
             "integrationTestSchedule": {
                 "0 5 * * 2-6": "microsoft-foundry",
                 "0 8 * * 2-6": "azure-deploy",
-                "0 12 * * 2-6": "airunway-aks-setup,appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost,azure-diagnostics,azure-enterprise-infra-planner,azure-kubernetes,azure-kusto,azure-messaging,azure-prepare,azure-quotas,azure-resource-lookup,azure-resource-visualizer,azure-storage,azure-upgrade,azure-validate,entra-agent-id,entra-app-registration,azure-reliability,python-appservice-deploy,azure-app-onboard,azure-app-onboard-prereq"
+                "0 12 * * 2-6": "airunway-aks-setup,appinsights-instrumentation,azure-ai,azure-aigateway,azure-cloud-migrate,azure-compliance,azure-compute,azure-cost,azure-diagnostics,azure-enterprise-infra-planner,azure-kubernetes,azure-kusto,azure-messaging,azure-prepare,azure-quotas,azure-resource-lookup,azure-resource-visualizer,azure-service-retirement,azure-storage,azure-upgrade,azure-validate,entra-agent-id,entra-app-registration,azure-reliability,python-appservice-deploy,azure-app-onboard,azure-app-onboard-prereq"
             }
         },
         {


### PR DESCRIPTION
## Description

<!-- Briefly describe what this PR changes and why. -->

## Checklist

- [ ] Tests pass locally (`cd tests && npm test`)
- [ ] Title has one of the prefixes: `fix:`, `feat:`, `feature:`, `chore:`, `misc:`, `test:`, `eval:`
- [ ] **If modifying skill descriptions:** verified routing correctness with integration tests (In `tests/`, `npm run test:vally -- --plugin <plugin-dirname> --skill <skill>`)

## Related Issues

<!-- Link to related issues, e.g. Fixes #1234 -->
